### PR TITLE
Keep (disabled-by-default) configs for MMA8452Q accelerometer

### DIFF
--- a/blockware/lib/DefaultConfig/DefaultConfig.h
+++ b/blockware/lib/DefaultConfig/DefaultConfig.h
@@ -32,3 +32,8 @@
 // 15MHz SPI for communication with the OLED display
 // The ESP8266 can supposedly can go up to 30MHz but seems to cause instability
 #define SPI_SPEED 15000000
+
+// V4 Microcontroller board accelerometer
+#define ACCEL_LIS2DW12
+// V2 and V3 Microcontroller board accelerometer
+// #define ACCEL_MMA8452Q

--- a/blockware/pixel-dust/platformio.ini
+++ b/blockware/pixel-dust/platformio.ini
@@ -20,7 +20,7 @@ lib_deps =
     https://github.com/johnboiles/Adafruit-GFX-Library#patch-1
     Adafruit SSD1351 library
     Adafruit PixelDust
-    https://github.com/stm32duino/LIS2DW12
+    stm32duino/STM32duino LIS2DW12 @ ^2.0.0
 
 ; Change this if your USB-serial device is not auto-detected by PlatformIO
 ;upload_port = /dev/cu.usbserial*

--- a/cad/pcb/README.md
+++ b/cad/pcb/README.md
@@ -49,6 +49,10 @@ There's an included [script](https://github.com/bountylabs/blocks-with-screens/b
 
 ## Changelog
 
+### Microcontroller Board V4
+
+* MMA8452QR1 accelerometers are #chipshortage'd. Switch to LIS2DW12
+
 ### OLED Board V5
 
 * Revert the revert to go back to VIN for the 13V boost circuit as it didn't seem to have any effect. And this lightens the load on the 3.3V regulator. This is effectively the same design as OLED Board V3.


### PR DESCRIPTION
Followup to #5

So we can support the V2 and V3 microcontroller boards we still have on our desks.