### PR TITLE
Fix angle randomization

### DIFF
--- a/blockware/fireworks/lib/Particle/Particle.cpp
+++ b/blockware/fireworks/lib/Particle/Particle.cpp
@@ -17,7 +17,7 @@ Particle::Particle(int x, int y, bool isRocket, int color)
     _vel.set(random(-3, 3), random(-7, -3));
     _resistance = 1.0f;
   } else {
-    float angle = random(TAU);
+    float angle = ((float)random(RAND_MAX)/(float)RAND_MAX) * TAU;
     float speed = cos(random(0, TAU)) * 15;
     _vel.set(cos(angle) * speed, sin(angle) * speed);
     _resistance = 0.92f;


### PR DESCRIPTION
`random` returns a `long`. `random(TAU)` produced unsigned integers up to 6. So the angle of the sparks always came out along the points of a hexagon. By converting to a float before scaling we can distribute the sparks more evenly around the explosion point.