### PR TITLE
[WIP] ESP32-PICO-D4 based microcontroller board

### DIFF
--- a/cad/pcb/microcontroller-esp32.brd
+++ b/cad/pcb/microcontroller-esp32.brd
@@ -1,0 +1,1955 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.6.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="6.25" unitdist="mil" unit="mil" style="lines" multiple="1" display="no" altdistance="1" altunitdist="mil" altunit="mil"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="GND" color="16" fill="1" visible="yes" active="yes"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
+<layer number="15" name="3.3V" color="23" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="no" active="no"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="no"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="no" active="no"/>
+<layer number="95" name="Names" color="7" fill="1" visible="no" active="no"/>
+<layer number="96" name="Values" color="7" fill="1" visible="no" active="no"/>
+<layer number="97" name="Info" color="7" fill="1" visible="no" active="no"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
+<layer number="99" name="SpiceOrder" color="7" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Mittellin" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="Stiffner" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="7" fill="1" visible="no" active="yes"/>
+<layer number="105" name="Beschreib" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="BGA-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="BD-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tBridges" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="tBPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="bBPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="MPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="ReferenceLS" color="7" fill="1" visible="no" active="no"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="no" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="117" name="BACKMAAT1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="no"/>
+<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="no" active="yes"/>
+<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="sName" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bPlace" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
+<layer number="130" name="SMDSTROOK" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="133" name="bottom_silk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="134" name="mbFinish" color="7" fill="1" visible="no" active="yes"/>
+<layer number="135" name="mtGlue" color="7" fill="1" visible="no" active="yes"/>
+<layer number="136" name="mbGlue" color="7" fill="1" visible="no" active="yes"/>
+<layer number="137" name="mtTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="138" name="mbTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="139" name="mtKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="140" name="mbKeepout" color="7" fill="1" visible="no" active="yes"/>
+<layer number="141" name="mtRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="142" name="mbRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="143" name="mvRestrict" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="145" name="mHoles" color="7" fill="1" visible="no" active="yes"/>
+<layer number="146" name="mMilling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="147" name="mMeasures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="148" name="mDocument" color="7" fill="1" visible="no" active="yes"/>
+<layer number="149" name="mReference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
+<layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
+<layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
+<layer number="191" name="mNets" color="7" fill="1" visible="no" active="yes"/>
+<layer number="192" name="mBusses" color="7" fill="1" visible="no" active="yes"/>
+<layer number="193" name="mPins" color="7" fill="1" visible="no" active="yes"/>
+<layer number="194" name="mSymbols" color="7" fill="1" visible="no" active="yes"/>
+<layer number="195" name="mNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="196" name="mValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="no" active="no"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="no"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="no"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="7" fill="1" visible="no" active="yes"/>
+<layer number="251" name="SMDround" color="7" fill="1" visible="no" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
+</layers>
+<board>
+<fusionsync huburn="a.cGVyc29uYWw6dWUyYjFlZDY0" projecturn="a.cGVyc29uYWw6dWUyYjFlZDY0IzIwMTgxMjAxMTYzMjIxMDU2" f3durn="urn:adsk.wipprod:dm.lineage:Qhrg8WgVTiKLt4HT-10KwQ" pcbguid="3acbaef0-80b3-43c3-8df5-5b165ba3065e" lastpulledtime="" lastsyncedchangeguid="f07d20a8-c11d-7315-1675-b4d7888495a1" latestrevisionid="" lastsyncedrevisionid="" lastboardhashguid="" lastpushedtime="" linktopcb3d="false"/>
+<plain>
+<wire x1="26.162" y1="0" x2="0" y2="0" width="0" layer="20"/>
+<wire x1="0" y1="26.162" x2="0" y2="0" width="0" layer="20"/>
+<wire x1="0" y1="26.162" x2="26.162" y2="26.162" width="0" layer="20"/>
+<wire x1="26.162" y1="26.162" x2="26.162" y2="0" width="0" layer="20"/>
+<text x="3.01625" y="15.67815" size="1.8288" layer="22" font="vector" ratio="12" rot="MR270" align="center">-</text>
+<dimension x1="0" y1="0.3175" x2="31.75" y2="0.3175" x3="15.875" y3="-1.5875" textsize="1.778" layer="47"/>
+<dimension x1="32.639" y1="0.9906" x2="32.6898" y2="18.7452" x3="40.74160625" y3="9.8447875" textsize="1.778" layer="47"/>
+<text x="8.89" y="12.61745" size="1.0668" layer="22" font="vector" ratio="12" rot="MR180" align="bottom-center">PSRAM</text>
+</plain>
+<libraries>
+<library name="microbuilder">
+<description>&lt;h2&gt;&lt;b&gt;microBuilder.eu&lt;/b&gt; Eagle Footprint Library&lt;/h2&gt;
+
+&lt;p&gt;Footprints for common components used in our projects and products.  This is the same library that we use internally, and it is regularly updated.  The newest version can always be found at &lt;b&gt;www.microBuilder.eu&lt;/b&gt;.  If you find this library useful, please feel free to purchase something from our online store. Please also note that all holes are optimised for metric drill bits!&lt;/p&gt;
+
+&lt;h3&gt;Obligatory Warning&lt;/h3&gt;
+&lt;p&gt;While it probably goes without saying, there are no guarantees that the footprints or schematic symbols in this library are flawless, and we make no promises of fitness for production, prototyping or any other purpose. These libraries are provided for information puposes only, and are used at your own discretion.  While we make every effort to produce accurate footprints, and many of the items found in this library have be proven in production, we can't make any promises of suitability for a specific purpose. If you do find any errors, though, please feel free to contact us at www.microbuilder.eu to let us know about it so that we can update the library accordingly!&lt;/p&gt;
+
+&lt;h3&gt;License&lt;/h3&gt;
+&lt;p&gt;This work is placed in the public domain, and may be freely used for commercial and non-commercial work with the following conditions:&lt;/p&gt;
+&lt;p&gt;THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+&lt;/p&gt;</description>
+<packages>
+<package name="_0402MP">
+<description>&lt;b&gt;0402 MicroPitch&lt;p&gt;</description>
+<wire x1="-0.245" y1="0.174" x2="0.245" y2="0.174" width="0.1016" layer="51"/>
+<wire x1="0.245" y1="-0.174" x2="-0.245" y2="-0.174" width="0.1016" layer="51"/>
+<wire x1="0" y1="0.127" x2="0" y2="-0.127" width="0.2032" layer="21"/>
+<smd name="1" x="-0.508" y="0" dx="0.5" dy="0.5" layer="1"/>
+<smd name="2" x="0.508" y="0" dx="0.5" dy="0.5" layer="1"/>
+<text x="-0.635" y="0.4763" size="0.6096" layer="25" ratio="18">&gt;NAME</text>
+<text x="-0.635" y="-0.7938" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.1" y1="-0.2" x2="0.1" y2="0.2" layer="35"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.254" y2="0.25" layer="51"/>
+<rectangle x1="0.2588" y1="-0.25" x2="0.5" y2="0.25" layer="51"/>
+</package>
+</packages>
+</library>
+<library name="Nordic_nRF" urn="urn:adsk.eagle:library:169009">
+<description>&lt;h4&gt;Nordic Semiconductor Devices&lt;/h4&gt;
+&lt;br&gt;
+&lt;a href=http://www.nordicsemi.com&gt;www.nordicsemi.com&lt;/a&gt;
+&lt;br&gt;
+To report issues with this library go to &lt;a href=https://github.com/NordicPlayground/nrf5-eagle-reference-design/blob/master/Library/Nordic_nRF.lbr&gt;github&lt;/a&gt;</description>
+<packages>
+<package name="RESC0402_N" urn="urn:adsk.eagle:footprint:2593711/1" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<smd name="1" x="-0.55" y="0" dx="0.6" dy="0.6" layer="1"/>
+<smd name="2" x="0.55" y="0" dx="0.6" dy="0.6" layer="1"/>
+<text x="-0.6" y="1.1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.7" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.5" y1="0.25" x2="0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.25" x2="0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.25" x2="-0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.25" x2="-0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="1" y1="-0.45" x2="1" y2="0.45" width="0.1" layer="39"/>
+<wire x1="1" y1="0.45" x2="-1" y2="0.45" width="0.1" layer="39"/>
+<wire x1="-1" y1="0.45" x2="-1" y2="-0.45" width="0.1" layer="39"/>
+<wire x1="-1" y1="-0.45" x2="1" y2="-0.45" width="0.1" layer="39"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="RESC0402_N" urn="urn:adsk.eagle:package:2593732/1" type="box" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<packageinstances>
+<packageinstance name="RESC0402_N"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="UnexpectedMaker">
+<description>Generated from &lt;b&gt;WattsSegment_Display.sch&lt;/b&gt;&lt;p&gt;
+by exp-lbrs.ulp</description>
+<packages>
+<package name="SOP8" urn="urn:adsk.eagle:footprint:26249/1" locally_modified="yes">
+<description>&lt;b&gt;SOP8&lt;/b&gt;&lt;p&gt;
+Source: http://www.rohm.com/products/databook/motor/pdf/bd623x_series-e.pdf</description>
+<wire x1="2.395" y1="-2.11" x2="-2.395" y2="-2.11" width="0.2032" layer="51"/>
+<wire x1="-2.649" y1="-2.11" x2="-2.649" y2="2.085" width="0.2032" layer="21"/>
+<wire x1="-2.395" y1="2.085" x2="2.395" y2="2.085" width="0.2032" layer="51"/>
+<wire x1="-2.594" y1="0.635" x2="-2.594" y2="-0.635" width="0.2032" layer="21" curve="-180"/>
+<smd name="1" x="-1.905" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="2" x="-0.635" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="3" x="0.635" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="4" x="1.905" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="5" x="1.905" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="6" x="0.635" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="7" x="-0.635" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="8" x="-1.905" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<text x="4.445" y="-3.175" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+<rectangle x1="-2.1549" y1="-3.1" x2="-1.6551" y2="-2.2" layer="51"/>
+<rectangle x1="-0.8849" y1="-3.1" x2="-0.3851" y2="-2.2" layer="51"/>
+<rectangle x1="0.3851" y1="-3.1" x2="0.8849" y2="-2.2" layer="51"/>
+<rectangle x1="1.6551" y1="-3.1" x2="2.1549" y2="-2.2" layer="51"/>
+<rectangle x1="1.6551" y1="2.2" x2="2.1549" y2="3.1" layer="51"/>
+<rectangle x1="0.3851" y1="2.2" x2="0.8849" y2="3.1" layer="51"/>
+<rectangle x1="-0.8849" y1="2.2" x2="-0.3851" y2="3.1" layer="51"/>
+<rectangle x1="-2.1549" y1="2.2" x2="-1.6551" y2="3.1" layer="51"/>
+</package>
+<package name="PICO-D4-QFN48">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<wire x1="-3" y1="3.5" x2="3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="3.5" x2="3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="3" x2="3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="-3" x2="3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="-3.5" x2="-3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="-3" y1="-3.5" x2="-3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="-3" x2="-3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="3" x2="-3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="-3.5916" y1="2.84" x2="-3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.84" x2="-3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.66" x2="-3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.66" x2="-3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.75" x2="-3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.845" x2="-3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.845" x2="-3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.655" x2="-3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.655" x2="-3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="2.75" x2="-3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="2.34" x2="-3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.34" x2="-3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.16" x2="-3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.16" x2="-3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.25" x2="-3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.345" x2="-3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.345" x2="-3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.155" x2="-3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.155" x2="-3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="2.25" x2="-3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.84" x2="-3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.84" x2="-3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.66" x2="-3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.66" x2="-3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="1.75" x2="-3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.845" x2="-3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.845" x2="-3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.655" x2="-3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.655" x2="-3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="1.75" x2="-3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.34" x2="-3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.34" x2="-3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.16" x2="-3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.16" x2="-3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="1.25" x2="-3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.345" x2="-3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.345" x2="-3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.155" x2="-3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.155" x2="-3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="1.25" x2="-3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.84" x2="-3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.84" x2="-3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.66" x2="-3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.66" x2="-3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.75" x2="-3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.845" x2="-3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.845" x2="-3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.655" x2="-3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.655" x2="-3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="0.75" x2="-3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.34" x2="-3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.34" x2="-3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.16" x2="-3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.16" x2="-3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.25" x2="-3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.345" x2="-3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.345" x2="-3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.155" x2="-3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.155" x2="-3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="0.25" x2="-3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.16" x2="-3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.16" x2="-3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.34" x2="-3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.34" x2="-3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.25" x2="-3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.155" x2="-3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.155" x2="-3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.345" x2="-3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.345" x2="-3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-0.25" x2="-3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.66" x2="-3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.66" x2="-3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.84" x2="-3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.84" x2="-3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.75" x2="-3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.655" x2="-3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.655" x2="-3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.845" x2="-3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.845" x2="-3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-0.75" x2="-3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.16" x2="-3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.16" x2="-3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.34" x2="-3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.34" x2="-3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-1.25" x2="-3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.155" x2="-3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.155" x2="-3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.345" x2="-3.60295" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.345" x2="-3.60295" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.54025" y1="-1.25" x2="-3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.66" x2="-3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.66" x2="-3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.84" x2="-3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.84" x2="-3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-1.75" x2="-3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.655" x2="-3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.655" x2="-3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.845" x2="-3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.845" x2="-3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-1.75" x2="-3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.16" x2="-3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.16" x2="-3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.34" x2="-3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.34" x2="-3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-2.25" x2="-3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.155" x2="-3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.155" x2="-3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.345" x2="-3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.345" x2="-3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.56565" y1="-2.25" x2="-3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.66" x2="-3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.66" x2="-3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.84" x2="-3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.84" x2="-3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-2.75" x2="-3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.655" x2="-3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.655" x2="-3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.845" x2="-3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.845" x2="-3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-2.75" x2="-3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="-2.84" y1="-3.5916" x2="-2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="-3.06" x2="-2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.06" x2="-2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.5916" x2="-2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="-3.5416" x2="-2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.845" y1="-3.60295" x2="-2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="-3.055" x2="-2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.055" x2="-2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.60295" x2="-2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="-3.5593" x2="-2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-2.34" y1="-3.5916" x2="-2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="-3.06" x2="-2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.06" x2="-2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.5916" x2="-2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="-3.5416" x2="-2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.345" y1="-3.60295" x2="-2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="-3.055" x2="-2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.055" x2="-2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.60295" x2="-2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="-3.5593" x2="-2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.84" y1="-3.5916" x2="-1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="-3.06" x2="-1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.06" x2="-1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.5916" x2="-1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="-3.5416" x2="-1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.845" y1="-3.60295" x2="-1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="-3.055" x2="-1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.055" x2="-1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.60295" x2="-1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="-3.5593" x2="-1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.34" y1="-3.5916" x2="-1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="-3.06" x2="-1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.06" x2="-1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.5916" x2="-1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="-3.5416" x2="-1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.345" y1="-3.60295" x2="-1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="-3.055" x2="-1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.055" x2="-1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.60295" x2="-1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="-3.55295" x2="-1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.84" y1="-3.5916" x2="-0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="-3.06" x2="-0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.06" x2="-0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.5916" x2="-0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="-3.567" x2="-0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.845" y1="-3.60295" x2="-0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="-3.055" x2="-0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.055" x2="-0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.60295" x2="-0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="-3.56565" x2="-0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.34" y1="-3.5916" x2="-0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="-3.06" x2="-0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.06" x2="-0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.5916" x2="-0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="-3.5416" x2="-0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.345" y1="-3.60295" x2="-0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="-3.055" x2="-0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.055" x2="-0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.60295" x2="-0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="-3.55295" x2="-0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.16" y1="-3.5916" x2="0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="-3.06" x2="0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.06" x2="0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.5916" x2="0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="-3.5416" x2="0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.155" y1="-3.60295" x2="0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="-3.055" x2="0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.055" x2="0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.60295" x2="0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="-3.5593" x2="0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.66" y1="-3.5916" x2="0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="-3.06" x2="0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.06" x2="0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.5916" x2="0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="-3.5416" x2="0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.655" y1="-3.60295" x2="0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="-3.055" x2="0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.055" x2="0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.60295" x2="0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="-3.572" x2="0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.16" y1="-3.5916" x2="1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="-3.06" x2="1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.06" x2="1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.5916" x2="1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="-3.5416" x2="1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.155" y1="-3.60295" x2="1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="-3.055" x2="1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.055" x2="1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.60295" x2="1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="-3.56565" x2="1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.66" y1="-3.5916" x2="1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="-3.06" x2="1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.06" x2="1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.5916" x2="1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="-3.5416" x2="1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.655" y1="-3.60295" x2="1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="-3.055" x2="1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.055" x2="1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.60295" x2="1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="-3.56565" x2="1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.16" y1="-3.5916" x2="2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="-3.06" x2="2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.06" x2="2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.5916" x2="2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="-3.5416" x2="2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.155" y1="-3.60295" x2="2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="-3.055" x2="2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.055" x2="2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.60295" x2="2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="-3.5466" x2="2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.66" y1="-3.5916" x2="2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="-3.06" x2="2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.06" x2="2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.5916" x2="2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="-3.5416" x2="2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.655" y1="-3.60295" x2="2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="-3.055" x2="2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.055" x2="2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.60295" x2="2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="-3.54025" x2="2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.84" x2="3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.84" x2="3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.66" x2="3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.66" x2="3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.75" x2="3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.845" x2="3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.845" x2="3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.655" x2="3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.655" x2="3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-2.75" x2="3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.34" x2="3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.34" x2="3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.16" x2="3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.16" x2="3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.25" x2="3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.345" x2="3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.345" x2="3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.155" x2="3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.155" x2="3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-2.25" x2="3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.84" x2="3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.84" x2="3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.66" x2="3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.66" x2="3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.75" x2="3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.845" x2="3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.845" x2="3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.655" x2="3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.655" x2="3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-1.75" x2="3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.34" x2="3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.34" x2="3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.16" x2="3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.16" x2="3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.25" x2="3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.35135" x2="3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.345" x2="3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.155" x2="3.60295" y2="-1.16135" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.16135" x2="3.60295" y2="-1.35135" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-1.25" x2="3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.84" x2="3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.84" x2="3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.66" x2="3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.66" x2="3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.75" x2="3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.845" x2="3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.845" x2="3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.655" x2="3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.655" x2="3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.75" x2="3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.34" x2="3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.34" x2="3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.16" x2="3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.16" x2="3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.25" x2="3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.345" x2="3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.345" x2="3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.155" x2="3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.155" x2="3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.25" x2="3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.16" x2="3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.16" x2="3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.34" x2="3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.34" x2="3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.25" x2="3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.155" x2="3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.155" x2="3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.345" x2="3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.345" x2="3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.25" x2="3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.66" x2="3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.66" x2="3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.84" x2="3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.84" x2="3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.75" x2="3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.655" x2="3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.655" x2="3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.845" x2="3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.845" x2="3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.75" x2="3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.16" x2="3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.16" x2="3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.34" x2="3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.34" x2="3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="1.25" x2="3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.155" x2="3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.155" x2="3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.345" x2="3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.345" x2="3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.25" x2="3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.66" x2="3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.66" x2="3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.84" x2="3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.84" x2="3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.567" y1="1.75" x2="3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.655" x2="3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.655" x2="3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.845" x2="3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.845" x2="3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.75" x2="3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.16" x2="3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.16" x2="3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.34" x2="3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.34" x2="3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.25" x2="3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.155" x2="3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.155" x2="3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.345" x2="3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.345" x2="3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="2.25" x2="3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.66" x2="3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.66" x2="3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.84" x2="3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.84" x2="3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.75" x2="3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.655" x2="3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.655" x2="3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.845" x2="3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.845" x2="3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="2.75" x2="3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="2.84" y1="3.5916" x2="2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="3.06" x2="2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.06" x2="2.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.5916" x2="2.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="3.5416" x2="2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.845" y1="3.60295" x2="2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="3.055" x2="2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.055" x2="2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.60295" x2="2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="3.55295" x2="2.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="2.34" y1="3.5916" x2="2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="3.06" x2="2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.06" x2="2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.5916" x2="2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="3.5162" x2="2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.345" y1="3.60295" x2="2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="3.055" x2="2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.055" x2="2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.60295" x2="2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="3.56565" x2="2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.84" y1="3.5916" x2="1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="3.06" x2="1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.06" x2="1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.5916" x2="1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="3.5416" x2="1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.845" y1="3.60295" x2="1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="3.055" x2="1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.055" x2="1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.60295" x2="1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="3.55295" x2="1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.34" y1="3.5916" x2="1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="3.06" x2="1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.06" x2="1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.5916" x2="1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="3.5416" x2="1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.345" y1="3.60295" x2="1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="3.055" x2="1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.055" x2="1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.60295" x2="1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="3.5466" x2="1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.84" y1="3.5916" x2="0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="3.06" x2="0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.06" x2="0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.5916" x2="0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="3.5416" x2="0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.845" y1="3.60295" x2="0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="3.055" x2="0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.055" x2="0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.60295" x2="0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="3.54025" x2="0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.34" y1="3.5916" x2="0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="3.06" x2="0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.06" x2="0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.5916" x2="0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="3.5416" x2="0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.345" y1="3.60295" x2="0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="3.055" x2="0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.055" x2="0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.60295" x2="0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="3.5466" x2="0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.16" y1="3.5916" x2="-0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="3.06" x2="-0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.06" x2="-0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.5916" x2="-0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="3.567" x2="-0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.155" y1="3.60295" x2="-0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="3.055" x2="-0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.055" x2="-0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.60295" x2="-0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="3.5466" x2="-0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.66" y1="3.5916" x2="-0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="3.06" x2="-0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.06" x2="-0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.5916" x2="-0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="3.567" x2="-0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.655" y1="3.60295" x2="-0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="3.055" x2="-0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.055" x2="-0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.60295" x2="-0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="3.5466" x2="-0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.16" y1="3.5916" x2="-1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="3.06" x2="-1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.06" x2="-1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.5916" x2="-1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="3.5416" x2="-1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.155" y1="3.60295" x2="-1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="3.055" x2="-1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.055" x2="-1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.60295" x2="-1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="3.5593" x2="-1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.66" y1="3.5916" x2="-1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="3.06" x2="-1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.06" x2="-1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.5916" x2="-1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="3.567" x2="-1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.655" y1="3.60295" x2="-1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="3.055" x2="-1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.055" x2="-1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.60295" x2="-1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="3.572" x2="-1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.16" y1="3.5916" x2="-2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="3.06" x2="-2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.06" x2="-2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.5916" x2="-2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="3.5416" x2="-2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.155" y1="3.60295" x2="-2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="3.055" x2="-2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.055" x2="-2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.60295" x2="-2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="3.5593" x2="-2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.66" y1="3.5941" x2="-2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="3.06" x2="-2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.06" x2="-2.84" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.5941" x2="-2.75" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.66" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.655" y1="3.60295" x2="-2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="3.055" x2="-2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.055" x2="-2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.60295" x2="-2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="3.572" x2="-2.75" y2="3.105" width="0.1016" layer="29"/>
+<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
+<smd name="EXP" x="0" y="0" dx="4.572" dy="4.572" layer="1" roundness="5" stop="no" cream="no"/>
+<smd name="1" x="-3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="2" x="-3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="-3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="-3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="5" x="-3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="-3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="7" x="-3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="8" x="-3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="9" x="-3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="10" x="-3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="11" x="-3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="12" x="-3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="13" x="-2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="14" x="-2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="15" x="-1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="16" x="-1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="17" x="-0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="18" x="-0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="19" x="0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="20" x="0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="21" x="1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="22" x="1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="23" x="2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="24" x="2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="25" x="3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="26" x="3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="27" x="3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="28" x="3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="29" x="3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="30" x="3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="31" x="3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="32" x="3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="33" x="3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="34" x="3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="35" x="3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="36" x="3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="37" x="2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="38" x="2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="39" x="1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="40" x="1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="41" x="0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="42" x="0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="43" x="-0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="44" x="-0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="45" x="-1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="46" x="-1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="47" x="-2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="48" x="-2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-3.45" y1="2.535" x2="-3.22" y2="2.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="2.035" x2="-3.22" y2="2.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.535" x2="-3.22" y2="1.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.035" x2="-3.22" y2="1.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.535" x2="-3.22" y2="0.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.035" x2="-3.22" y2="0.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.465" x2="-3.22" y2="-0.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.965" x2="-3.22" y2="-0.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.465" x2="-3.22" y2="-1.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.965" x2="-3.22" y2="-1.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.465" x2="-3.22" y2="-2.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.965" x2="-3.22" y2="-2.535" layer="51" rot="R270"/>
+<rectangle x1="-2.865" y1="-3.55" x2="-2.635" y2="-3.12" layer="51"/>
+<rectangle x1="-2.365" y1="-3.55" x2="-2.135" y2="-3.12" layer="51"/>
+<rectangle x1="-1.865" y1="-3.55" x2="-1.635" y2="-3.12" layer="51"/>
+<rectangle x1="-1.365" y1="-3.55" x2="-1.135" y2="-3.12" layer="51"/>
+<rectangle x1="-0.865" y1="-3.55" x2="-0.635" y2="-3.12" layer="51"/>
+<rectangle x1="-0.365" y1="-3.55" x2="-0.135" y2="-3.12" layer="51"/>
+<rectangle x1="0.135" y1="-3.55" x2="0.365" y2="-3.12" layer="51"/>
+<rectangle x1="0.635" y1="-3.55" x2="0.865" y2="-3.12" layer="51"/>
+<rectangle x1="1.135" y1="-3.55" x2="1.365" y2="-3.12" layer="51"/>
+<rectangle x1="1.635" y1="-3.55" x2="1.865" y2="-3.12" layer="51"/>
+<rectangle x1="2.135" y1="-3.55" x2="2.365" y2="-3.12" layer="51"/>
+<rectangle x1="2.635" y1="-3.55" x2="2.865" y2="-3.12" layer="51"/>
+<rectangle x1="3.22" y1="-2.965" x2="3.45" y2="-2.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-2.465" x2="3.45" y2="-2.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.965" x2="3.45" y2="-1.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.465" x2="3.45" y2="-1.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.965" x2="3.45" y2="-0.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.465" x2="3.45" y2="-0.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.035" x2="3.45" y2="0.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.535" x2="3.45" y2="0.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.035" x2="3.45" y2="1.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.535" x2="3.45" y2="1.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.035" x2="3.45" y2="2.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.535" x2="3.45" y2="2.965" layer="51" rot="R90"/>
+<rectangle x1="2.635" y1="3.12" x2="2.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="2.135" y1="3.12" x2="2.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.635" y1="3.12" x2="1.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.135" y1="3.12" x2="1.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.635" y1="3.12" x2="0.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.135" y1="3.12" x2="0.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.365" y1="3.12" x2="-0.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.865" y1="3.12" x2="-0.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.365" y1="3.12" x2="-1.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.865" y1="3.12" x2="-1.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.365" y1="3.12" x2="-2.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.865" y1="3.12" x2="-2.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.286" y1="-2.286" x2="2.286" y2="2.286" layer="29"/>
+<wire x1="-2.667" y1="1.27" x2="-2.667" y2="2.667" width="0.127" layer="25"/>
+<wire x1="-2.667" y1="2.667" x2="-1.27" y2="2.667" width="0.127" layer="25"/>
+<rectangle x1="-2.159" y1="1.016" x2="-1.016" y2="2.159" layer="31"/>
+<rectangle x1="1.016" y1="1.016" x2="2.159" y2="2.159" layer="31"/>
+<rectangle x1="-0.5715" y1="1.016" x2="0.5715" y2="2.159" layer="31"/>
+<rectangle x1="1.016" y1="-2.159" x2="2.159" y2="-1.016" layer="31"/>
+<rectangle x1="-2.159" y1="-2.159" x2="-1.016" y2="-1.016" layer="31"/>
+<rectangle x1="-0.5715" y1="-2.159" x2="0.5715" y2="-1.016" layer="31"/>
+<rectangle x1="-2.159" y1="-0.5715" x2="-1.016" y2="0.5715" layer="31"/>
+<rectangle x1="-0.5715" y1="-0.5715" x2="0.5715" y2="0.5715" layer="31"/>
+<rectangle x1="1.016" y1="-0.5715" x2="2.159" y2="0.5715" layer="31"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="SOP8" urn="urn:adsk.eagle:package:26262/1" locally_modified="yes" type="box">
+<description>SOP8
+Source: http://www.rohm.com/products/databook/motor/pdf/bd623x_series-e.pdf</description>
+<packageinstances>
+<packageinstance name="SOP8"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="47219-2001">
+<packages>
+<package name="MOLEX_47219-2001">
+<wire x1="-6.8" y1="-7.25" x2="6.8" y2="-7.25" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="7.25" x2="6.8" y2="7.25" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="7.2" x2="-6.8" y2="4.8" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="-5.9" x2="-6.8" y2="-3.5" width="0.127" layer="51"/>
+<wire x1="-6.8" y1="2.3" x2="-6.8" y2="4.8" width="0.127" layer="51"/>
+<wire x1="6.8" y1="7.2" x2="6.8" y2="4.8" width="0.127" layer="21"/>
+<wire x1="6.8" y1="4.8" x2="6.8" y2="-5.9" width="0.127" layer="51"/>
+<wire x1="-6" y1="-7.2" x2="-6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="6" y1="-7.2" x2="6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="-6" y1="-6.5" x2="-4.3" y2="-5.5" width="0.127" layer="21"/>
+<wire x1="-4.3" y1="-5.5" x2="-1.9" y2="-4.9" width="0.127" layer="21"/>
+<wire x1="-1.9" y1="-4.9" x2="1.6" y2="-4.9" width="0.127" layer="21"/>
+<wire x1="1.6" y1="-4.9" x2="4.2" y2="-5.5" width="0.127" layer="21"/>
+<wire x1="4.2" y1="-5.5" x2="6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="4.8" x2="6.8" y2="4.8" width="0.127" layer="21"/>
+<text x="-8.20976875" y="-6.10726875" size="1.271509375" layer="25" rot="R90">&gt;NAME</text>
+<text x="9.252459375" y="-5.75153125" size="1.270340625" layer="27" rot="R90">&gt;VALUE</text>
+<wire x1="-7.9" y1="7.6" x2="7.9" y2="7.6" width="0.127" layer="39"/>
+<wire x1="7.9" y1="7.6" x2="7.9" y2="-7.6" width="0.127" layer="39"/>
+<wire x1="7.9" y1="-7.6" x2="-7.9" y2="-7.6" width="0.127" layer="39"/>
+<wire x1="-7.9" y1="-7.6" x2="-7.9" y2="7.6" width="0.127" layer="39"/>
+<smd name="1" x="3.2" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="2" x="2.1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="3" x="1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="4" x="-0.1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="5" x="-1.2" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="6" x="-2.3" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="7" x="-3.4" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="8" x="-4.5" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="G1" x="6.875" y="-4.7" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G2" x="6.875" y="3.6" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G3" x="-6.875" y="3.6" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G4" x="-6.875" y="-4.7" dx="1.5" dy="2.05" layer="1"/>
+</package>
+</packages>
+</library>
+<library name="adafruit" urn="urn:adsk.eagle:library:420">
+<packages>
+<package name="1X08-CLEANBIG" urn="urn:adsk.eagle:footprint:6240062/1" library_version="2">
+<pad name="1" x="-8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="2" x="-6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="3" x="-3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="4" x="-1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="5" x="1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="6" x="3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="7" x="6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="8" x="8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<text x="-10.2362" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-10.16" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="6.096" y1="-0.254" x2="6.604" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="-6.604" y1="-0.254" x2="-6.096" y2="0.254" layer="51"/>
+<rectangle x1="-9.144" y1="-0.254" x2="-8.636" y2="0.254" layer="51"/>
+<rectangle x1="8.636" y1="-0.254" x2="9.144" y2="0.254" layer="51"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X08-CLEANBIG" urn="urn:adsk.eagle:package:6240708/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="1X08-CLEANBIG"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="SparkFun-RF" urn="urn:adsk.eagle:library:531">
+<description>&lt;h3&gt;SparkFun RF, WiFi, Cellular, and Bluetooth&lt;/h3&gt;
+In this library you'll find things that send or receive RF-- cellular modules, Bluetooth, WiFi, etc.
+&lt;br&gt;
+&lt;br&gt;
+We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
+&lt;br&gt;
+&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
+&lt;br&gt;
+&lt;br&gt;
+&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
+&lt;br&gt;
+&lt;br&gt;
+You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<packages>
+<package name="TRACE_ANTENNA_2.4GHZ_15.2MM" urn="urn:adsk.eagle:footprint:39532/1" library_version="1">
+<description>&lt;h3&gt;2.4GHz Meander PCB Trace Antenna&lt;/h3&gt;
+&lt;p&gt;PCB trace antenna with a 15.2 x 5.7mm footprint.&lt;/p&gt;
+&lt;p&gt;Based on layout from &lt;a href="http://www.ti.com/lit/an/swra117d/swra117d.pdf"&gt;TI app note AN043&lt;/a&gt;.&lt;/p&gt;</description>
+<polygon width="0.002540625" layer="1">
+<vertex x="-0.25" y="-0.5"/>
+<vertex x="-0.25" y="4.4"/>
+<vertex x="-1.65" y="4.4"/>
+<vertex x="-1.65" y="-0.5"/>
+<vertex x="-2.55" y="-0.5"/>
+<vertex x="-2.55" y="4.9"/>
+<vertex x="2.45" y="4.9"/>
+<vertex x="2.45" y="2.26"/>
+<vertex x="4.45" y="2.26"/>
+<vertex x="4.45" y="4.9"/>
+<vertex x="7.15" y="4.9"/>
+<vertex x="7.15" y="2.26"/>
+<vertex x="9.15" y="2.26"/>
+<vertex x="9.15" y="4.9"/>
+<vertex x="11.85" y="4.9"/>
+<vertex x="11.85" y="0.46"/>
+<vertex x="11.35" y="0.46"/>
+<vertex x="11.35" y="4.4"/>
+<vertex x="9.65" y="4.4"/>
+<vertex x="9.65" y="1.76"/>
+<vertex x="6.65" y="1.76"/>
+<vertex x="6.65" y="4.4"/>
+<vertex x="4.95" y="4.4"/>
+<vertex x="4.95" y="1.76"/>
+<vertex x="1.95" y="1.76"/>
+<vertex x="1.95" y="4.4"/>
+<vertex x="0.25" y="4.4"/>
+<vertex x="0.25" y="-0.5"/>
+</polygon>
+<wire x1="-3" y1="0" x2="12" y2="0" width="0.05" layer="51"/>
+<wire x1="-3" y1="5.2" x2="12" y2="5.2" width="0.05" layer="51"/>
+<smd name="GND" x="-2.1" y="-0.25" dx="0.9" dy="0.5" layer="1" stop="no" thermals="no" cream="no"/>
+<smd name="ANT" x="0" y="-0.25" dx="0.5" dy="0.5" layer="1" stop="no" thermals="no" cream="no"/>
+<text x="1" y="-0.8" size="0.64" layer="51" font="vector">Ground Plane</text>
+<text x="1.5" y="5.5" size="0.64" layer="51" font="vector">Board Edge</text>
+<text x="0" y="1.27" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="TRACE_ANTENNA_2.4GHZ_15.2MM" urn="urn:adsk.eagle:package:39575/1" type="box" library_version="1">
+<description>2.4GHz Meander PCB Trace Antenna
+PCB trace antenna with a 15.2 x 5.7mm footprint.
+Based on layout from TI app note AN043.</description>
+<packageinstances>
+<packageinstance name="TRACE_ANTENNA_2.4GHZ_15.2MM"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0" drill="0">
+</class>
+<class number="1" name="power" width="0.4064" drill="0">
+</class>
+</classes>
+<designrules name="UnexpectedMaker_JLCPCB 4 Layer Tight">
+<description language="en">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+&lt;p&gt;
+The default Design Rules have been set to cover
+a wide range of applications. Your particular design
+may have different requirements, so please make the
+necessary adjustments and save your customized
+design rules under a new name.</description>
+<param name="layerSetup" value="(1+2*15+16)"/>
+<param name="mtCopper" value="0.035mm 0.017mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.017mm 0.035mm"/>
+<param name="mtIsolate" value="0.18mm 1.12mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.18mm"/>
+<param name="mdWireWire" value="5mil"/>
+<param name="mdWirePad" value="5mil"/>
+<param name="mdWireVia" value="5mil"/>
+<param name="mdPadPad" value="5mil"/>
+<param name="mdPadVia" value="5mil"/>
+<param name="mdViaVia" value="5mil"/>
+<param name="mdSmdPad" value="5mil"/>
+<param name="mdSmdVia" value="5mil"/>
+<param name="mdSmdSmd" value="5mil"/>
+<param name="mdViaViaSameLayer" value="8mil"/>
+<param name="mnLayersViaInSmd" value="2"/>
+<param name="mdCopperDimension" value="9mil"/>
+<param name="mdDrill" value="6mil"/>
+<param name="mdSmdStop" value="0mil"/>
+<param name="msWidth" value="5mil"/>
+<param name="msDrill" value="7mil"/>
+<param name="msMicroVia" value="10mm"/>
+<param name="msBlindViaRatio" value="0.5"/>
+<param name="rvPadTop" value="0.25"/>
+<param name="rvPadInner" value="0.25"/>
+<param name="rvPadBottom" value="0.25"/>
+<param name="rvViaOuter" value="0.25"/>
+<param name="rvViaInner" value="0.25"/>
+<param name="rvMicroViaOuter" value="0.25"/>
+<param name="rvMicroViaInner" value="0.25"/>
+<param name="rlMinPadTop" value="4mil"/>
+<param name="rlMaxPadTop" value="20mil"/>
+<param name="rlMinPadInner" value="4mil"/>
+<param name="rlMaxPadInner" value="20mil"/>
+<param name="rlMinPadBottom" value="4mil"/>
+<param name="rlMaxPadBottom" value="20mil"/>
+<param name="rlMinViaOuter" value="4mil"/>
+<param name="rlMaxViaOuter" value="20mil"/>
+<param name="rlMinViaInner" value="4mil"/>
+<param name="rlMaxViaInner" value="20mil"/>
+<param name="rlMinMicroViaOuter" value="4mil"/>
+<param name="rlMaxMicroViaOuter" value="20mil"/>
+<param name="rlMinMicroViaInner" value="4mil"/>
+<param name="rlMaxMicroViaInner" value="20mil"/>
+<param name="psTop" value="-1"/>
+<param name="psBottom" value="-1"/>
+<param name="psFirst" value="-1"/>
+<param name="psElongationLong" value="100"/>
+<param name="psElongationOffset" value="100"/>
+<param name="mvStopFrame" value="1"/>
+<param name="mvCreamFrame" value="0"/>
+<param name="mlMinStopFrame" value="1.25mil"/>
+<param name="mlMaxStopFrame" value="1.25mil"/>
+<param name="mlMinCreamFrame" value="0mil"/>
+<param name="mlMaxCreamFrame" value="0mil"/>
+<param name="mlViaStopLimit" value="12mil"/>
+<param name="srRoundness" value="0"/>
+<param name="srMinRoundness" value="0mil"/>
+<param name="srMaxRoundness" value="0mil"/>
+<param name="slThermalIsolate" value="10mil"/>
+<param name="slThermalsForVias" value="0"/>
+<param name="dpMaxLengthDifference" value="10mm"/>
+<param name="dpGapFactor" value="2.5"/>
+<param name="checkAngle" value="0"/>
+<param name="checkFont" value="1"/>
+<param name="checkRestrict" value="1"/>
+<param name="checkStop" value="0"/>
+<param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
+<param name="useDiameter" value="13"/>
+<param name="maxErrors" value="50"/>
+</designrules>
+<autorouter>
+<pass name="Default">
+<param name="RoutingGrid" value="50mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="2"/>
+<param name="TopRouterVariant" value="1"/>
+<param name="tpViaShape" value="round"/>
+<param name="PrefDir.1" value="a"/>
+<param name="PrefDir.2" value="0"/>
+<param name="PrefDir.3" value="0"/>
+<param name="PrefDir.4" value="0"/>
+<param name="PrefDir.5" value="0"/>
+<param name="PrefDir.6" value="0"/>
+<param name="PrefDir.7" value="0"/>
+<param name="PrefDir.8" value="0"/>
+<param name="PrefDir.9" value="0"/>
+<param name="PrefDir.10" value="0"/>
+<param name="PrefDir.11" value="0"/>
+<param name="PrefDir.12" value="0"/>
+<param name="PrefDir.13" value="0"/>
+<param name="PrefDir.14" value="0"/>
+<param name="PrefDir.15" value="0"/>
+<param name="PrefDir.16" value="a"/>
+<param name="cfVia" value="8"/>
+<param name="cfNonPref" value="5"/>
+<param name="cfChangeDir" value="2"/>
+<param name="cfOrthStep" value="2"/>
+<param name="cfDiagStep" value="3"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="1"/>
+<param name="cfMalusStep" value="1"/>
+<param name="cfPadImpact" value="4"/>
+<param name="cfSmdImpact" value="4"/>
+<param name="cfBusImpact" value="0"/>
+<param name="cfHugging" value="3"/>
+<param name="cfAvoid" value="4"/>
+<param name="cfPolygon" value="10"/>
+<param name="cfBase.1" value="0"/>
+<param name="cfBase.2" value="1"/>
+<param name="cfBase.3" value="1"/>
+<param name="cfBase.4" value="1"/>
+<param name="cfBase.5" value="1"/>
+<param name="cfBase.6" value="1"/>
+<param name="cfBase.7" value="1"/>
+<param name="cfBase.8" value="1"/>
+<param name="cfBase.9" value="1"/>
+<param name="cfBase.10" value="1"/>
+<param name="cfBase.11" value="1"/>
+<param name="cfBase.12" value="1"/>
+<param name="cfBase.13" value="1"/>
+<param name="cfBase.14" value="1"/>
+<param name="cfBase.15" value="1"/>
+<param name="cfBase.16" value="0"/>
+<param name="mnVias" value="20"/>
+<param name="mnSegments" value="9999"/>
+<param name="mnExtdSteps" value="9999"/>
+<param name="mnRipupLevel" value="10"/>
+<param name="mnRipupSteps" value="100"/>
+<param name="mnRipupTotal" value="100"/>
+</pass>
+<pass name="Follow-me" refer="Default" active="yes">
+</pass>
+<pass name="Busses" refer="Default" active="yes">
+<param name="cfNonPref" value="4"/>
+<param name="cfBusImpact" value="4"/>
+<param name="cfHugging" value="0"/>
+<param name="mnVias" value="0"/>
+</pass>
+<pass name="Route" refer="Default" active="yes">
+</pass>
+<pass name="Optimize1" refer="Default" active="yes">
+<param name="cfVia" value="99"/>
+<param name="cfExtdStep" value="10"/>
+<param name="cfHugging" value="1"/>
+<param name="mnExtdSteps" value="1"/>
+<param name="mnRipupLevel" value="0"/>
+</pass>
+<pass name="Optimize2" refer="Optimize1" active="yes">
+<param name="cfNonPref" value="0"/>
+<param name="cfChangeDir" value="6"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="2"/>
+<param name="cfMalusStep" value="2"/>
+<param name="cfPadImpact" value="2"/>
+<param name="cfSmdImpact" value="2"/>
+<param name="cfHugging" value="0"/>
+</pass>
+<pass name="Optimize3" refer="Optimize2" active="yes">
+<param name="cfChangeDir" value="8"/>
+<param name="cfPadImpact" value="0"/>
+<param name="cfSmdImpact" value="0"/>
+</pass>
+<pass name="Optimize4" refer="Optimize3" active="yes">
+<param name="cfChangeDir" value="25"/>
+</pass>
+</autorouter>
+<elements>
+<element name="R4" library="microbuilder" package="_0402MP" value="10K" x="12.10945" y="10.19175" smashed="yes" rot="R225"/>
+<element name="PICO-D4" library="UnexpectedMaker" package="PICO-D4-QFN48" value="ESP32-PICO-D4" x="14.1351" y="15.5448" smashed="yes" rot="R225"/>
+<element name="C1" library="microbuilder" package="_0402MP" value="0.1uF" x="14.8463" y="10.1473" smashed="yes" rot="R225"/>
+<element name="C2" library="microbuilder" package="_0402MP" value="0.1uF" x="16.44015" y="20.65655" smashed="yes" rot="R135"/>
+<element name="C5" library="microbuilder" package="_0402MP" value="1.5pF" x="19.812" y="17.78635" smashed="yes" rot="R90"/>
+<element name="R6" library="microbuilder" package="_0402MP" value="442K" x="2.25425" y="3.5433" smashed="yes"/>
+<element name="R7" library="microbuilder" package="_0402MP" value="160K" x="2.25425" y="4.40055" smashed="yes" rot="R180"/>
+<element name="LY68L6400SLIT" library="UnexpectedMaker" package="SOP8" package3d_urn="urn:adsk.eagle:package:26262/1" value="PSRAM0" x="5.1054" y="9.68375" smashed="yes">
+<attribute name="MF" value="" x="5.1054" y="9.68375" size="1.778" layer="27" display="off"/>
+<attribute name="MPN" value="BD6230F-E2" x="5.1054" y="9.68375" size="1.778" layer="27" display="off"/>
+<attribute name="OC_FARNELL" value="1716264" x="5.1054" y="9.68375" size="1.778" layer="27" display="off"/>
+<attribute name="OC_NEWARK" value="15R0529" x="5.1054" y="9.68375" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="9.5504" y="6.50875" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="C6" library="microbuilder" package="_0402MP" value="0.1uF" x="5.44195" y="20.8661" smashed="yes" rot="R270">
+<attribute name="VALUE" x="4.64815" y="21.5011" size="0.4064" layer="27" ratio="10" rot="R270"/>
+</element>
+<element name="L1" library="Nordic_nRF" library_urn="urn:adsk.eagle:library:169009" package="RESC0402_N" package3d_urn="urn:adsk.eagle:package:2593732/1" value="7.5nH" x="19.2913" y="19.2405" smashed="yes">
+<attribute name="VALUE" x="18.5913" y="17.2405" size="1.27" layer="27"/>
+</element>
+<element name="C4" library="microbuilder" package="_0402MP" value="0.75pF" x="18.72615" y="17.7927" smashed="yes" rot="R90">
+<attribute name="VALUE" x="19.51995" y="17.1577" size="0.4064" layer="27" ratio="10" rot="R90"/>
+</element>
+<element name="J2" library="47219-2001" package="MOLEX_47219-2001" value="47219-2001" x="10.63625" y="12.85875" smashed="yes" rot="MR90">
+<attribute name="AVAILABILITY" value="In Stock" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="DESCRIPTION" value=" 8 Position Card Connector Secure Digital - microSD™ Surface Mount, Right Angle Gold " x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="MF" value="Molex" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="MP" value="47219-2001" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="NAME" x="4.52898125" y="4.64898125" size="1.271509375" layer="26" rot="MR180"/>
+<attribute name="PACKAGE" value="None" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="PRICE" value="None" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="PURCHASE-URL" value="https://pricing.snapeda.com/search/part/47219-2001/?ref=eda" x="10.63625" y="12.85875" size="1.778" layer="28" rot="MR90" display="off"/>
+<attribute name="VALUE" x="4.88471875" y="22.111209375" size="1.270340625" layer="28" rot="MR180"/>
+</element>
+<element name="JP2" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="1X08-CLEANBIG" package3d_urn="urn:adsk.eagle:package:6240708/1" override_package3d_urn="urn:adsk.eagle:package:21520910/2" override_package_urn="urn:adsk.eagle:footprint:6240062/1" value="" x="13.081" y="24.511" smashed="yes">
+<attribute name="BOTTOM" value="1" x="13.081" y="24.511" size="1.778" layer="27" display="off"/>
+<attribute name="MPN" value="83-15410" x="13.081" y="24.511" size="1.778" layer="27" display="off"/>
+<attribute name="THRU-HOLE" value="1" x="13.081" y="24.511" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="2.921" y="21.336" size="1.27" layer="27"/>
+</element>
+<element name="JP1" library="adafruit" library_urn="urn:adsk.eagle:library:420" package="1X08-CLEANBIG" package3d_urn="urn:adsk.eagle:package:6240708/1" override_package3d_urn="urn:adsk.eagle:package:21520912/2" override_package_urn="urn:adsk.eagle:footprint:6240062/1" value="" x="13.081" y="1.651" smashed="yes" rot="R180">
+<attribute name="BOTTOM" value="1" x="13.081" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="MPN" value="83-15410" x="13.081" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="THRU-HOLE" value="1" x="13.081" y="1.651" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" x="23.241" y="4.826" size="1.27" layer="27" rot="R180"/>
+</element>
+<element name="C3" library="microbuilder" package="_0402MP" value="10uF" x="10.31875" y="12.22375" smashed="yes" rot="R270">
+<attribute name="NAME" x="10.79505" y="12.85875" size="0.6096" layer="25" ratio="18" rot="R270"/>
+<attribute name="VALUE" x="9.52495" y="12.85875" size="0.4064" layer="27" ratio="10" rot="R270"/>
+</element>
+<element name="E1" library="SparkFun-RF" library_urn="urn:adsk.eagle:library:531" package="TRACE_ANTENNA_2.4GHZ_15.2MM" package3d_urn="urn:adsk.eagle:package:39575/1" value="ANTENNA-GROUNDEDTRACE-15.2MM" x="20.955" y="18.25625" smashed="yes" rot="R270">
+<attribute name="NAME" x="22.225" y="18.25625" size="0.6096" layer="25" font="vector" ratio="20" rot="R270" align="bottom-center"/>
+<attribute name="VALUE" x="21.971" y="18.25625" size="0.6096" layer="27" font="vector" ratio="20" rot="R270" align="top-center"/>
+</element>
+</elements>
+<signals>
+<signal name="GND">
+<contactref element="PICO-D4" pad="EXP"/>
+<contactref element="C1" pad="2"/>
+<contactref element="C2" pad="2"/>
+<contactref element="R7" pad="2"/>
+<polygon width="0.254" layer="16">
+<vertex x="-0.3175" y="26.51125"/>
+<vertex x="-0.3175" y="-0.47625"/>
+<vertex x="20.955" y="-0.47625"/>
+<vertex x="20.955" y="26.51125"/>
+</polygon>
+<polygon width="0.1524" layer="1" isolate="0.3048">
+<vertex x="-0.36195" y="26.3398"/>
+<vertex x="-0.36195" y="-0.48895"/>
+<vertex x="20.89785" y="-0.48895"/>
+<vertex x="20.89785" y="26.3398"/>
+</polygon>
+<contactref element="LY68L6400SLIT" pad="4"/>
+<contactref element="C6" pad="2"/>
+<contactref element="C4" pad="2"/>
+<contactref element="L1" pad="1"/>
+<contactref element="JP1" pad="7"/>
+<contactref element="J2" pad="G4"/>
+<contactref element="J2" pad="G3"/>
+<contactref element="J2" pad="G2"/>
+<contactref element="J2" pad="G1"/>
+<contactref element="C3" pad="2"/>
+<contactref element="J2" pad="6"/>
+<contactref element="E1" pad="GND"/>
+<wire x1="14.12875" y1="6.0325" x2="7.62" y2="6.0325" width="0.127" layer="16"/>
+<wire x1="7.62" y1="6.0325" x2="6.0325" y2="6.0325" width="0.127" layer="16"/>
+<wire x1="6.0325" y1="6.0325" x2="5.93625" y2="5.98375" width="0.127" layer="16"/>
+<wire x1="14.12875" y1="6.0325" x2="14.23625" y2="5.98375" width="0.127" layer="16"/>
+<wire x1="9.04875" y1="10.63625" x2="8.5725" y2="10.63625" width="0.127" layer="16"/>
+<wire x1="9.68375" y1="11.27125" x2="9.04875" y2="10.63625" width="0.127" layer="16"/>
+<wire x1="9.68375" y1="11.43" x2="9.68375" y2="11.27125" width="0.127" layer="16"/>
+<wire x1="9.8425" y1="11.58875" x2="9.68375" y2="11.43" width="0.127" layer="1"/>
+<wire x1="10.31875" y1="11.58875" x2="9.8425" y2="11.58875" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="10.63625" x2="8.53625" y2="10.55875" width="0.127" layer="16"/>
+<wire x1="10.31875" y1="11.58875" x2="10.31875" y2="11.71575" width="0.127" layer="1"/>
+<wire x1="18.7325" y1="18.415" x2="18.72615" y2="18.3007" width="0.127" layer="1"/>
+<wire x1="6.0325" y1="20.955" x2="6.0325" y2="19.84375" width="0.127" layer="16"/>
+<wire x1="5.55625" y1="20.47875" x2="6.0325" y2="20.955" width="0.127" layer="1"/>
+<wire x1="6.0325" y1="19.84375" x2="5.93625" y2="19.73375" width="0.127" layer="16"/>
+<wire x1="5.55625" y1="20.47875" x2="5.44195" y2="20.3581" width="0.127" layer="1"/>
+<wire x1="15.39875" y1="20.955" x2="14.2875" y2="19.84375" width="0.127" layer="16"/>
+<wire x1="16.03375" y1="20.955" x2="15.39875" y2="20.955" width="0.127" layer="1"/>
+<wire x1="14.2875" y1="19.84375" x2="14.23625" y2="19.73375" width="0.127" layer="16"/>
+<wire x1="16.03375" y1="20.955" x2="16.0809375" y2="21.015759375" width="0.127" layer="1"/>
+<wire x1="7.62" y1="6.985" x2="7.62" y2="6.0325" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="6.985" x2="7.62" y2="6.985" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="6.985" x2="7.067825" y2="7.041225" width="0.127" layer="1"/>
+<via x="9.68375" y="11.43" extent="1-16" drill="0.1778"/>
+<via x="6.0325" y="20.955" extent="1-16" drill="0.1778"/>
+<via x="15.39875" y="20.955" extent="1-16" drill="0.1778"/>
+<via x="7.62" y="6.0325" extent="1-16" drill="0.1778"/>
+<via x="14.12875" y="15.71625" extent="1-16" drill="0.35"/>
+<via x="19.20875" y="21.59" extent="1-16" drill="0.35"/>
+<wire x1="7.067825" y1="7.041225" x2="7.0104" y2="7.08375" width="0.127" layer="1"/>
+<wire x1="14.4870875" y1="9.7880875" x2="14.4870875" y2="8.4545875" width="0.1524" layer="1"/>
+<wire x1="14.4870875" y1="8.4545875" x2="14.2875" y2="8.255" width="0.1524" layer="1"/>
+<via x="14.2875" y="8.255" extent="1-16" drill="0.35"/>
+<wire x1="14.2875" y1="8.255" x2="14.2875" y2="6.035" width="0.1524" layer="16"/>
+<wire x1="14.2875" y1="6.035" x2="14.23625" y2="5.98375" width="0.1524" layer="16"/>
+<wire x1="8.53625" y1="10.55875" x2="9.03305" y2="10.06195" width="0.1524" layer="16"/>
+<wire x1="9.03305" y1="10.06195" x2="9.37041875" y2="10.06195" width="0.1524" layer="16"/>
+<wire x1="9.37041875" y1="10.06195" x2="10.00125" y2="9.43111875" width="0.1524" layer="16"/>
+<wire x1="10.00125" y1="9.43111875" x2="10.00125" y2="8.89" width="0.1524" layer="16"/>
+<via x="10.00125" y="8.89" extent="1-16" drill="0.35"/>
+<wire x1="10.00125" y1="8.89" x2="8.152475" y2="7.041225" width="0.1524" layer="1"/>
+<wire x1="8.152475" y1="7.041225" x2="7.067825" y2="7.041225" width="0.1524" layer="1"/>
+</signal>
+<signal name="3.3V">
+<contactref element="R4" pad="2"/>
+<contactref element="PICO-D4" pad="46"/>
+<contactref element="PICO-D4" pad="43"/>
+<contactref element="PICO-D4" pad="37"/>
+<contactref element="PICO-D4" pad="19"/>
+<contactref element="PICO-D4" pad="3"/>
+<contactref element="PICO-D4" pad="4"/>
+<contactref element="C1" pad="1"/>
+<contactref element="PICO-D4" pad="1"/>
+<contactref element="JP2" pad="1"/>
+<contactref element="C3" pad="1"/>
+<contactref element="J2" pad="4"/>
+<wire x1="12.065" y1="10.00125" x2="11.90625" y2="9.8425" width="0.127" layer="1"/>
+<wire x1="13.97" y1="10.00125" x2="12.065" y2="10.00125" width="0.127" layer="1"/>
+<wire x1="14.44625" y1="10.4775" x2="13.97" y2="10.00125" width="0.127" layer="1"/>
+<wire x1="15.08125" y1="10.4775" x2="14.605" y2="10.4775" width="0.127" layer="1"/>
+<wire x1="14.605" y1="10.4775" x2="14.44625" y2="10.4775" width="0.127" layer="1"/>
+<wire x1="11.90625" y1="9.8425" x2="11.7502375" y2="9.8325375" width="0.127" layer="1"/>
+<wire x1="15.08125" y1="10.4775" x2="15.205509375" y2="10.506509375" width="0.127" layer="1"/>
+<wire x1="14.605" y1="10.4775" x2="14.605" y2="11.1125" width="0.127" layer="1"/>
+<wire x1="14.605" y1="11.1125" x2="14.54338125" y2="11.247428125" width="0.127" layer="1"/>
+<wire x1="16.8275" y1="13.17625" x2="16.66875" y2="13.335" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="13.17625" x2="16.8275" y2="13.17625" width="0.127" layer="1"/>
+<wire x1="17.93875" y1="13.81125" x2="17.30375" y2="13.17625" width="0.127" layer="1"/>
+<wire x1="17.93875" y1="14.2875" x2="17.93875" y2="13.81125" width="0.127" layer="1"/>
+<wire x1="17.78" y1="14.2875" x2="17.93875" y2="14.2875" width="0.127" layer="1"/>
+<wire x1="16.66875" y1="13.335" x2="16.664703125" y2="13.368746875" width="0.127" layer="1"/>
+<wire x1="17.78" y1="14.2875" x2="17.7253625" y2="14.429409375" width="0.127" layer="1"/>
+<wire x1="17.78" y1="16.66875" x2="17.62125" y2="16.8275" width="0.127" layer="1"/>
+<wire x1="17.62125" y1="16.8275" x2="17.4625" y2="16.98625" width="0.127" layer="1"/>
+<wire x1="17.4625" y1="16.98625" x2="17.371809375" y2="17.013740625" width="0.127" layer="1"/>
+<wire x1="17.78" y1="16.66875" x2="17.7253625" y2="16.6601875" width="0.127" layer="1"/>
+<wire x1="11.90625" y1="17.4625" x2="11.7475" y2="17.62125" width="0.127" layer="1"/>
+<wire x1="12.54125" y1="17.4625" x2="11.90625" y2="17.4625" width="0.127" layer="1"/>
+<wire x1="14.12875" y1="19.05" x2="12.54125" y2="17.4625" width="0.127" layer="1"/>
+<wire x1="14.44625" y1="19.05" x2="14.12875" y2="19.05" width="0.127" layer="1"/>
+<wire x1="16.66875" y1="16.8275" x2="14.44625" y2="19.05" width="0.127" layer="1"/>
+<wire x1="17.62125" y1="16.8275" x2="16.66875" y2="16.8275" width="0.127" layer="1"/>
+<wire x1="11.7475" y1="17.62125" x2="11.60549375" y2="17.72085" width="0.127" layer="1"/>
+<wire x1="18.25625" y1="15.71625" x2="18.415" y2="15.875" width="0.127" layer="1"/>
+<wire x1="17.78" y1="15.71625" x2="17.93875" y2="15.71625" width="0.127" layer="1"/>
+<wire x1="17.93875" y1="15.71625" x2="18.25625" y2="15.71625" width="0.127" layer="1"/>
+<wire x1="16.66875" y1="16.8275" x2="17.78" y2="15.71625" width="0.127" layer="1"/>
+<wire x1="18.415" y1="15.875" x2="18.43246875" y2="15.95308125" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="14.76375" x2="17.62125" y2="14.44625" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="15.08125" x2="17.30375" y2="14.76375" width="0.127" layer="1"/>
+<wire x1="17.93875" y1="15.71625" x2="17.30375" y2="15.08125" width="0.127" layer="1"/>
+<wire x1="17.62125" y1="14.44625" x2="17.7253625" y2="14.429409375" width="0.127" layer="1"/>
+<wire x1="14.12875" y1="11.58875" x2="14.44625" y2="11.27125" width="0.127" layer="1"/>
+<wire x1="14.12875" y1="12.065" x2="14.12875" y2="11.58875" width="0.127" layer="1"/>
+<wire x1="14.605" y1="12.065" x2="14.12875" y2="12.065" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="14.76375" x2="14.605" y2="12.065" width="0.127" layer="1"/>
+<wire x1="14.44625" y1="11.27125" x2="14.54338125" y2="11.247428125" width="0.127" layer="1"/>
+<wire x1="9.68375" y1="12.7" x2="10.31875" y2="12.7" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="12.7" x2="9.68375" y2="12.7" width="0.127" layer="16"/>
+<wire x1="10.31875" y1="12.7" x2="10.31875" y2="12.73175" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="12.7" x2="8.53625" y2="12.75875" width="0.127" layer="16"/>
+<wire x1="10.31875" y1="12.7" x2="9.68375" y2="12.7" width="0.127" layer="16"/>
+<wire x1="10.95375" y1="13.335" x2="10.31875" y2="12.7" width="0.127" layer="16"/>
+<wire x1="10.95375" y1="23.8125" x2="10.95375" y2="18.25625" width="0.127" layer="16"/>
+<wire x1="10.95375" y1="18.25625" x2="10.95375" y2="13.335" width="0.127" layer="16"/>
+<wire x1="10.4775" y1="24.28875" x2="10.95375" y2="23.8125" width="0.127" layer="16"/>
+<wire x1="10.4775" y1="24.92375" x2="10.4775" y2="24.28875" width="0.127" layer="16"/>
+<wire x1="9.68375" y1="25.7175" x2="10.4775" y2="24.92375" width="0.127" layer="16"/>
+<wire x1="5.3975" y1="25.7175" x2="9.68375" y2="25.7175" width="0.127" layer="16"/>
+<wire x1="4.191" y1="24.511" x2="5.3975" y2="25.7175" width="0.127" layer="16"/>
+<wire x1="11.1125" y1="18.25625" x2="11.58875" y2="17.78" width="0.127" layer="1"/>
+<wire x1="10.95375" y1="18.25625" x2="11.1125" y2="18.25625" width="0.127" layer="1"/>
+<wire x1="11.58875" y1="17.78" x2="11.60549375" y2="17.72085" width="0.127" layer="1"/>
+<via x="9.68375" y="12.7" extent="1-16" drill="0.1778"/>
+<via x="10.95375" y="18.25625" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="RESET">
+<contactref element="R4" pad="1"/>
+<contactref element="C2" pad="1"/>
+<contactref element="PICO-D4" pad="9"/>
+<contactref element="JP2" pad="8"/>
+<wire x1="16.66875" y1="19.05" x2="16.66875" y2="20.16125" width="0.127" layer="1"/>
+<wire x1="15.875" y1="19.05" x2="16.66875" y2="19.05" width="0.127" layer="1"/>
+<wire x1="15.71625" y1="18.89125" x2="15.875" y2="19.05" width="0.127" layer="1"/>
+<wire x1="16.66875" y1="20.16125" x2="16.799359375" y2="20.2973375" width="0.127" layer="1"/>
+<wire x1="15.71625" y1="18.89125" x2="15.604040625" y2="18.781509375" width="0.127" layer="1"/>
+<wire x1="13.17625" y1="10.63625" x2="12.54125" y2="10.63625" width="0.127" layer="1"/>
+<wire x1="21.9075" y1="19.3675" x2="19.20875" y2="16.66875" width="0.127" layer="16"/>
+<wire x1="19.20875" y1="16.66875" x2="13.17625" y2="10.63625" width="0.127" layer="16"/>
+<wire x1="21.9075" y1="24.4475" x2="21.9075" y2="19.3675" width="0.127" layer="16"/>
+<wire x1="12.54125" y1="10.63625" x2="12.468659375" y2="10.550959375" width="0.127" layer="1"/>
+<wire x1="21.9075" y1="24.4475" x2="21.971" y2="24.511" width="0.127" layer="16"/>
+<wire x1="17.145" y1="18.57375" x2="16.66875" y2="19.05" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="18.57375" x2="17.145" y2="18.57375" width="0.127" layer="1"/>
+<wire x1="19.20875" y1="16.66875" x2="17.30375" y2="18.57375" width="0.127" layer="16"/>
+<via x="13.17625" y="10.63625" extent="1-16" drill="0.1778"/>
+<via x="17.30375" y="18.57375" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO0">
+<contactref element="PICO-D4" pad="23"/>
+<contactref element="JP1" pad="5"/>
+<wire x1="10.00125" y1="16.51" x2="10.16" y2="16.35125" width="0.127" layer="1"/>
+<wire x1="5.3975" y1="16.51" x2="10.00125" y2="16.51" width="0.127" layer="1"/>
+<wire x1="3.01625" y1="14.12875" x2="5.3975" y2="16.51" width="0.127" layer="16"/>
+<wire x1="3.01625" y1="6.19125" x2="3.01625" y2="14.12875" width="0.127" layer="16"/>
+<wire x1="6.35" y1="2.8575" x2="3.01625" y2="6.19125" width="0.127" layer="16"/>
+<wire x1="10.63625" y1="2.8575" x2="6.35" y2="2.8575" width="0.127" layer="1"/>
+<wire x1="11.7475" y1="1.74625" x2="10.63625" y2="2.8575" width="0.127" layer="1"/>
+<wire x1="10.16" y1="16.35125" x2="10.19128125" y2="16.306634375" width="0.127" layer="1"/>
+<wire x1="11.7475" y1="1.74625" x2="11.811" y2="1.651" width="0.127" layer="1"/>
+<via x="5.3975" y="16.51" extent="1-16" drill="0.1778"/>
+<via x="6.35" y="2.8575" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="TXD">
+<contactref element="PICO-D4" pad="41"/>
+<contactref element="JP1" pad="1"/>
+<wire x1="21.11375" y1="7.46125" x2="16.03375" y2="12.54125" width="0.127" layer="1"/>
+<wire x1="21.11375" y1="1.74625" x2="21.11375" y2="7.46125" width="0.127" layer="1"/>
+<wire x1="21.9075" y1="1.74625" x2="21.11375" y2="1.74625" width="0.127" layer="1"/>
+<wire x1="16.03375" y1="12.54125" x2="15.957596875" y2="12.661640625" width="0.127" layer="1"/>
+<wire x1="21.9075" y1="1.74625" x2="21.971" y2="1.651" width="0.127" layer="1"/>
+</signal>
+<signal name="GND1">
+</signal>
+<signal name="DATA_OUT">
+</signal>
+<signal name="RXD">
+<contactref element="PICO-D4" pad="40"/>
+<contactref element="JP1" pad="2"/>
+<wire x1="19.3675" y1="8.5725" x2="15.71625" y2="12.22375" width="0.127" layer="1"/>
+<wire x1="19.3675" y1="1.74625" x2="19.3675" y2="8.5725" width="0.127" layer="1"/>
+<wire x1="15.71625" y1="12.22375" x2="15.604040625" y2="12.3080875" width="0.127" layer="1"/>
+<wire x1="19.3675" y1="1.74625" x2="19.431" y2="1.651" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO35">
+<contactref element="PICO-D4" pad="11"/>
+<contactref element="R6" pad="2"/>
+<contactref element="R7" pad="1"/>
+<wire x1="15.24" y1="19.84375" x2="14.9225" y2="19.52625" width="0.127" layer="1"/>
+<wire x1="15.24" y1="20.47875" x2="15.24" y2="19.84375" width="0.127" layer="1"/>
+<wire x1="8.255" y1="20.47875" x2="15.24" y2="20.47875" width="0.127" layer="1"/>
+<wire x1="3.81" y1="16.03375" x2="8.255" y2="20.47875" width="0.127" layer="1"/>
+<wire x1="2.2225" y1="14.44625" x2="3.81" y2="16.03375" width="0.127" layer="16"/>
+<wire x1="14.9225" y1="19.52625" x2="14.896934375" y2="19.488615625" width="0.127" layer="1"/>
+<via x="3.81" y="16.03375" extent="1-16" drill="0.1778"/>
+<via x="2.2225" y="14.44625" extent="1-16" drill="0.1778"/>
+<wire x1="2.69875" y1="4.28625" x2="2.69875" y2="3.65125" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="3.65125" x2="2.76225" y2="3.5433" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="4.28625" x2="2.76225" y2="4.40055" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="10.795" x2="2.69875" y2="4.445" width="0.127" layer="1"/>
+<wire x1="2.2225" y1="11.27125" x2="2.69875" y2="10.795" width="0.127" layer="1"/>
+<wire x1="2.2225" y1="14.44625" x2="2.2225" y2="11.27125" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="4.445" x2="2.76225" y2="4.40055" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO32">
+<contactref element="PICO-D4" pad="12"/>
+</signal>
+<signal name="GPIO33">
+<contactref element="PICO-D4" pad="13"/>
+</signal>
+<signal name="GPIO25">
+<contactref element="PICO-D4" pad="14"/>
+</signal>
+<signal name="GPIO26">
+<contactref element="PICO-D4" pad="15"/>
+</signal>
+<signal name="GPIO27">
+<contactref element="PICO-D4" pad="16"/>
+</signal>
+<signal name="GPIO12">
+<contactref element="PICO-D4" pad="18"/>
+<contactref element="JP1" pad="3"/>
+<wire x1="11.27125" y1="18.7325" x2="11.90625" y2="18.0975" width="0.127" layer="1"/>
+<wire x1="11.27125" y1="19.3675" x2="11.27125" y2="18.7325" width="0.127" layer="1"/>
+<wire x1="12.065" y1="19.3675" x2="11.27125" y2="19.3675" width="0.127" layer="1"/>
+<wire x1="12.065" y1="19.20875" x2="12.065" y2="19.3675" width="0.127" layer="16"/>
+<wire x1="12.22375" y1="19.05" x2="12.065" y2="19.20875" width="0.127" layer="16"/>
+<wire x1="12.22375" y1="9.68375" x2="12.22375" y2="19.05" width="0.127" layer="16"/>
+<wire x1="11.58875" y1="9.04875" x2="12.22375" y2="9.68375" width="0.127" layer="16"/>
+<wire x1="16.8275" y1="3.81" x2="11.58875" y2="9.04875" width="0.127" layer="1"/>
+<wire x1="16.8275" y1="1.74625" x2="16.8275" y2="3.81" width="0.127" layer="1"/>
+<wire x1="11.90625" y1="18.0975" x2="11.959046875" y2="18.074403125" width="0.127" layer="1"/>
+<wire x1="16.8275" y1="1.74625" x2="16.891" y2="1.651" width="0.127" layer="1"/>
+<via x="12.065" y="19.3675" extent="1-16" drill="0.1778"/>
+<via x="11.58875" y="9.04875" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO4">
+<contactref element="PICO-D4" pad="24"/>
+<contactref element="JP1" pad="4"/>
+<wire x1="8.73125" y1="15.08125" x2="9.68375" y2="16.03375" width="0.127" layer="1"/>
+<wire x1="4.60375" y1="15.08125" x2="8.73125" y2="15.08125" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="13.81125" x2="4.60375" y2="15.08125" width="0.127" layer="16"/>
+<wire x1="3.33375" y1="6.50875" x2="3.33375" y2="13.81125" width="0.127" layer="16"/>
+<wire x1="6.985" y1="2.8575" x2="3.33375" y2="6.50875" width="0.127" layer="16"/>
+<wire x1="7.14375" y1="2.8575" x2="6.985" y2="2.8575" width="0.127" layer="16"/>
+<wire x1="8.09625" y1="1.905" x2="7.14375" y2="2.8575" width="0.127" layer="16"/>
+<wire x1="8.09625" y1="1.27" x2="8.09625" y2="1.905" width="0.127" layer="16"/>
+<wire x1="8.89" y1="0.47625" x2="8.09625" y2="1.27" width="0.127" layer="16"/>
+<wire x1="13.17625" y1="0.47625" x2="8.89" y2="0.47625" width="0.127" layer="16"/>
+<wire x1="14.351" y1="1.651" x2="13.17625" y2="0.47625" width="0.127" layer="16"/>
+<wire x1="9.68375" y1="16.03375" x2="9.837728125" y2="15.95308125" width="0.127" layer="1"/>
+<via x="4.60375" y="15.08125" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO16">
+<contactref element="PICO-D4" pad="25"/>
+</signal>
+<signal name="GPIO17">
+<contactref element="PICO-D4" pad="27"/>
+<contactref element="LY68L6400SLIT" pad="2"/>
+<wire x1="10.00125" y1="13.81125" x2="10.4775" y2="14.2875" width="0.127" layer="1"/>
+<wire x1="6.50875" y1="13.81125" x2="10.00125" y2="13.81125" width="0.127" layer="1"/>
+<wire x1="6.50875" y1="9.36625" x2="6.50875" y2="13.81125" width="0.127" layer="16"/>
+<wire x1="4.60375" y1="7.46125" x2="6.50875" y2="9.36625" width="0.127" layer="1"/>
+<wire x1="4.60375" y1="7.14375" x2="4.60375" y2="7.46125" width="0.127" layer="1"/>
+<wire x1="10.4775" y1="14.2875" x2="10.544834375" y2="14.429409375" width="0.127" layer="1"/>
+<wire x1="4.60375" y1="7.14375" x2="4.4704" y2="7.08375" width="0.127" layer="1"/>
+<via x="6.50875" y="13.81125" extent="1-16" drill="0.1778"/>
+<via x="6.50875" y="9.36625" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="CLK">
+<contactref element="PICO-D4" pad="31"/>
+<contactref element="LY68L6400SLIT" pad="6"/>
+<wire x1="11.27125" y1="12.22375" x2="11.90625" y2="12.85875" width="0.127" layer="1"/>
+<wire x1="10.63625" y1="11.58875" x2="11.27125" y2="12.22375" width="0.127" layer="16"/>
+<wire x1="10.63625" y1="10.4775" x2="10.63625" y2="11.58875" width="0.127" layer="16"/>
+<wire x1="10.4775" y1="10.63625" x2="10.63625" y2="10.4775" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="10.63625" x2="10.4775" y2="10.63625" width="0.127" layer="1"/>
+<wire x1="5.87375" y1="11.90625" x2="7.14375" y2="10.63625" width="0.127" layer="1"/>
+<wire x1="5.87375" y1="12.22375" x2="5.87375" y2="11.90625" width="0.127" layer="1"/>
+<wire x1="11.90625" y1="12.85875" x2="11.959046875" y2="13.01519375" width="0.127" layer="1"/>
+<wire x1="5.87375" y1="12.22375" x2="5.7404" y2="12.28375" width="0.127" layer="1"/>
+<via x="11.27125" y="12.22375" extent="1-16" drill="0.1778"/>
+<via x="10.63625" y="10.4775" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="SENS_VP">
+<contactref element="PICO-D4" pad="5"/>
+<contactref element="JP2" pad="7"/>
+<wire x1="17.78" y1="18.0975" x2="17.145" y2="17.4625" width="0.127" layer="1"/>
+<wire x1="17.78" y1="23.8125" x2="17.78" y2="18.0975" width="0.127" layer="1"/>
+<wire x1="18.7325" y1="23.8125" x2="17.78" y2="23.8125" width="0.127" layer="1"/>
+<wire x1="19.431" y1="24.511" x2="18.7325" y2="23.8125" width="0.127" layer="1"/>
+<wire x1="17.145" y1="17.4625" x2="17.01825625" y2="17.367296875" width="0.127" layer="1"/>
+</signal>
+<signal name="SENS_CAPP">
+<contactref element="PICO-D4" pad="6"/>
+</signal>
+<signal name="SENS_CAPN">
+<contactref element="PICO-D4" pad="7"/>
+</signal>
+<signal name="SENS_VN">
+<contactref element="PICO-D4" pad="8"/>
+</signal>
+<signal name="STAT">
+<contactref element="PICO-D4" pad="10"/>
+</signal>
+<signal name="ANT">
+<contactref element="C5" pad="2"/>
+<contactref element="L1" pad="2"/>
+<contactref element="E1" pad="ANT"/>
+<wire x1="19.84375" y1="19.20875" x2="19.84375" y2="18.415" width="0.127" layer="1"/>
+<wire x1="19.84375" y1="18.415" x2="19.812" y2="18.29435" width="0.127" layer="1"/>
+<wire x1="19.84375" y1="19.20875" x2="19.8413" y2="19.2405" width="0.127" layer="1"/>
+<wire x1="20.705" y1="18.25625" x2="19.8501" y2="18.25625" width="0.4064" layer="1"/>
+<wire x1="19.8501" y1="18.25625" x2="19.812" y2="18.29435" width="0.4064" layer="1"/>
+</signal>
+<signal name="GPIO9">
+<contactref element="PICO-D4" pad="28"/>
+</signal>
+<signal name="GPIO10">
+<contactref element="PICO-D4" pad="29"/>
+<contactref element="LY68L6400SLIT" pad="1"/>
+<wire x1="10.95375" y1="13.49375" x2="11.1125" y2="13.6525" width="0.127" layer="1"/>
+<wire x1="10.4775" y1="13.49375" x2="10.95375" y2="13.49375" width="0.127" layer="1"/>
+<wire x1="10.4775" y1="16.98625" x2="10.4775" y2="13.49375" width="0.127" layer="16"/>
+<wire x1="10.63625" y1="17.145" x2="10.4775" y2="16.98625" width="0.127" layer="16"/>
+<wire x1="10.63625" y1="17.4625" x2="10.63625" y2="17.145" width="0.127" layer="16"/>
+<wire x1="10.31875" y1="17.78" x2="10.63625" y2="17.4625" width="0.127" layer="16"/>
+<wire x1="8.255" y1="17.78" x2="10.31875" y2="17.78" width="0.127" layer="16"/>
+<wire x1="6.6675" y1="16.1925" x2="8.255" y2="17.78" width="0.127" layer="16"/>
+<wire x1="6.6675" y1="14.605" x2="6.6675" y2="16.1925" width="0.127" layer="16"/>
+<wire x1="4.1275" y1="12.065" x2="6.6675" y2="14.605" width="0.127" layer="16"/>
+<wire x1="4.1275" y1="8.255" x2="4.1275" y2="12.065" width="0.127" layer="16"/>
+<wire x1="3.33375" y1="7.46125" x2="4.1275" y2="8.255" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="7.14375" x2="3.33375" y2="7.46125" width="0.127" layer="1"/>
+<wire x1="11.1125" y1="13.6525" x2="11.251940625" y2="13.7223" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="7.14375" x2="3.2004" y2="7.08375" width="0.127" layer="1"/>
+<via x="10.4775" y="13.49375" extent="1-16" drill="0.1778"/>
+<via x="4.1275" y="8.255" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO7">
+<contactref element="PICO-D4" pad="32"/>
+<contactref element="LY68L6400SLIT" pad="3"/>
+<wire x1="11.1125" y1="11.43" x2="12.22375" y2="12.54125" width="0.127" layer="1"/>
+<wire x1="11.1125" y1="8.73125" x2="11.1125" y2="11.43" width="0.127" layer="16"/>
+<wire x1="7.9375" y1="5.55625" x2="11.1125" y2="8.73125" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="5.55625" x2="7.9375" y2="5.55625" width="0.127" layer="1"/>
+<wire x1="5.715" y1="6.985" x2="7.14375" y2="5.55625" width="0.127" layer="1"/>
+<wire x1="12.22375" y1="12.54125" x2="12.3126" y2="12.661640625" width="0.127" layer="1"/>
+<wire x1="5.715" y1="6.985" x2="5.7404" y2="7.08375" width="0.127" layer="1"/>
+<via x="11.1125" y="11.43" extent="1-16" drill="0.1778"/>
+<via x="11.1125" y="8.73125" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO11">
+<contactref element="LY68L6400SLIT" pad="7"/>
+<contactref element="PICO-D4" pad="30"/>
+<wire x1="10.795" y1="12.54125" x2="11.58875" y2="13.335" width="0.127" layer="1"/>
+<wire x1="10.795" y1="12.22375" x2="10.795" y2="12.54125" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="12.22375" x2="10.795" y2="12.22375" width="0.127" layer="1"/>
+<wire x1="7.46125" y1="13.335" x2="8.5725" y2="12.22375" width="0.127" layer="1"/>
+<wire x1="5.3975" y1="13.335" x2="7.46125" y2="13.335" width="0.127" layer="1"/>
+<wire x1="4.445" y1="12.3825" x2="5.3975" y2="13.335" width="0.127" layer="1"/>
+<wire x1="11.58875" y1="13.335" x2="11.60549375" y2="13.368746875" width="0.127" layer="1"/>
+<wire x1="4.445" y1="12.3825" x2="4.4704" y2="12.28375" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO8">
+<contactref element="PICO-D4" pad="33"/>
+<contactref element="LY68L6400SLIT" pad="5"/>
+<wire x1="11.27125" y1="10.95375" x2="12.54125" y2="12.22375" width="0.127" layer="1"/>
+<wire x1="8.41375" y1="10.95375" x2="11.27125" y2="10.95375" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="12.22375" x2="8.41375" y2="10.95375" width="0.127" layer="1"/>
+<wire x1="12.54125" y1="12.22375" x2="12.66615625" y2="12.3080875" width="0.127" layer="1"/>
+<wire x1="7.14375" y1="12.22375" x2="7.0104" y2="12.28375" width="0.127" layer="1"/>
+</signal>
+<signal name="VDDSDIO">
+<contactref element="PICO-D4" pad="26"/>
+<contactref element="LY68L6400SLIT" pad="8"/>
+<contactref element="C6" pad="1"/>
+<wire x1="3.33375" y1="19.20875" x2="5.3975" y2="21.2725" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="12.3825" x2="3.33375" y2="14.605" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="14.605" x2="3.33375" y2="19.20875" width="0.127" layer="1"/>
+<wire x1="5.3975" y1="21.2725" x2="5.44195" y2="21.3741" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="12.3825" x2="3.2004" y2="12.28375" width="0.127" layer="1"/>
+<wire x1="10.00125" y1="14.605" x2="10.16" y2="14.76375" width="0.127" layer="1"/>
+<wire x1="3.33375" y1="14.605" x2="10.00125" y2="14.605" width="0.127" layer="1"/>
+<wire x1="10.16" y1="14.76375" x2="10.19128125" y2="14.7829625" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO22/DC">
+<contactref element="JP1" pad="6"/>
+<contactref element="PICO-D4" pad="39"/>
+<wire x1="15.875" y1="11.43" x2="15.39875" y2="11.90625" width="0.127" layer="1"/>
+<wire x1="15.875" y1="5.55625" x2="15.875" y2="11.43" width="0.127" layer="16"/>
+<wire x1="13.17625" y1="2.8575" x2="15.875" y2="5.55625" width="0.127" layer="16"/>
+<wire x1="10.4775" y1="2.8575" x2="13.17625" y2="2.8575" width="0.127" layer="16"/>
+<wire x1="9.271" y1="1.651" x2="10.4775" y2="2.8575" width="0.127" layer="16"/>
+<wire x1="15.39875" y1="11.90625" x2="15.2504875" y2="11.954534375" width="0.127" layer="1"/>
+<via x="15.875" y="11.43" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO21/RESET">
+<contactref element="JP2" pad="2"/>
+<contactref element="PICO-D4" pad="42"/>
+<wire x1="16.51" y1="12.7" x2="16.35125" y2="12.85875" width="0.127" layer="1"/>
+<wire x1="17.30375" y1="12.7" x2="16.51" y2="12.7" width="0.127" layer="1"/>
+<wire x1="20.32" y1="15.71625" x2="17.30375" y2="12.7" width="0.127" layer="1"/>
+<wire x1="20.32" y1="17.78" x2="20.32" y2="15.71625" width="0.127" layer="1"/>
+<wire x1="18.415" y1="17.78" x2="20.32" y2="17.78" width="0.127" layer="1"/>
+<wire x1="18.0975" y1="18.0975" x2="18.415" y2="17.78" width="0.127" layer="1"/>
+<wire x1="18.0975" y1="23.33625" x2="18.0975" y2="18.0975" width="0.127" layer="1"/>
+<wire x1="19.84375" y1="23.33625" x2="18.0975" y2="23.33625" width="0.127" layer="1"/>
+<wire x1="20.6375" y1="24.13" x2="19.84375" y2="23.33625" width="0.127" layer="1"/>
+<wire x1="20.6375" y1="25.7175" x2="20.6375" y2="24.13" width="0.127" layer="1"/>
+<wire x1="7.9375" y1="25.7175" x2="20.6375" y2="25.7175" width="0.127" layer="1"/>
+<wire x1="6.731" y1="24.511" x2="7.9375" y2="25.7175" width="0.127" layer="1"/>
+<wire x1="16.35125" y1="12.85875" x2="16.31115" y2="13.01519375" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO18/SCK">
+<contactref element="JP2" pad="5"/>
+<contactref element="PICO-D4" pad="35"/>
+<wire x1="12.85875" y1="11.1125" x2="13.335" y2="11.58875" width="0.127" layer="1"/>
+<wire x1="12.85875" y1="23.01875" x2="12.85875" y2="11.1125" width="0.127" layer="16"/>
+<wire x1="14.351" y1="24.511" x2="12.85875" y2="23.01875" width="0.127" layer="16"/>
+<wire x1="13.335" y1="11.58875" x2="13.3732625" y2="11.60098125" width="0.127" layer="1"/>
+<via x="12.85875" y="11.1125" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO5/CS">
+<contactref element="JP2" pad="6"/>
+<contactref element="PICO-D4" pad="34"/>
+<wire x1="12.22375" y1="11.1125" x2="13.0175" y2="11.90625" width="0.127" layer="1"/>
+<wire x1="12.22375" y1="10.95375" x2="12.22375" y2="11.1125" width="0.127" layer="1"/>
+<wire x1="11.27125" y1="10.00125" x2="12.22375" y2="10.95375" width="0.127" layer="1"/>
+<wire x1="3.96875" y1="10.00125" x2="11.27125" y2="10.00125" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="11.27125" x2="3.96875" y2="10.00125" width="0.127" layer="1"/>
+<wire x1="2.69875" y1="23.33625" x2="2.69875" y2="11.27125" width="0.127" layer="1"/>
+<wire x1="15.71625" y1="23.33625" x2="2.69875" y2="23.33625" width="0.127" layer="1"/>
+<wire x1="16.891" y1="24.511" x2="15.71625" y2="23.33625" width="0.127" layer="1"/>
+<wire x1="13.0175" y1="11.90625" x2="13.019709375" y2="11.954534375" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO23/MOSI">
+<contactref element="JP2" pad="3"/>
+<contactref element="PICO-D4" pad="36"/>
+<wire x1="13.6525" y1="10.63625" x2="13.6525" y2="11.1125" width="0.127" layer="1"/>
+<wire x1="13.81125" y1="10.63625" x2="13.6525" y2="10.63625" width="0.127" layer="1"/>
+<wire x1="10.795" y1="7.62" x2="13.81125" y2="10.63625" width="0.127" layer="16"/>
+<wire x1="4.1275" y1="7.62" x2="10.795" y2="7.62" width="0.127" layer="16"/>
+<wire x1="3.65125" y1="8.09625" x2="4.1275" y2="7.62" width="0.127" layer="16"/>
+<wire x1="3.65125" y1="13.49375" x2="3.65125" y2="8.09625" width="0.127" layer="16"/>
+<wire x1="6.35" y1="16.1925" x2="3.65125" y2="13.49375" width="0.127" layer="16"/>
+<wire x1="6.35" y1="18.0975" x2="6.35" y2="16.1925" width="0.127" layer="16"/>
+<wire x1="9.2075" y1="20.955" x2="6.35" y2="18.0975" width="0.127" layer="16"/>
+<wire x1="9.2075" y1="24.4475" x2="9.2075" y2="20.955" width="0.127" layer="16"/>
+<wire x1="13.6525" y1="11.1125" x2="13.726815625" y2="11.247428125" width="0.127" layer="1"/>
+<wire x1="9.2075" y1="24.4475" x2="9.271" y2="24.511" width="0.127" layer="16"/>
+<via x="13.81125" y="10.63625" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="VIN" class="1">
+<contactref element="JP1" pad="8"/>
+<contactref element="R6" pad="1"/>
+<wire x1="4.28625" y1="1.74625" x2="4.28625" y2="2.06375" width="0.4064" layer="1"/>
+<wire x1="4.28625" y1="1.74625" x2="4.191" y2="1.651" width="0.4064" layer="1"/>
+<wire x1="3.175" y1="2.06375" x2="1.74625" y2="3.4925" width="0.4064" layer="1"/>
+<wire x1="4.1275" y1="2.06375" x2="3.175" y2="2.06375" width="0.4064" layer="1"/>
+<wire x1="1.74625" y1="3.4925" x2="1.74625" y2="3.5433" width="0.4064" layer="1"/>
+<wire x1="4.1275" y1="2.06375" x2="4.191" y2="1.651" width="0.4064" layer="1"/>
+</signal>
+<signal name="GPIO19/MISO">
+<contactref element="JP2" pad="4"/>
+<contactref element="PICO-D4" pad="38"/>
+<wire x1="15.5575" y1="10.95375" x2="14.9225" y2="11.58875" width="0.127" layer="1"/>
+<wire x1="16.35125" y1="10.95375" x2="15.5575" y2="10.95375" width="0.127" layer="1"/>
+<wire x1="16.35125" y1="13.335" x2="16.35125" y2="10.95375" width="0.127" layer="16"/>
+<wire x1="23.1775" y1="20.16125" x2="16.35125" y2="13.335" width="0.127" layer="16"/>
+<wire x1="23.1775" y1="24.92375" x2="23.1775" y2="20.16125" width="0.127" layer="16"/>
+<wire x1="22.38375" y1="25.7175" x2="23.1775" y2="24.92375" width="0.127" layer="16"/>
+<wire x1="13.0175" y1="25.7175" x2="22.38375" y2="25.7175" width="0.127" layer="16"/>
+<wire x1="11.811" y1="24.511" x2="13.0175" y2="25.7175" width="0.127" layer="16"/>
+<wire x1="14.9225" y1="11.58875" x2="14.896934375" y2="11.60098125" width="0.127" layer="1"/>
+<via x="16.35125" y="10.95375" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="LNA_IN">
+<contactref element="PICO-D4" pad="2"/>
+<contactref element="C5" pad="1"/>
+<contactref element="C4" pad="1"/>
+<wire x1="18.7325" y1="17.30375" x2="19.05" y2="17.30375" width="0.127" layer="1"/>
+<wire x1="19.05" y1="17.30375" x2="19.685" y2="17.30375" width="0.127" layer="1"/>
+<wire x1="19.685" y1="17.30375" x2="19.812" y2="17.27835" width="0.127" layer="1"/>
+<wire x1="18.7325" y1="17.30375" x2="18.72615" y2="17.2847" width="0.127" layer="1"/>
+<wire x1="19.05" y1="17.30375" x2="18.0975" y2="16.35125" width="0.127" layer="1"/>
+<wire x1="18.0975" y1="16.35125" x2="18.078915625" y2="16.306634375" width="0.127" layer="1"/>
+</signal>
+<signal name="GPIO13/SD_MOSI">
+<contactref element="J2" pad="3"/>
+<contactref element="PICO-D4" pad="20"/>
+<wire x1="10.795" y1="17.78" x2="11.1125" y2="17.4625" width="0.127" layer="1"/>
+<wire x1="6.0325" y1="17.78" x2="10.795" y2="17.78" width="0.127" layer="1"/>
+<wire x1="4.92125" y1="16.66875" x2="6.0325" y2="17.78" width="0.127" layer="1"/>
+<wire x1="4.92125" y1="15.71625" x2="4.92125" y2="16.66875" width="0.127" layer="1"/>
+<wire x1="7.46125" y1="15.71625" x2="4.92125" y2="15.71625" width="0.127" layer="1"/>
+<wire x1="7.46125" y1="14.605" x2="7.46125" y2="15.71625" width="0.127" layer="16"/>
+<wire x1="8.09625" y1="13.97" x2="7.46125" y2="14.605" width="0.127" layer="16"/>
+<wire x1="8.41375" y1="13.97" x2="8.09625" y2="13.97" width="0.127" layer="16"/>
+<wire x1="11.1125" y1="17.4625" x2="11.251940625" y2="17.367296875" width="0.127" layer="1"/>
+<wire x1="8.41375" y1="13.97" x2="8.53625" y2="13.85875" width="0.127" layer="16"/>
+<via x="7.46125" y="15.71625" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO2/SD_MISO">
+<contactref element="J2" pad="7"/>
+<contactref element="PICO-D4" pad="22"/>
+<wire x1="10.31875" y1="16.8275" x2="10.4775" y2="16.66875" width="0.127" layer="1"/>
+<wire x1="8.255" y1="16.8275" x2="10.31875" y2="16.8275" width="0.127" layer="1"/>
+<wire x1="8.09625" y1="16.98625" x2="8.255" y2="16.8275" width="0.127" layer="1"/>
+<wire x1="7.77875" y1="16.66875" x2="8.09625" y2="16.98625" width="0.127" layer="16"/>
+<wire x1="7.62" y1="16.66875" x2="7.77875" y2="16.66875" width="0.127" layer="16"/>
+<wire x1="6.985" y1="16.03375" x2="7.62" y2="16.66875" width="0.127" layer="16"/>
+<wire x1="6.985" y1="10.63625" x2="6.985" y2="16.03375" width="0.127" layer="16"/>
+<wire x1="8.09625" y1="9.525" x2="6.985" y2="10.63625" width="0.127" layer="16"/>
+<wire x1="8.41375" y1="9.525" x2="8.09625" y2="9.525" width="0.127" layer="16"/>
+<wire x1="10.4775" y1="16.66875" x2="10.544834375" y2="16.6601875" width="0.127" layer="1"/>
+<wire x1="8.41375" y1="9.525" x2="8.53625" y2="9.45875" width="0.127" layer="16"/>
+<via x="8.09625" y="16.98625" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="N$4">
+<contactref element="J2" pad="8"/>
+</signal>
+<signal name="N$5">
+<contactref element="J2" pad="1"/>
+</signal>
+<signal name="GPIO15/SD_CS">
+<contactref element="J2" pad="2"/>
+<contactref element="PICO-D4" pad="21"/>
+<wire x1="10.63625" y1="17.30375" x2="10.795" y2="17.145" width="0.127" layer="1"/>
+<wire x1="10.16" y1="17.30375" x2="10.63625" y2="17.30375" width="0.127" layer="1"/>
+<wire x1="10.16" y1="16.1925" x2="10.16" y2="17.30375" width="0.127" layer="16"/>
+<wire x1="9.04875" y1="15.08125" x2="10.16" y2="16.1925" width="0.127" layer="16"/>
+<wire x1="8.5725" y1="15.08125" x2="9.04875" y2="15.08125" width="0.127" layer="16"/>
+<wire x1="10.795" y1="17.145" x2="10.8983875" y2="17.013740625" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="15.08125" x2="8.53625" y2="14.95875" width="0.127" layer="16"/>
+<via x="10.16" y="17.30375" extent="1-16" drill="0.1778"/>
+</signal>
+<signal name="GPIO14/SD_CLK">
+<contactref element="J2" pad="5"/>
+<contactref element="PICO-D4" pad="17"/>
+<wire x1="11.90625" y1="18.89125" x2="12.22375" y2="18.57375" width="0.127" layer="1"/>
+<wire x1="11.7475" y1="18.89125" x2="11.90625" y2="18.89125" width="0.127" layer="1"/>
+<wire x1="11.7475" y1="13.6525" x2="11.7475" y2="18.89125" width="0.127" layer="16"/>
+<wire x1="10.00125" y1="11.90625" x2="11.7475" y2="13.6525" width="0.127" layer="16"/>
+<wire x1="8.73125" y1="11.90625" x2="10.00125" y2="11.90625" width="0.127" layer="16"/>
+<wire x1="8.5725" y1="11.7475" x2="8.73125" y2="11.90625" width="0.127" layer="16"/>
+<wire x1="12.22375" y1="18.57375" x2="12.3126" y2="18.42795625" width="0.127" layer="1"/>
+<wire x1="8.5725" y1="11.7475" x2="8.53625" y2="11.65875" width="0.127" layer="16"/>
+<via x="11.7475" y="18.89125" extent="1-16" drill="0.1778"/>
+</signal>
+</signals>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
+<errors>
+<approved hash="19,1,f135f3bfd251d0db"/>
+</errors>
+</board>
+</drawing>
+<compatibility>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports Fusion synchronisation.
+This feature will not be available in this version and saving
+the document will break the link to the Fusion PCB feature.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+<note version="9.4" severity="warning">
+Since Version 9.4, EAGLE supports the overriding of 3D packages
+in schematics and board files. Those overridden 3d packages
+will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>

--- a/cad/pcb/microcontroller-esp32.sch
+++ b/cad/pcb/microcontroller-esp32.sch
@@ -1,0 +1,10978 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.6.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
+<layer number="2" name="Route2" color="16" fill="1" visible="no" active="no"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
+<layer number="15" name="Route15" color="23" fill="1" visible="no" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
+<layer number="20" name="Dimension" color="24" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="no"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="no"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="no"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="88" name="SimResults" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="89" name="SimProbes" color="9" fill="1" visible="yes" active="yes"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="99" name="SpiceOrder" color="7" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Mittellin" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="Stiffner" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="7" fill="1" visible="no" active="yes"/>
+<layer number="105" name="Beschreib" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="BGA-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="BD-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tBridges" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="tBPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="bBPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="MPL" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="ReferenceLS" color="7" fill="1" visible="no" active="no"/>
+<layer number="114" name="Badge_Outline" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="117" name="BACKMAAT1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="no"/>
+<layer number="119" name="KAP_TEKEN" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="120" name="KAP_MAAT1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="sName" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bPlace" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="130" name="SMDSTROOK" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="133" name="bottom_silk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="134" name="mbFinish" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="135" name="mtGlue" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="136" name="mbGlue" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="137" name="mtTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="138" name="mbTest" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="139" name="mtKeepout" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="140" name="mbKeepout" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="141" name="mtRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="142" name="mbRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="143" name="mvRestrict" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="145" name="mHoles" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="146" name="mMilling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="147" name="mMeasures" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="148" name="mDocument" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="149" name="mReference" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="6" fill="1" visible="no" active="no"/>
+<layer number="154" name="FabDoc2" color="2" fill="1" visible="no" active="no"/>
+<layer number="155" name="FabDoc3" color="7" fill="15" visible="no" active="no"/>
+<layer number="191" name="mNets" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="192" name="mBusses" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="193" name="mPins" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="194" name="mSymbols" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="195" name="mNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="196" name="mValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="no"/>
+<layer number="201" name="201bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="no" active="no"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="no"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="no"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="7" fill="1" visible="no" active="yes"/>
+<layer number="251" name="SMDround" color="7" fill="1" visible="no" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
+</layers>
+<schematic xreflabel="%F%N/%S.%C%R" xrefpart="/%S.%C%R">
+<libraries>
+<library name="microbuilder">
+<description>&lt;h2&gt;&lt;b&gt;microBuilder.eu&lt;/b&gt; Eagle Footprint Library&lt;/h2&gt;
+
+&lt;p&gt;Footprints for common components used in our projects and products.  This is the same library that we use internally, and it is regularly updated.  The newest version can always be found at &lt;b&gt;www.microBuilder.eu&lt;/b&gt;.  If you find this library useful, please feel free to purchase something from our online store. Please also note that all holes are optimised for metric drill bits!&lt;/p&gt;
+
+&lt;h3&gt;Obligatory Warning&lt;/h3&gt;
+&lt;p&gt;While it probably goes without saying, there are no guarantees that the footprints or schematic symbols in this library are flawless, and we make no promises of fitness for production, prototyping or any other purpose. These libraries are provided for information puposes only, and are used at your own discretion.  While we make every effort to produce accurate footprints, and many of the items found in this library have be proven in production, we can't make any promises of suitability for a specific purpose. If you do find any errors, though, please feel free to contact us at www.microbuilder.eu to let us know about it so that we can update the library accordingly!&lt;/p&gt;
+
+&lt;h3&gt;License&lt;/h3&gt;
+&lt;p&gt;This work is placed in the public domain, and may be freely used for commercial and non-commercial work with the following conditions:&lt;/p&gt;
+&lt;p&gt;THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+&lt;/p&gt;</description>
+<packages>
+<package name="_0402">
+<description>&lt;b&gt; 0402&lt;/b&gt;</description>
+<wire x1="-0.245" y1="0.174" x2="0.245" y2="0.174" width="0.1016" layer="51"/>
+<wire x1="0.245" y1="-0.174" x2="-0.245" y2="-0.174" width="0.1016" layer="51"/>
+<wire x1="-1.0573" y1="0.5557" x2="1.0573" y2="0.5557" width="0.2032" layer="21"/>
+<wire x1="1.0573" y1="0.5557" x2="1.0573" y2="-0.5556" width="0.2032" layer="21"/>
+<wire x1="1.0573" y1="-0.5556" x2="-1.0573" y2="-0.5557" width="0.2032" layer="21"/>
+<wire x1="-1.0573" y1="-0.5557" x2="-1.0573" y2="0.5557" width="0.2032" layer="21"/>
+<smd name="1" x="-0.508" y="0" dx="0.6" dy="0.6" layer="1"/>
+<smd name="2" x="0.508" y="0" dx="0.6" dy="0.6" layer="1"/>
+<text x="-0.9525" y="0.7939" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-0.9525" y="-1.3336" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.0794" y1="-0.2381" x2="0.0794" y2="0.2381" layer="35"/>
+<rectangle x1="0.25" y1="-0.25" x2="0.5" y2="0.25" layer="51"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.25" y2="0.25" layer="51"/>
+</package>
+<package name="_0402MP">
+<description>&lt;b&gt;0402 MicroPitch&lt;p&gt;</description>
+<wire x1="-0.245" y1="0.174" x2="0.245" y2="0.174" width="0.1016" layer="51"/>
+<wire x1="0.245" y1="-0.174" x2="-0.245" y2="-0.174" width="0.1016" layer="51"/>
+<wire x1="0" y1="0.127" x2="0" y2="-0.127" width="0.2032" layer="21"/>
+<smd name="1" x="-0.508" y="0" dx="0.5" dy="0.5" layer="1"/>
+<smd name="2" x="0.508" y="0" dx="0.5" dy="0.5" layer="1"/>
+<text x="-0.635" y="0.4763" size="0.6096" layer="25" ratio="18">&gt;NAME</text>
+<text x="-0.635" y="-0.7938" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.1" y1="-0.2" x2="0.1" y2="0.2" layer="35"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.254" y2="0.25" layer="51"/>
+<rectangle x1="0.2588" y1="-0.25" x2="0.5" y2="0.25" layer="51"/>
+</package>
+<package name="_0603">
+<description>&lt;b&gt;0603&lt;/b&gt;</description>
+<wire x1="-0.432" y1="-0.306" x2="0.432" y2="-0.306" width="0.1016" layer="51"/>
+<wire x1="0.432" y1="0.306" x2="-0.432" y2="0.306" width="0.1016" layer="51"/>
+<wire x1="-1.4605" y1="0.635" x2="1.4605" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.4605" y1="0.635" x2="1.4605" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="1.4605" y1="-0.635" x2="-1.4605" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-1.4605" y1="-0.635" x2="-1.4605" y2="0.635" width="0.2032" layer="21"/>
+<smd name="1" x="-0.762" y="0" dx="0.9" dy="0.8" layer="1"/>
+<smd name="2" x="0.762" y="0" dx="0.9" dy="0.8" layer="1"/>
+<text x="-1.27" y="0.9525" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-1.27" y="-1.4923" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="0.4318" y1="-0.4" x2="0.8382" y2="0.4" layer="51"/>
+<rectangle x1="-0.8382" y1="-0.4" x2="-0.4318" y2="0.4" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+</package>
+<package name="_0603MP">
+<description>&lt;b&gt;0603 MicroPitch&lt;/b&gt;</description>
+<wire x1="-0.432" y1="-0.306" x2="0.432" y2="-0.306" width="0.1016" layer="51"/>
+<wire x1="0.432" y1="0.306" x2="-0.432" y2="0.306" width="0.1016" layer="51"/>
+<wire x1="0" y1="0.254" x2="0" y2="-0.254" width="0.2032" layer="21"/>
+<smd name="1" x="-0.762" y="0" dx="0.8" dy="0.8" layer="1"/>
+<smd name="2" x="0.762" y="0" dx="0.8" dy="0.8" layer="1"/>
+<text x="-0.9525" y="0.635" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-0.9525" y="-0.9525" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="0.4318" y1="-0.4" x2="0.8" y2="0.4" layer="51"/>
+<rectangle x1="-0.8" y1="-0.4" x2="-0.4318" y2="0.4" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.25" x2="0.1999" y2="0.25" layer="35"/>
+</package>
+<package name="_0805">
+<description>&lt;b&gt;0805&lt;/b&gt;</description>
+<wire x1="-0.41" y1="0.585" x2="0.41" y2="0.585" width="0.1016" layer="51"/>
+<wire x1="-0.41" y1="-0.585" x2="0.41" y2="-0.585" width="0.1016" layer="51"/>
+<wire x1="-1.905" y1="0.889" x2="1.905" y2="0.889" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="0.889" x2="1.905" y2="-0.889" width="0.2032" layer="21"/>
+<wire x1="1.905" y1="-0.889" x2="-1.905" y2="-0.889" width="0.2032" layer="21"/>
+<wire x1="-1.905" y1="-0.889" x2="-1.905" y2="0.889" width="0.2032" layer="21"/>
+<smd name="1" x="-1.016" y="0" dx="1.2" dy="1.3" layer="1"/>
+<smd name="2" x="1.016" y="0" dx="1.2" dy="1.3" layer="1"/>
+<text x="-1.5875" y="1.27" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-1.5874" y="-1.651" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="0.4064" y1="-0.65" x2="1.0564" y2="0.65" layer="51"/>
+<rectangle x1="-1.0668" y1="-0.65" x2="-0.4168" y2="0.65" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.5001" x2="0.1999" y2="0.5001" layer="35"/>
+</package>
+<package name="_0805MP">
+<description>&lt;b&gt;0805 MicroPitch&lt;/b&gt;</description>
+<wire x1="-0.51" y1="0.535" x2="0.51" y2="0.535" width="0.1016" layer="51"/>
+<wire x1="-0.51" y1="-0.535" x2="0.51" y2="-0.535" width="0.1016" layer="51"/>
+<wire x1="0" y1="0.508" x2="0" y2="-0.508" width="0.2032" layer="21"/>
+<smd name="1" x="-1.016" y="0" dx="1.2" dy="1.3" layer="1"/>
+<smd name="2" x="1.016" y="0" dx="1.2" dy="1.3" layer="1"/>
+<text x="-1.5875" y="0.9525" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-1.5875" y="-1.27" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="0.4064" y1="-0.65" x2="1" y2="0.65" layer="51"/>
+<rectangle x1="-1" y1="-0.65" x2="-0.4168" y2="0.65" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.5001" x2="0.1999" y2="0.5001" layer="35"/>
+</package>
+<package name="2012">
+<wire x1="-1.662" y1="1.245" x2="1.662" y2="1.245" width="0.2032" layer="51"/>
+<wire x1="-1.637" y1="-1.245" x2="1.687" y2="-1.245" width="0.2032" layer="51"/>
+<wire x1="-3.473" y1="1.483" x2="3.473" y2="1.483" width="0.0508" layer="39"/>
+<wire x1="3.473" y1="1.483" x2="3.473" y2="-1.483" width="0.0508" layer="39"/>
+<wire x1="3.473" y1="-1.483" x2="-3.473" y2="-1.483" width="0.0508" layer="39"/>
+<wire x1="-3.473" y1="-1.483" x2="-3.473" y2="1.483" width="0.0508" layer="39"/>
+<wire x1="-3.302" y1="1.524" x2="3.302" y2="1.524" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="1.524" x2="3.302" y2="-1.524" width="0.2032" layer="21"/>
+<wire x1="3.302" y1="-1.524" x2="-3.302" y2="-1.524" width="0.2032" layer="21"/>
+<wire x1="-3.302" y1="-1.524" x2="-3.302" y2="1.524" width="0.2032" layer="21"/>
+<smd name="1" x="-2.2" y="0" dx="1.8" dy="2.7" layer="1"/>
+<smd name="2" x="2.2" y="0" dx="1.8" dy="2.7" layer="1"/>
+<text x="-2.54" y="1.8415" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-2.667" y="-2.159" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-2.4892" y1="-1.3208" x2="-1.6393" y2="1.3292" layer="51"/>
+<rectangle x1="1.651" y1="-1.3208" x2="2.5009" y2="1.3292" layer="51"/>
+</package>
+<package name="2512">
+<description>&lt;b&gt;RESISTOR 2512 (Metric 6432)&lt;/b&gt;</description>
+<wire x1="-2.362" y1="1.473" x2="2.387" y2="1.473" width="0.2032" layer="51"/>
+<wire x1="-2.362" y1="-1.473" x2="2.387" y2="-1.473" width="0.2032" layer="51"/>
+<wire x1="-3.973" y1="1.983" x2="3.973" y2="1.983" width="0.0508" layer="39"/>
+<wire x1="3.973" y1="1.983" x2="3.973" y2="-1.983" width="0.0508" layer="39"/>
+<wire x1="3.973" y1="-1.983" x2="-3.973" y2="-1.983" width="0.0508" layer="39"/>
+<wire x1="-3.973" y1="-1.983" x2="-3.973" y2="1.983" width="0.0508" layer="39"/>
+<smd name="1" x="-2.8" y="0" dx="1.8" dy="3.2" layer="1"/>
+<smd name="2" x="2.8" y="0" dx="1.8" dy="3.2" layer="1"/>
+<text x="-3.683" y="1.905" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-3.556" y="-2.286" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-3.2004" y1="-1.5494" x2="-2.3505" y2="1.5507" layer="51"/>
+<rectangle x1="2.3622" y1="-1.5494" x2="3.2121" y2="1.5507" layer="51"/>
+<rectangle x1="-0.5001" y1="-1" x2="0.5001" y2="1" layer="35"/>
+</package>
+<package name="0603-MINI@1">
+<description>0603-Mini
+&lt;p&gt;Mini footprint for dense boards&lt;/p&gt;</description>
+<wire x1="-1.346" y1="0.583" x2="1.346" y2="0.583" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="0.583" x2="1.346" y2="-0.583" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="-0.583" x2="-1.346" y2="-0.583" width="0.0508" layer="39"/>
+<wire x1="-1.346" y1="-0.583" x2="-1.346" y2="0.583" width="0.0508" layer="39"/>
+<wire x1="-1.45" y1="-0.7" x2="-1.45" y2="0.7" width="0.2032" layer="21"/>
+<wire x1="-1.45" y1="0.7" x2="1.45" y2="0.7" width="0.2032" layer="21"/>
+<wire x1="1.45" y1="0.7" x2="1.45" y2="-0.7" width="0.2032" layer="21"/>
+<wire x1="1.45" y1="-0.7" x2="-1.45" y2="-0.7" width="0.2032" layer="21"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<smd name="1" x="-0.75" y="0" dx="0.9" dy="0.9" layer="1"/>
+<smd name="2" x="0.75" y="0" dx="0.9" dy="0.9" layer="1"/>
+<text x="1.524" y="-0.0635" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="1.524" y="-0.635" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+</package>
+<package name="0805_NOTHERMALS@1">
+<wire x1="-1.873" y1="0.883" x2="1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="1.873" y1="-0.883" x2="-1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="-1.873" y1="-0.883" x2="-1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="-0.381" y1="0.66" x2="0.381" y2="0.66" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.66" x2="0.381" y2="-0.66" width="0.1016" layer="51"/>
+<wire x1="1.873" y1="0.883" x2="1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="1.85" y1="1" x2="1.85" y2="-1" width="0.2032" layer="21"/>
+<wire x1="1.85" y1="-1" x2="-1.85" y2="-1" width="0.2032" layer="21"/>
+<wire x1="-1.85" y1="-1" x2="-1.85" y2="1" width="0.2032" layer="21"/>
+<wire x1="-1.85" y1="1" x2="1.85" y2="1" width="0.2032" layer="21"/>
+<smd name="1" x="-0.95" y="0" dx="1.3" dy="1.5" layer="1" thermals="no"/>
+<smd name="2" x="0.95" y="0" dx="1.3" dy="1.5" layer="1" thermals="no"/>
+<text x="2.032" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.032" y="-0.762" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.0922" y1="-0.7239" x2="-0.3421" y2="0.7262" layer="51"/>
+<rectangle x1="0.3556" y1="-0.7239" x2="1.1057" y2="0.7262" layer="51"/>
+</package>
+<package name="0805-NO@1">
+<wire x1="-0.381" y1="0.66" x2="0.381" y2="0.66" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.66" x2="0.381" y2="-0.66" width="0.1016" layer="51"/>
+<smd name="1" x="-0.95" y="0" dx="1.24" dy="1.5" layer="1"/>
+<smd name="2" x="0.95" y="0" dx="1.24" dy="1.5" layer="1"/>
+<text x="2.032" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.032" y="-0.762" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.0922" y1="-0.7239" x2="-0.3421" y2="0.7262" layer="51"/>
+<rectangle x1="0.3556" y1="-0.7239" x2="1.1057" y2="0.7262" layer="51"/>
+<wire x1="0" y1="0.508" x2="0" y2="-0.508" width="0.3048" layer="21"/>
+</package>
+<package name="_1206">
+<wire x1="0.9525" y1="-0.8128" x2="-0.9652" y2="-0.8128" width="0.1016" layer="51"/>
+<wire x1="0.9525" y1="0.8128" x2="-0.9652" y2="0.8128" width="0.1016" layer="51"/>
+<wire x1="-2.286" y1="1.143" x2="2.286" y2="1.143" width="0.2032" layer="21"/>
+<wire x1="2.286" y1="1.143" x2="2.286" y2="-1.143" width="0.2032" layer="21"/>
+<wire x1="2.286" y1="-1.143" x2="-2.286" y2="-1.143" width="0.2032" layer="21"/>
+<wire x1="-2.286" y1="-1.143" x2="-2.286" y2="1.143" width="0.2032" layer="21"/>
+<smd name="2" x="1.27" y="0" dx="1.4" dy="1.8" layer="1"/>
+<smd name="1" x="-1.27" y="0" dx="1.4" dy="1.8" layer="1"/>
+<rectangle x1="-1.6891" y1="-0.8763" x2="-0.9525" y2="0.8763" layer="51"/>
+<rectangle x1="0.9525" y1="-0.8763" x2="1.6891" y2="0.8763" layer="51"/>
+<rectangle x1="-0.3" y1="-0.7" x2="0.3" y2="0.7" layer="35"/>
+<text x="-2.2225" y="1.5113" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-2.2225" y="-1.8288" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="_1206MP">
+<wire x1="1.0525" y1="-0.7128" x2="-1.0652" y2="-0.7128" width="0.1016" layer="51"/>
+<wire x1="1.0525" y1="0.7128" x2="-1.0652" y2="0.7128" width="0.1016" layer="51"/>
+<wire x1="-0.635" y1="0.635" x2="0.635" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-0.635" y1="-0.635" x2="0.635" y2="-0.635" width="0.2032" layer="21"/>
+<smd name="2" x="1.524" y="0" dx="1.3" dy="1.6" layer="1"/>
+<smd name="1" x="-1.524" y="0" dx="1.3" dy="1.6" layer="1"/>
+<text x="-2.2225" y="1.1113" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="-2.2225" y="-1.4288" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.6" y1="-0.8" x2="-0.9" y2="0.8" layer="51"/>
+<rectangle x1="-0.3" y1="-0.7" x2="0.3" y2="0.7" layer="35"/>
+<rectangle x1="0.9001" y1="-0.8" x2="1.6" y2="0.8" layer="51" rot="R180"/>
+</package>
+<package name="0805_10MGAP">
+<wire x1="-0.381" y1="0.66" x2="0.381" y2="0.66" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.66" x2="0.381" y2="-0.66" width="0.1016" layer="51"/>
+<smd name="1" x="-1.05" y="0" dx="1.2" dy="1.5" layer="1"/>
+<smd name="2" x="1.05" y="0" dx="1.2" dy="1.5" layer="1"/>
+<text x="2.032" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.032" y="-0.762" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.0922" y1="-0.7239" x2="-0.3421" y2="0.7262" layer="51"/>
+<rectangle x1="0.3556" y1="-0.7239" x2="1.1057" y2="0.7262" layer="51"/>
+<wire x1="0" y1="0.508" x2="0" y2="-0.508" width="0.3048" layer="21"/>
+</package>
+<package name="0603-NO">
+<wire x1="-1.473" y1="0.729" x2="1.473" y2="0.729" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="0.729" x2="1.473" y2="-0.729" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="-0.729" x2="-1.473" y2="-0.729" width="0.0508" layer="39"/>
+<wire x1="-1.473" y1="-0.729" x2="-1.473" y2="0.729" width="0.0508" layer="39"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<text x="1.778" y="-0.127" size="0.8128" layer="25" font="vector" ratio="18">&gt;NAME</text>
+<text x="1.778" y="-0.762" size="0.4064" layer="27" font="vector" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+</package>
+<package name="0805">
+<description>0805 (2012 Metric)</description>
+<wire x1="-1.873" y1="0.883" x2="1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="1.873" y1="-0.883" x2="-1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="-1.873" y1="-0.883" x2="-1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="-0.381" y1="0.66" x2="0.381" y2="0.66" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.66" x2="0.381" y2="-0.66" width="0.1016" layer="51"/>
+<wire x1="1.873" y1="0.883" x2="1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="1.8" y1="0.9" x2="1.8" y2="-0.9" width="0.2032" layer="21"/>
+<wire x1="1.8" y1="-0.9" x2="-1.8" y2="-0.9" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="-0.9" x2="-1.8" y2="0.9" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="0.9" x2="1.8" y2="0.9" width="0.2032" layer="21"/>
+<smd name="1" x="-0.95" y="0" dx="1.3" dy="1.5" layer="1"/>
+<smd name="2" x="0.95" y="0" dx="1.3" dy="1.5" layer="1"/>
+<text x="2.032" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.032" y="-0.762" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.0922" y1="-0.7239" x2="-0.3421" y2="0.7262" layer="51"/>
+<rectangle x1="0.3556" y1="-0.7239" x2="1.1057" y2="0.7262" layer="51"/>
+<rectangle x1="-0.1001" y1="-0.4001" x2="0.1001" y2="0.4001" layer="35"/>
+</package>
+<package name="1206">
+<description>1206 (3216 Metric)</description>
+<wire x1="-2.473" y1="0.983" x2="2.473" y2="0.983" width="0.0508" layer="39"/>
+<wire x1="2.473" y1="-0.983" x2="-2.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="-2.473" y1="-0.983" x2="-2.473" y2="0.983" width="0.0508" layer="39"/>
+<wire x1="2.473" y1="0.983" x2="2.473" y2="-0.983" width="0.0508" layer="39"/>
+<wire x1="-0.965" y1="0.787" x2="0.965" y2="0.787" width="0.1016" layer="51"/>
+<wire x1="-0.965" y1="-0.787" x2="0.965" y2="-0.787" width="0.1016" layer="51"/>
+<wire x1="-2.4" y1="1" x2="2.4" y2="1" width="0.2032" layer="21"/>
+<wire x1="2.4" y1="1" x2="2.4" y2="-1" width="0.2032" layer="21"/>
+<wire x1="2.4" y1="-1" x2="-2.4" y2="-1" width="0.2032" layer="21"/>
+<wire x1="-2.4" y1="-1" x2="-2.4" y2="1" width="0.2032" layer="21"/>
+<smd name="1" x="-1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
+<smd name="2" x="1.4" y="0" dx="1.6" dy="1.8" layer="1"/>
+<text x="2.54" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.54" y="-0.635" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.7018" y1="-0.8509" x2="-0.9517" y2="0.8491" layer="51"/>
+<rectangle x1="0.9517" y1="-0.8491" x2="1.7018" y2="0.8509" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+</package>
+<package name="0603">
+<description>0603 (1608 Metric)</description>
+<wire x1="-1.473" y1="0.729" x2="1.473" y2="0.729" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="0.729" x2="1.473" y2="-0.729" width="0.0508" layer="39"/>
+<wire x1="1.473" y1="-0.729" x2="-1.473" y2="-0.729" width="0.0508" layer="39"/>
+<wire x1="-1.473" y1="-0.729" x2="-1.473" y2="0.729" width="0.0508" layer="39"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.2032" layer="21"/>
+<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.2032" layer="21"/>
+<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.2032" layer="21"/>
+<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.2032" layer="21"/>
+<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<text x="1.778" y="-0.127" size="0.8128" layer="25" font="vector" ratio="18">&gt;NAME</text>
+<text x="1.778" y="-0.762" size="0.4064" layer="27" font="vector" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+</package>
+<package name="0402">
+<description>&lt;b&gt;CAPACITOR&lt;/b&gt;&lt;p&gt;
+chip</description>
+<wire x1="-0.245" y1="0.224" x2="0.245" y2="0.224" width="0.2032" layer="51"/>
+<wire x1="0.245" y1="-0.224" x2="-0.245" y2="-0.224" width="0.2032" layer="51"/>
+<wire x1="-1.346" y1="0.483" x2="1.346" y2="0.483" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="0.483" x2="1.346" y2="-0.483" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="-0.483" x2="-1.346" y2="-0.483" width="0.0508" layer="39"/>
+<wire x1="-1.346" y1="-0.483" x2="-1.346" y2="0.483" width="0.0508" layer="39"/>
+<wire x1="-1.27" y1="-0.635" x2="-1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="1.27" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="-1.27" y2="-0.635" width="0.2032" layer="21"/>
+<smd name="1" x="-0.65" y="0" dx="0.7" dy="0.9" layer="1"/>
+<smd name="2" x="0.65" y="0" dx="0.7" dy="0.9" layer="1"/>
+<text x="1.397" y="-0.1905" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="1.397" y="-0.635" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.554" y1="-0.3048" x2="-0.254" y2="0.2951" layer="51"/>
+<rectangle x1="0.2588" y1="-0.3048" x2="0.5588" y2="0.2951" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+</package>
+<package name="0603-MINI">
+<description>0603-Mini
+&lt;p&gt;Mini footprint for dense boards&lt;/p&gt;</description>
+<wire x1="-1.346" y1="0.583" x2="1.346" y2="0.583" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="0.583" x2="1.346" y2="-0.583" width="0.0508" layer="39"/>
+<wire x1="1.346" y1="-0.583" x2="-1.346" y2="-0.583" width="0.0508" layer="39"/>
+<wire x1="-1.346" y1="-0.583" x2="-1.346" y2="0.583" width="0.0508" layer="39"/>
+<wire x1="-1.37" y1="-0.635" x2="-1.37" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="-1.37" y1="0.635" x2="1.37" y2="0.635" width="0.2032" layer="21"/>
+<wire x1="1.37" y1="0.635" x2="1.37" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="1.37" y1="-0.635" x2="-1.37" y2="-0.635" width="0.2032" layer="21"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<smd name="1" x="-0.75" y="0" dx="0.9" dy="0.9" layer="1"/>
+<smd name="2" x="0.75" y="0" dx="0.9" dy="0.9" layer="1"/>
+<text x="1.524" y="-0.0635" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="1.524" y="-0.635" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+</package>
+<package name="0805_NOTHERMALS">
+<wire x1="-1.873" y1="0.883" x2="1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="1.873" y1="-0.883" x2="-1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="-1.873" y1="-0.883" x2="-1.873" y2="0.883" width="0.0508" layer="39"/>
+<wire x1="-0.381" y1="0.66" x2="0.381" y2="0.66" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.66" x2="0.381" y2="-0.66" width="0.1016" layer="51"/>
+<wire x1="1.873" y1="0.883" x2="1.873" y2="-0.883" width="0.0508" layer="39"/>
+<wire x1="1.8" y1="0.9" x2="1.8" y2="-0.9" width="0.2032" layer="21"/>
+<wire x1="1.8" y1="-0.9" x2="-1.8" y2="-0.9" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="-0.9" x2="-1.8" y2="0.9" width="0.2032" layer="21"/>
+<wire x1="-1.8" y1="0.9" x2="1.8" y2="0.9" width="0.2032" layer="21"/>
+<smd name="1" x="-0.95" y="0" dx="1.3" dy="1.5" layer="1" thermals="no"/>
+<smd name="2" x="0.95" y="0" dx="1.3" dy="1.5" layer="1" thermals="no"/>
+<text x="2.032" y="-0.127" size="0.8128" layer="25" ratio="18">&gt;NAME</text>
+<text x="2.032" y="-0.762" size="0.4064" layer="27" ratio="10">&gt;VALUE</text>
+<rectangle x1="-1.0922" y1="-0.7239" x2="-0.3421" y2="0.7262" layer="51"/>
+<rectangle x1="0.3556" y1="-0.7239" x2="1.1057" y2="0.7262" layer="51"/>
+</package>
+</packages>
+<symbols>
+<symbol name="CAPACITOR">
+<wire x1="0" y1="0.762" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="2.54" x2="0" y2="1.778" width="0.1524" layer="94"/>
+<text x="-2.29" y="1.25" size="1.27" layer="95" font="vector" rot="R90" align="center">&gt;NAME</text>
+<text x="2.3" y="1.25" size="1.27" layer="96" font="vector" rot="R90" align="center">&gt;VALUE</text>
+<rectangle x1="-1.27" y1="0.508" x2="1.27" y2="1.016" layer="94"/>
+<rectangle x1="-1.27" y1="1.524" x2="1.27" y2="2.032" layer="94"/>
+<pin name="1" x="0" y="5.08" visible="off" length="short" direction="pas" swaplevel="1" rot="R270"/>
+<pin name="2" x="0" y="-2.54" visible="off" length="short" direction="pas" swaplevel="1" rot="R90"/>
+</symbol>
+<symbol name="GND">
+<wire x1="-1.27" y1="0" x2="1.27" y2="0" width="0.254" layer="94"/>
+<text x="-1.524" y="-2.54" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
+</symbol>
+<symbol name="RESISTOR">
+<wire x1="-2.54" y1="1.27" x2="2.54" y2="1.27" width="0.254" layer="94"/>
+<wire x1="2.54" y1="1.27" x2="2.54" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-1.27" x2="-2.54" y2="-1.27" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="-2.54" y2="1.27" width="0.254" layer="94"/>
+<text x="-2.54" y="2.032" size="1.27" layer="95" font="vector">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="96" font="vector">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="3.3V">
+<wire x1="-1.27" y1="-1.27" x2="0" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="0" x2="1.27" y2="-1.27" width="0.254" layer="94"/>
+<text x="-1.524" y="1.016" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="3.3V" x="0" y="-2.54" visible="off" length="short" direction="sup" rot="R90"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="CAP_CERAMIC" prefix="C" uservalue="yes">
+<description>&lt;p&gt;&lt;b&gt;Ceramic Capacitors&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;For new designs, use the packages preceded by an '_' character since they are more reliable:&lt;/p&gt;
+&lt;p&gt;The following footprints should be used on most boards:&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;_0402&lt;/b&gt; - Standard footprint for regular board layouts&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_0603&lt;/b&gt; - Standard footprint for regular board layouts&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_0805&lt;/b&gt; - Standard footprint for regular board layouts&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_1206&lt;/b&gt; - Standard footprint for regular board layouts&lt;/li&gt;
+&lt;/ul&gt;
+&lt;p&gt;For extremely tight-pitch boards where space is at a premium, the following 'micro-pitch' footprints can be used (smaller pads, no silkscreen outline, etc.):&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;_0402MP&lt;/b&gt; - Micro-pitch footprint for very dense/compact boards&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_0603MP&lt;/b&gt; - Micro-pitch footprint for very dense/compact boards&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_0805MP&lt;/b&gt; - Micro-pitch footprint for very dense/compact boards&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;_1206MP&lt;/b&gt; - Micro-pitch footprint for very dense/compact boards&lt;/li&gt;
+&lt;/ul&gt;</description>
+<gates>
+<gate name="G$1" symbol="CAPACITOR" x="0" y="-2.54"/>
+</gates>
+<devices>
+<device name="0603MINI" package="0603-MINI@1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-NOTHERMALS" package="0805_NOTHERMALS@1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402" package="_0402">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402MP" package="_0402MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="_0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603MP" package="_0603MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805" package="_0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805MP" package="_0805MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805-NOOUTLINE" package="0805-NO@1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805_10MGAP" package="0805_10MGAP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603_NO" package="0603-NO">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206" package="_1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206MP" package="_1206MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="GND">
+<description>&lt;b&gt;GND&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="GND" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="RESISTOR" prefix="R" uservalue="yes">
+<description>&lt;p&gt;&lt;b&gt;Resistors&lt;/b&gt;&lt;/p&gt;
+&lt;b&gt;0402&lt;/b&gt; - 0402 Surface Mount Package
+&lt;ul&gt;
+&lt;li&gt;22 Ohm 1% 1/16W [Digikey: 311-22.0LRTR-ND]&lt;/li&gt;
+&lt;li&gt;33 Ohm 5% 1/16W&lt;/li&gt;
+&lt;li&gt;1.0K 5% 1/16W&lt;/li&gt;
+&lt;li&gt;1.5K 5% 1/16W&lt;/li&gt;
+&lt;li&gt;2.0K 1% 1/16W&lt;/li&gt;
+&lt;li&gt;10.0K 1% 1/16W [Digikey: 311-10.0KLRTR-ND]&lt;/li&gt;
+&lt;li&gt;10.0K 5% 1/16W [Digikey: RMCF0402JT10K0TR-ND]&lt;/li&gt;
+&lt;li&gt;12.1K 1% 1/16W [Digikey: 311-22.0LRTR-ND]&lt;/li&gt;
+&lt;li&gt;100.0K 5% 1/16W&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;0603&lt;/b&gt; - 0603 Surface Mount Package&lt;br&gt;
+&lt;ul&gt;
+&lt;li&gt;0 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;15 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;33 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;49.9 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;100 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;150 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;240 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;390 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;560 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;680 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;750 Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;1.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;1.5K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;2.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;2.2K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;3.3K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;4.7K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;10.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;12.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;12.1K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;20.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;33.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;100.0K Ohm 1/10 Watt 1% Resistor&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;0805&lt;/b&gt; - 0805 Surface Mount Package
+&lt;ul&gt;
+&lt;li&gt;0 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;33 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;100 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;150 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;200 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;240 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;330 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;390 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;470 Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;1.0K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;1.5K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;2.0K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;4.7K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;5.1K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;5.6K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;10.0K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;22.0K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;33.0K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;li&gt;100K Ohm 1/8 Watt 1% Resistor&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;1206&lt;/b&gt; - 1206 Surface Mount Package&lt;br/&gt;
+&lt;br/&gt;
+&lt;b&gt;2012&lt;/b&gt; - 2010 Surface Mount Package&lt;br/&gt;
+&lt;ul&gt;&lt;li&gt;0.11 Ohm 1/2 Watt 1% Resistor - Digikey: RHM.11UCT-ND&lt;/li&gt;&lt;/ul&gt;</description>
+<gates>
+<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="0805" package="0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0402" package="0402">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0603MINI" package="0603-MINI">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2012" package="2012">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="0805_NOTHERMALS" package="0805_NOTHERMALS">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2512" package="2512">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402" package="_0402">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402MP" package="_0402MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="_0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603MP" package="_0603MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805" package="_0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805MP" package="_0805MP">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="3.3V">
+<description>&lt;b&gt;3.3V Supply&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="3.3V" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="supply1">
+<packages>
+</packages>
+<symbols>
+<symbol name="GND">
+<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.254" layer="94"/>
+<text x="-2.54" y="-2.54" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="GND" prefix="GND">
+<description>&lt;b&gt;SUPPLY SYMBOL&lt;/b&gt;</description>
+<gates>
+<gate name="1" symbol="GND" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="Nordic_nRF" urn="urn:adsk.eagle:library:169009">
+<description>&lt;h4&gt;Nordic Semiconductor Devices&lt;/h4&gt;
+&lt;br&gt;
+&lt;a href=http://www.nordicsemi.com&gt;www.nordicsemi.com&lt;/a&gt;
+&lt;br&gt;
+To report issues with this library go to &lt;a href=https://github.com/NordicPlayground/nrf5-eagle-reference-design/blob/master/Library/Nordic_nRF.lbr&gt;github&lt;/a&gt;</description>
+<packages>
+<package name="RESC0402_L" urn="urn:adsk.eagle:footprint:2593700/1" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC High Density</description>
+<smd name="1" x="-0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="2" x="0.5" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.5" y1="0.25" x2="0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.25" x2="0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.25" x2="-0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.25" x2="-0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="0.85" y1="-0.4" x2="0.85" y2="0.4" width="0.1" layer="39"/>
+<wire x1="0.85" y1="0.4" x2="-0.85" y2="0.4" width="0.1" layer="39"/>
+<wire x1="-0.85" y1="0.4" x2="-0.85" y2="-0.4" width="0.1" layer="39"/>
+<wire x1="-0.85" y1="-0.4" x2="0.85" y2="-0.4" width="0.1" layer="39"/>
+</package>
+<package name="RESC0201_L" urn="urn:adsk.eagle:footprint:2593703/1" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC High Density</description>
+<smd name="1" x="-0.255" y="0" dx="0.28" dy="0.43" layer="1"/>
+<smd name="2" x="0.255" y="0" dx="0.28" dy="0.43" layer="1"/>
+<text x="-2" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-0.3" y1="0.15" x2="-0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="-0.3" y1="-0.15" x2="0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.15" x2="0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.15" x2="-0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.3" x2="0.5" y2="-0.3" width="0.1" layer="39"/>
+<wire x1="0.5" y1="-0.3" x2="0.5" y2="0.3" width="0.1" layer="39"/>
+<wire x1="0.5" y1="0.3" x2="-0.5" y2="0.3" width="0.1" layer="39"/>
+<wire x1="-0.5" y1="0.3" x2="-0.5" y2="-0.3" width="0.1" layer="39"/>
+</package>
+<package name="RESC0201_M" urn="urn:adsk.eagle:footprint:2593710/1" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<smd name="1" x="-0.355" y="0" dx="0.5" dy="0.55" layer="1"/>
+<smd name="2" x="0.355" y="0" dx="0.5" dy="0.55" layer="1"/>
+<text x="-0.4" y="1.1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-0.3" y1="0.15" x2="-0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="-0.3" y1="-0.15" x2="0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.15" x2="0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.15" x2="-0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="0.8" y1="-0.5" x2="0.8" y2="0.5" width="0.1" layer="39"/>
+<wire x1="0.8" y1="0.5" x2="-0.8" y2="0.5" width="0.1" layer="39"/>
+<wire x1="-0.8" y1="0.5" x2="-0.8" y2="-0.5" width="0.1" layer="39"/>
+<wire x1="-0.8" y1="-0.5" x2="0.8" y2="-0.5" width="0.1" layer="39"/>
+</package>
+<package name="RESC0201_N" urn="urn:adsk.eagle:footprint:2593709/1" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<smd name="1" x="-0.305" y="0" dx="0.4" dy="0.45" layer="1"/>
+<smd name="2" x="0.305" y="0" dx="0.4" dy="0.45" layer="1"/>
+<text x="-0.635" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-0.3" y1="0.15" x2="-0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="-0.3" y1="-0.15" x2="0.3" y2="-0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="-0.15" x2="0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="0.3" y1="0.15" x2="-0.3" y2="0.15" width="0.1" layer="51"/>
+<wire x1="0.65" y1="-0.35" x2="0.65" y2="0.35" width="0.1" layer="39"/>
+<wire x1="0.65" y1="0.35" x2="-0.65" y2="0.35" width="0.1" layer="39"/>
+<wire x1="-0.65" y1="0.35" x2="-0.65" y2="-0.35" width="0.1" layer="39"/>
+<wire x1="-0.65" y1="-0.35" x2="0.65" y2="-0.35" width="0.1" layer="39"/>
+</package>
+<package name="RESC0402_M" urn="urn:adsk.eagle:footprint:2593712/1" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<smd name="1" x="-0.6" y="0" dx="0.7" dy="0.7" layer="1"/>
+<smd name="2" x="0.6" y="0" dx="0.7" dy="0.7" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.5" y1="0.25" x2="0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.25" x2="0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.25" x2="-0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.25" x2="-0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="1.15" y1="-0.55" x2="1.15" y2="0.55" width="0.1" layer="39"/>
+<wire x1="1.15" y1="0.55" x2="-1.15" y2="0.55" width="0.1" layer="39"/>
+<wire x1="-1.15" y1="0.55" x2="-1.15" y2="-0.55" width="0.1" layer="39"/>
+<wire x1="-1.15" y1="-0.55" x2="1.15" y2="-0.55" width="0.1" layer="39"/>
+</package>
+<package name="RESC0402_N" urn="urn:adsk.eagle:footprint:2593711/1" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<smd name="1" x="-0.55" y="0" dx="0.6" dy="0.6" layer="1"/>
+<smd name="2" x="0.55" y="0" dx="0.6" dy="0.6" layer="1"/>
+<text x="-0.6" y="1.1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.7" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.5" y1="0.25" x2="0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="0.25" x2="0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="0.5" y1="-0.25" x2="-0.5" y2="-0.25" width="0.1" layer="51"/>
+<wire x1="-0.5" y1="-0.25" x2="-0.5" y2="0.25" width="0.1" layer="51"/>
+<wire x1="1" y1="-0.45" x2="1" y2="0.45" width="0.1" layer="39"/>
+<wire x1="1" y1="0.45" x2="-1" y2="0.45" width="0.1" layer="39"/>
+<wire x1="-1" y1="0.45" x2="-1" y2="-0.45" width="0.1" layer="39"/>
+<wire x1="-1" y1="-0.45" x2="1" y2="-0.45" width="0.1" layer="39"/>
+</package>
+<package name="RESC0603_L" urn="urn:adsk.eagle:footprint:2593701/1" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC High Density</description>
+<smd name="1" x="-0.7" y="0" dx="0.85" dy="0.8" layer="1"/>
+<smd name="2" x="0.7" y="0" dx="0.85" dy="0.8" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.8" y1="0.4" x2="0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="0.4" x2="0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="-0.4" x2="-0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="-0.8" y1="-0.4" x2="-0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="1.25" y1="-0.5" x2="1.25" y2="0.5" width="0.1" layer="39"/>
+<wire x1="1.25" y1="0.5" x2="-1.25" y2="0.5" width="0.1" layer="39"/>
+<wire x1="-1.25" y1="0.5" x2="-1.25" y2="-0.5" width="0.1" layer="39"/>
+<wire x1="-1.25" y1="-0.5" x2="1.25" y2="-0.5" width="0.1" layer="39"/>
+</package>
+<package name="RESC0603_M" urn="urn:adsk.eagle:footprint:2593714/1" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC High Density</description>
+<smd name="1" x="-0.9" y="0" dx="1.25" dy="1" layer="1"/>
+<smd name="2" x="0.9" y="0" dx="1.25" dy="1" layer="1"/>
+<text x="-1" y="2" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-3" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.8" y1="0.4" x2="0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="0.4" x2="0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="-0.4" x2="-0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="-0.8" y1="-0.4" x2="-0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="2" y1="-1" x2="2" y2="1" width="0.1" layer="39"/>
+<wire x1="2" y1="1" x2="-2" y2="1" width="0.1" layer="39"/>
+<wire x1="-2" y1="1" x2="-2" y2="-1" width="0.1" layer="39"/>
+<wire x1="-2" y1="-1" x2="2" y2="-1" width="0.1" layer="39"/>
+</package>
+<package name="RESC0603_N" urn="urn:adsk.eagle:footprint:2593713/1" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<smd name="1" x="-0.8" y="0" dx="1.05" dy="0.9" layer="1"/>
+<smd name="2" x="0.8" y="0" dx="1.05" dy="0.9" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2.5" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.4001" x2="0.1999" y2="0.4001" layer="35"/>
+<wire x1="-0.8" y1="0.4" x2="0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="0.4" x2="0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="0.8" y1="-0.4" x2="-0.8" y2="-0.4" width="0.127" layer="51"/>
+<wire x1="-0.8" y1="-0.4" x2="-0.8" y2="0.4" width="0.127" layer="51"/>
+<wire x1="1.6" y1="-0.7" x2="1.6" y2="0.7" width="0.1" layer="39"/>
+<wire x1="1.6" y1="0.7" x2="-1.6" y2="0.7" width="0.1" layer="39"/>
+<wire x1="-1.6" y1="0.7" x2="-1.6" y2="-0.7" width="0.1" layer="39"/>
+<wire x1="-1.6" y1="-0.7" x2="1.6" y2="-0.7" width="0.1" layer="39"/>
+</package>
+<package name="RESC0805_L" urn="urn:adsk.eagle:footprint:2593702/1" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC High Density</description>
+<smd name="1" x="-1" y="0" dx="1" dy="1.25" layer="1"/>
+<smd name="2" x="1" y="0" dx="1" dy="1.25" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2.5" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.5001" x2="0.1999" y2="0.5001" layer="35"/>
+<wire x1="-1" y1="0.6" x2="1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="0.6" x2="1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="-0.6" x2="-1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="-1" y1="-0.6" x2="-1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1.6" y1="-0.75" x2="1.6" y2="0.75" width="0.1" layer="39"/>
+<wire x1="1.6" y1="0.75" x2="-1.6" y2="0.75" width="0.1" layer="39"/>
+<wire x1="-1.6" y1="0.75" x2="-1.6" y2="-0.75" width="0.1" layer="39"/>
+<wire x1="-1.6" y1="-0.75" x2="1.6" y2="-0.75" width="0.1" layer="39"/>
+</package>
+<package name="RESC0805_M" urn="urn:adsk.eagle:footprint:2593716/1" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<smd name="1" x="-1.2" y="0" dx="1.4" dy="1.45" layer="1"/>
+<smd name="2" x="1.2" y="0" dx="1.4" dy="1.45" layer="1"/>
+<text x="-2" y="2" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2" y="-3" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.5001" x2="0.1999" y2="0.5001" layer="35"/>
+<wire x1="-1" y1="0.6" x2="1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="0.6" x2="1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="-0.6" x2="-1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="-1" y1="-0.6" x2="-1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="2.4" y1="-1.2" x2="2.4" y2="1.2" width="0.1" layer="39"/>
+<wire x1="2.4" y1="1.2" x2="-2.4" y2="1.2" width="0.1" layer="39"/>
+<wire x1="-2.4" y1="1.2" x2="-2.4" y2="-1.2" width="0.1" layer="39"/>
+<wire x1="-2.4" y1="-1.2" x2="2.4" y2="-1.2" width="0.1" layer="39"/>
+</package>
+<package name="RESC0805_N" urn="urn:adsk.eagle:footprint:2593715/1" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<smd name="1" x="-1.1" y="0" dx="1.2" dy="1.35" layer="1"/>
+<smd name="2" x="1" y="0" dx="1.2" dy="1.35" layer="1"/>
+<text x="-1" y="1.5" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2.5" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1999" y1="-0.5001" x2="0.1999" y2="0.5001" layer="35"/>
+<wire x1="-1" y1="0.6" x2="1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="0.6" x2="1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="1" y1="-0.6" x2="-1" y2="-0.6" width="0.127" layer="51"/>
+<wire x1="-1" y1="-0.6" x2="-1" y2="0.6" width="0.127" layer="51"/>
+<wire x1="1.85" y1="-0.95" x2="1.85" y2="0.95" width="0.1" layer="39"/>
+<wire x1="1.85" y1="0.95" x2="-1.95" y2="0.95" width="0.1" layer="39"/>
+<wire x1="-1.95" y1="0.95" x2="-1.95" y2="-0.95" width="0.1" layer="39"/>
+<wire x1="-1.95" y1="-0.95" x2="1.85" y2="-0.95" width="0.1" layer="39"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="RESC0402_L" urn="urn:adsk.eagle:package:2593728/1" type="box" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC High Density</description>
+<packageinstances>
+<packageinstance name="RESC0402_L"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0201_L" urn="urn:adsk.eagle:package:2593725/1" type="box" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC High Density</description>
+<packageinstances>
+<packageinstance name="RESC0201_L"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0201_M" urn="urn:adsk.eagle:package:2593731/1" type="box" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<packageinstances>
+<packageinstance name="RESC0201_M"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0201_N" urn="urn:adsk.eagle:package:2593730/1" type="box" library_version="8">
+<description>&lt;b&gt;0201&lt;/b&gt; chip&lt;p&gt;
+0201 (imperial)&lt;br/&gt;
+0603 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<packageinstances>
+<packageinstance name="RESC0201_N"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0402_M" urn="urn:adsk.eagle:package:2593733/1" type="box" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<packageinstances>
+<packageinstance name="RESC0402_M"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0402_N" urn="urn:adsk.eagle:package:2593732/1" type="box" library_version="8">
+<description>&lt;b&gt;0402&lt;/b&gt; chip &lt;p&gt;
+
+0402 (imperial)&lt;br/&gt;
+1005 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<packageinstances>
+<packageinstance name="RESC0402_N"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0603_L" urn="urn:adsk.eagle:package:2593727/1" type="box" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC High Density</description>
+<packageinstances>
+<packageinstance name="RESC0603_L"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0603_M" urn="urn:adsk.eagle:package:2593735/1" type="box" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC High Density</description>
+<packageinstances>
+<packageinstance name="RESC0603_M"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0603_N" urn="urn:adsk.eagle:package:2593734/1" type="box" library_version="8">
+<description>&lt;b&gt;0603&lt;/b&gt; chip &lt;p&gt;
+
+0603 (imperial)&lt;br/&gt;
+1608 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<packageinstances>
+<packageinstance name="RESC0603_N"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0805_L" urn="urn:adsk.eagle:package:2593726/1" type="box" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC High Density</description>
+<packageinstances>
+<packageinstance name="RESC0805_L"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0805_M" urn="urn:adsk.eagle:package:2593737/1" type="box" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC Low Density</description>
+<packageinstances>
+<packageinstance name="RESC0805_M"/>
+</packageinstances>
+</package3d>
+<package3d name="RESC0805_N" urn="urn:adsk.eagle:package:2593736/1" type="box" library_version="8">
+<description>&lt;b&gt;0805&lt;/b&gt;chip&lt;p&gt;
+
+0805 (imperial)&lt;br/&gt;
+2012 (metric)&lt;br/&gt;
+IPC Nominal Density</description>
+<packageinstances>
+<packageinstance name="RESC0805_N"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="L-US" urn="urn:adsk.eagle:symbol:2593693/1" library_version="8">
+<wire x1="0" y1="5.08" x2="1.27" y2="3.81" width="0.254" layer="94" curve="-90"/>
+<wire x1="0" y1="2.54" x2="1.27" y2="3.81" width="0.254" layer="94" curve="90"/>
+<wire x1="0" y1="2.54" x2="1.27" y2="1.27" width="0.254" layer="94" curve="-90"/>
+<wire x1="0" y1="0" x2="1.27" y2="1.27" width="0.254" layer="94" curve="90"/>
+<wire x1="0" y1="0" x2="1.27" y2="-1.27" width="0.254" layer="94" curve="-90"/>
+<wire x1="0" y1="-2.54" x2="1.27" y2="-1.27" width="0.254" layer="94" curve="90"/>
+<wire x1="0" y1="-2.54" x2="1.27" y2="-3.81" width="0.254" layer="94" curve="-90"/>
+<wire x1="0" y1="-5.08" x2="1.27" y2="-3.81" width="0.254" layer="94" curve="90"/>
+<text x="-1.27" y="-5.08" size="1.778" layer="95" rot="R90">&gt;NAME</text>
+<text x="3.81" y="-5.08" size="1.778" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="2" x="0" y="-7.62" visible="off" length="short" direction="pas" swaplevel="1" rot="R90"/>
+<pin name="1" x="0" y="7.62" visible="off" length="short" direction="pas" swaplevel="1" rot="R270"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="INDUCTOR" urn="urn:adsk.eagle:component:2593748/1" uservalue="yes" library_version="8">
+<description>&lt;b&gt;Generic chip inductor&lt;/b&gt;</description>
+<gates>
+<gate name="L$1" symbol="L-US" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_0402_L" package="RESC0402_L">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593728/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0201_L" package="RESC0201_L">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593725/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0201_M" package="RESC0201_M">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593731/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0201_N" package="RESC0201_N">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593730/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402_M" package="RESC0402_M">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593733/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402_N" package="RESC0402_N">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593732/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603_L" package="RESC0603_L">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593727/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603_M" package="RESC0603_M">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593735/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603_N" package="RESC0603_N">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593734/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805_L" package="RESC0805_L">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593726/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805_M" package="RESC0805_M">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593737/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805_N" package="RESC0805_N">
+<connects>
+<connect gate="L$1" pin="1" pad="1"/>
+<connect gate="L$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:2593736/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="UnexpectedMaker">
+<description>Generated from &lt;b&gt;WattsSegment_Display.sch&lt;/b&gt;&lt;p&gt;
+by exp-lbrs.ulp</description>
+<packages>
+<package name="SOP8" urn="urn:adsk.eagle:footprint:26249/1" locally_modified="yes">
+<description>&lt;b&gt;SOP8&lt;/b&gt;&lt;p&gt;
+Source: http://www.rohm.com/products/databook/motor/pdf/bd623x_series-e.pdf</description>
+<wire x1="2.395" y1="-2.11" x2="-2.395" y2="-2.11" width="0.2032" layer="51"/>
+<wire x1="-2.649" y1="-2.11" x2="-2.649" y2="2.085" width="0.2032" layer="21"/>
+<wire x1="-2.395" y1="2.085" x2="2.395" y2="2.085" width="0.2032" layer="51"/>
+<wire x1="-2.594" y1="0.635" x2="-2.594" y2="-0.635" width="0.2032" layer="21" curve="-180"/>
+<smd name="1" x="-1.905" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="2" x="-0.635" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="3" x="0.635" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="4" x="1.905" y="-2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="5" x="1.905" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="6" x="0.635" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="7" x="-0.635" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<smd name="8" x="-1.905" y="2.6" dx="0.6" dy="1.6" layer="1"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<text x="4.445" y="-3.175" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+<rectangle x1="-2.1549" y1="-3.1" x2="-1.6551" y2="-2.2" layer="51"/>
+<rectangle x1="-0.8849" y1="-3.1" x2="-0.3851" y2="-2.2" layer="51"/>
+<rectangle x1="0.3851" y1="-3.1" x2="0.8849" y2="-2.2" layer="51"/>
+<rectangle x1="1.6551" y1="-3.1" x2="2.1549" y2="-2.2" layer="51"/>
+<rectangle x1="1.6551" y1="2.2" x2="2.1549" y2="3.1" layer="51"/>
+<rectangle x1="0.3851" y1="2.2" x2="0.8849" y2="3.1" layer="51"/>
+<rectangle x1="-0.8849" y1="2.2" x2="-0.3851" y2="3.1" layer="51"/>
+<rectangle x1="-2.1549" y1="2.2" x2="-1.6551" y2="3.1" layer="51"/>
+</package>
+<package name="PICO-D4-QFN48">
+<description>&lt;b&gt;48-pin QFN 7 x 7 mm LF48&lt;/b&gt;&lt;p&gt;
+48 Quad Flat Package No Leads&lt;br&gt;
+Source: http://v4.cypress.com/cfuploads/img/products/cywusb6934.pdf</description>
+<wire x1="-3" y1="3.5" x2="3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="3.5" x2="3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="3" x2="3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="3.5" y1="-3" x2="3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="3" y1="-3.5" x2="-3" y2="-3.5" width="0.1016" layer="51"/>
+<wire x1="-3" y1="-3.5" x2="-3.5" y2="-3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="-3" x2="-3.5" y2="3" width="0.1016" layer="51"/>
+<wire x1="-3.5" y1="3" x2="-3" y2="3.5" width="0.1016" layer="51"/>
+<wire x1="-3.5916" y1="2.84" x2="-3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.84" x2="-3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.66" x2="-3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.66" x2="-3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.75" x2="-3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.845" x2="-3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.845" x2="-3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.655" x2="-3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.655" x2="-3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="2.75" x2="-3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="2.34" x2="-3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.34" x2="-3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="2.16" x2="-3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="2.16" x2="-3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="2.25" x2="-3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="2.345" x2="-3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.345" x2="-3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="2.155" x2="-3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="2.155" x2="-3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="2.25" x2="-3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.84" x2="-3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.84" x2="-3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.66" x2="-3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.66" x2="-3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="1.75" x2="-3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.845" x2="-3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.845" x2="-3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.655" x2="-3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.655" x2="-3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="1.75" x2="-3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="1.34" x2="-3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.34" x2="-3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="1.16" x2="-3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="1.16" x2="-3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="1.25" x2="-3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="1.345" x2="-3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.345" x2="-3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="1.155" x2="-3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="1.155" x2="-3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="1.25" x2="-3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.84" x2="-3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.84" x2="-3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.66" x2="-3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.66" x2="-3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.75" x2="-3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.845" x2="-3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.845" x2="-3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.655" x2="-3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.655" x2="-3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="0.75" x2="-3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="0.34" x2="-3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.34" x2="-3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="0.16" x2="-3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="0.16" x2="-3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="0.25" x2="-3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="0.345" x2="-3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.345" x2="-3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="0.155" x2="-3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="0.155" x2="-3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="-3.5593" y1="0.25" x2="-3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.16" x2="-3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.16" x2="-3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.34" x2="-3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.34" x2="-3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.25" x2="-3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.155" x2="-3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.155" x2="-3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.345" x2="-3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.345" x2="-3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-0.25" x2="-3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-0.66" x2="-3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.66" x2="-3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-0.84" x2="-3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-0.84" x2="-3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-0.75" x2="-3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-0.655" x2="-3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.655" x2="-3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-0.845" x2="-3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-0.845" x2="-3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-0.75" x2="-3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.16" x2="-3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.16" x2="-3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.34" x2="-3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.34" x2="-3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-1.25" x2="-3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.155" x2="-3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.155" x2="-3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.345" x2="-3.60295" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.345" x2="-3.60295" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="-3.54025" y1="-1.25" x2="-3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-1.66" x2="-3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.66" x2="-3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-1.84" x2="-3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-1.84" x2="-3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-1.75" x2="-3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-1.655" x2="-3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.655" x2="-3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-1.845" x2="-3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-1.845" x2="-3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="-3.5466" y1="-1.75" x2="-3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.16" x2="-3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.16" x2="-3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.34" x2="-3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.34" x2="-3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="-3.5416" y1="-2.25" x2="-3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.155" x2="-3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.155" x2="-3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.345" x2="-3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.345" x2="-3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="-3.56565" y1="-2.25" x2="-3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="-3.5916" y1="-2.66" x2="-3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.66" x2="-3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.06" y1="-2.84" x2="-3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="-3.5916" y1="-2.84" x2="-3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="-3.567" y1="-2.75" x2="-3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="-3.60295" y1="-2.655" x2="-3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.655" x2="-3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.055" y1="-2.845" x2="-3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="-3.60295" y1="-2.845" x2="-3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="-3.55295" y1="-2.75" x2="-3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="-2.84" y1="-3.5916" x2="-2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="-3.06" x2="-2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.06" x2="-2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="-3.5916" x2="-2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="-3.5416" x2="-2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.845" y1="-3.60295" x2="-2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="-3.055" x2="-2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.055" x2="-2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="-3.60295" x2="-2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="-3.5593" x2="-2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-2.34" y1="-3.5916" x2="-2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="-3.06" x2="-2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.06" x2="-2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="-3.5916" x2="-2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="-3.5416" x2="-2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-2.345" y1="-3.60295" x2="-2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="-3.055" x2="-2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.055" x2="-2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="-3.60295" x2="-2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="-3.5593" x2="-2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.84" y1="-3.5916" x2="-1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="-3.06" x2="-1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.06" x2="-1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="-3.5916" x2="-1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="-3.5416" x2="-1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.845" y1="-3.60295" x2="-1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="-3.055" x2="-1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.055" x2="-1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="-3.60295" x2="-1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="-3.5593" x2="-1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-1.34" y1="-3.5916" x2="-1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="-3.06" x2="-1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.06" x2="-1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="-3.5916" x2="-1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="-3.5416" x2="-1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-1.345" y1="-3.60295" x2="-1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="-3.055" x2="-1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.055" x2="-1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="-3.60295" x2="-1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="-3.55295" x2="-1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.84" y1="-3.5916" x2="-0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="-3.06" x2="-0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.06" x2="-0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="-3.5916" x2="-0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="-3.567" x2="-0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.845" y1="-3.60295" x2="-0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="-3.055" x2="-0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.055" x2="-0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="-3.60295" x2="-0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="-3.56565" x2="-0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="-0.34" y1="-3.5916" x2="-0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="-3.06" x2="-0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.06" x2="-0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="-3.5916" x2="-0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="-3.5416" x2="-0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="-0.345" y1="-3.60295" x2="-0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="-3.055" x2="-0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.055" x2="-0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="-3.60295" x2="-0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="-3.55295" x2="-0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.16" y1="-3.5916" x2="0.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="-3.06" x2="0.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.06" x2="0.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="-3.5916" x2="0.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="-3.5416" x2="0.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.155" y1="-3.60295" x2="0.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="-3.055" x2="0.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.055" x2="0.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="-3.60295" x2="0.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="-3.5593" x2="0.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="0.66" y1="-3.5916" x2="0.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="-3.06" x2="0.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.06" x2="0.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="-3.5916" x2="0.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="-3.5416" x2="0.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="0.655" y1="-3.60295" x2="0.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="-3.055" x2="0.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.055" x2="0.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="-3.60295" x2="0.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="-3.572" x2="0.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.16" y1="-3.5916" x2="1.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="-3.06" x2="1.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.06" x2="1.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="-3.5916" x2="1.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="-3.5416" x2="1.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.155" y1="-3.60295" x2="1.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="-3.055" x2="1.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.055" x2="1.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="-3.60295" x2="1.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="-3.56565" x2="1.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="1.66" y1="-3.5916" x2="1.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="-3.06" x2="1.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.06" x2="1.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="-3.5916" x2="1.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="-3.5416" x2="1.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="1.655" y1="-3.60295" x2="1.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="-3.055" x2="1.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.055" x2="1.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="-3.60295" x2="1.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="-3.56565" x2="1.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.16" y1="-3.5916" x2="2.16" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="-3.06" x2="2.34" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.06" x2="2.34" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="-3.5916" x2="2.16" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="-3.5416" x2="2.25" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.155" y1="-3.60295" x2="2.155" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="-3.055" x2="2.345" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.055" x2="2.345" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="-3.60295" x2="2.155" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="-3.5466" x2="2.25" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="2.66" y1="-3.5916" x2="2.66" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="-3.06" x2="2.84" y2="-3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.06" x2="2.84" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="-3.5916" x2="2.66" y2="-3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="-3.5416" x2="2.75" y2="-3.11" width="0.1016" layer="31"/>
+<wire x1="2.655" y1="-3.60295" x2="2.655" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="-3.055" x2="2.845" y2="-3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.055" x2="2.845" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="-3.60295" x2="2.655" y2="-3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="-3.54025" x2="2.75" y2="-3.105" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.84" x2="3.06" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.84" x2="3.06" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.66" x2="3.5916" y2="-2.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.66" x2="3.5916" y2="-2.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.75" x2="3.11" y2="-2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.845" x2="3.055" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.845" x2="3.055" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.655" x2="3.60295" y2="-2.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.655" x2="3.60295" y2="-2.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-2.75" x2="3.105" y2="-2.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-2.34" x2="3.06" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.34" x2="3.06" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-2.16" x2="3.5916" y2="-2.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-2.16" x2="3.5916" y2="-2.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-2.25" x2="3.11" y2="-2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-2.345" x2="3.055" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.345" x2="3.055" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-2.155" x2="3.60295" y2="-2.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-2.155" x2="3.60295" y2="-2.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-2.25" x2="3.105" y2="-2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.84" x2="3.06" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.84" x2="3.06" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.66" x2="3.5916" y2="-1.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.66" x2="3.5916" y2="-1.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.75" x2="3.11" y2="-1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.845" x2="3.055" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.845" x2="3.055" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.655" x2="3.60295" y2="-1.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.655" x2="3.60295" y2="-1.845" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="-1.75" x2="3.105" y2="-1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-1.34" x2="3.06" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.34" x2="3.06" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-1.16" x2="3.5916" y2="-1.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-1.16" x2="3.5916" y2="-1.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-1.25" x2="3.11" y2="-1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-1.35135" x2="3.055" y2="-1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.345" x2="3.055" y2="-1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-1.155" x2="3.60295" y2="-1.16135" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-1.16135" x2="3.60295" y2="-1.35135" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-1.25" x2="3.105" y2="-1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.84" x2="3.06" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.84" x2="3.06" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.66" x2="3.5916" y2="-0.66" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.66" x2="3.5916" y2="-0.84" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.75" x2="3.11" y2="-0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.845" x2="3.055" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.845" x2="3.055" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.655" x2="3.60295" y2="-0.655" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.655" x2="3.60295" y2="-0.845" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.75" x2="3.105" y2="-0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="-0.34" x2="3.06" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.34" x2="3.06" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="-0.16" x2="3.5916" y2="-0.16" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="-0.16" x2="3.5916" y2="-0.34" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="-0.25" x2="3.11" y2="-0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="-0.345" x2="3.055" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.345" x2="3.055" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="-0.155" x2="3.60295" y2="-0.155" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="-0.155" x2="3.60295" y2="-0.345" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="-0.25" x2="3.105" y2="-0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.16" x2="3.06" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.16" x2="3.06" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.34" x2="3.5916" y2="0.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.34" x2="3.5916" y2="0.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.25" x2="3.11" y2="0.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.155" x2="3.055" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.155" x2="3.055" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.345" x2="3.60295" y2="0.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.345" x2="3.60295" y2="0.155" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.25" x2="3.105" y2="0.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="0.66" x2="3.06" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.66" x2="3.06" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="0.84" x2="3.5916" y2="0.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="0.84" x2="3.5916" y2="0.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="0.75" x2="3.11" y2="0.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="0.655" x2="3.055" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.655" x2="3.055" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="0.845" x2="3.60295" y2="0.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="0.845" x2="3.60295" y2="0.655" width="0.1016" layer="29"/>
+<wire x1="3.5593" y1="0.75" x2="3.105" y2="0.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.16" x2="3.06" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.16" x2="3.06" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.34" x2="3.5916" y2="1.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.34" x2="3.5916" y2="1.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="1.25" x2="3.11" y2="1.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.155" x2="3.055" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.155" x2="3.055" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.345" x2="3.60295" y2="1.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.345" x2="3.60295" y2="1.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.25" x2="3.105" y2="1.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="1.66" x2="3.06" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.66" x2="3.06" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="1.84" x2="3.5916" y2="1.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="1.84" x2="3.5916" y2="1.66" width="0.1016" layer="31"/>
+<wire x1="3.567" y1="1.75" x2="3.11" y2="1.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="1.655" x2="3.055" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.655" x2="3.055" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="1.845" x2="3.60295" y2="1.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="1.845" x2="3.60295" y2="1.655" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="1.75" x2="3.105" y2="1.75" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.16" x2="3.06" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.16" x2="3.06" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.34" x2="3.5916" y2="2.34" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.34" x2="3.5916" y2="2.16" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.25" x2="3.11" y2="2.25" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.155" x2="3.055" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.155" x2="3.055" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.345" x2="3.60295" y2="2.345" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.345" x2="3.60295" y2="2.155" width="0.1016" layer="29"/>
+<wire x1="3.55295" y1="2.25" x2="3.105" y2="2.25" width="0.1016" layer="29"/>
+<wire x1="3.5916" y1="2.66" x2="3.06" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.66" x2="3.06" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.06" y1="2.84" x2="3.5916" y2="2.84" width="0.1016" layer="31"/>
+<wire x1="3.5916" y1="2.84" x2="3.5916" y2="2.66" width="0.1016" layer="31"/>
+<wire x1="3.5416" y1="2.75" x2="3.11" y2="2.75" width="0.1016" layer="31"/>
+<wire x1="3.60295" y1="2.655" x2="3.055" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.655" x2="3.055" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.055" y1="2.845" x2="3.60295" y2="2.845" width="0.1016" layer="29"/>
+<wire x1="3.60295" y1="2.845" x2="3.60295" y2="2.655" width="0.1016" layer="29"/>
+<wire x1="3.5466" y1="2.75" x2="3.105" y2="2.75" width="0.1016" layer="29"/>
+<wire x1="2.84" y1="3.5916" x2="2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.84" y1="3.06" x2="2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.06" x2="2.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.66" y1="3.5916" x2="2.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.75" y1="3.5416" x2="2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.845" y1="3.60295" x2="2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.845" y1="3.055" x2="2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.055" x2="2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.655" y1="3.60295" x2="2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.75" y1="3.55295" x2="2.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="2.34" y1="3.5916" x2="2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.34" y1="3.06" x2="2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.06" x2="2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.16" y1="3.5916" x2="2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="2.25" y1="3.5162" x2="2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="2.345" y1="3.60295" x2="2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.345" y1="3.055" x2="2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.055" x2="2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.155" y1="3.60295" x2="2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="2.25" y1="3.56565" x2="2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.84" y1="3.5916" x2="1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.84" y1="3.06" x2="1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.06" x2="1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.66" y1="3.5916" x2="1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.75" y1="3.5416" x2="1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.845" y1="3.60295" x2="1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.845" y1="3.055" x2="1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.055" x2="1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.655" y1="3.60295" x2="1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.75" y1="3.55295" x2="1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="1.34" y1="3.5916" x2="1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.34" y1="3.06" x2="1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.06" x2="1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.16" y1="3.5916" x2="1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="1.25" y1="3.5416" x2="1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="1.345" y1="3.60295" x2="1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.345" y1="3.055" x2="1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.055" x2="1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.155" y1="3.60295" x2="1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="1.25" y1="3.5466" x2="1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.84" y1="3.5916" x2="0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.84" y1="3.06" x2="0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.06" x2="0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.66" y1="3.5916" x2="0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.75" y1="3.5416" x2="0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.845" y1="3.60295" x2="0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.845" y1="3.055" x2="0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.055" x2="0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.655" y1="3.60295" x2="0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.75" y1="3.54025" x2="0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="0.34" y1="3.5916" x2="0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.34" y1="3.06" x2="0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.06" x2="0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.16" y1="3.5916" x2="0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="0.25" y1="3.5416" x2="0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="0.345" y1="3.60295" x2="0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.345" y1="3.055" x2="0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.055" x2="0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.155" y1="3.60295" x2="0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="0.25" y1="3.5466" x2="0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.16" y1="3.5916" x2="-0.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.16" y1="3.06" x2="-0.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.06" x2="-0.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.34" y1="3.5916" x2="-0.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.25" y1="3.567" x2="-0.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.155" y1="3.60295" x2="-0.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.155" y1="3.055" x2="-0.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.055" x2="-0.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.345" y1="3.60295" x2="-0.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.25" y1="3.5466" x2="-0.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-0.66" y1="3.5916" x2="-0.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.66" y1="3.06" x2="-0.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.06" x2="-0.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.84" y1="3.5916" x2="-0.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-0.75" y1="3.567" x2="-0.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-0.655" y1="3.60295" x2="-0.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.655" y1="3.055" x2="-0.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.055" x2="-0.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.845" y1="3.60295" x2="-0.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-0.75" y1="3.5466" x2="-0.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.16" y1="3.5916" x2="-1.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.16" y1="3.06" x2="-1.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.06" x2="-1.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.34" y1="3.5916" x2="-1.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.25" y1="3.5416" x2="-1.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.155" y1="3.60295" x2="-1.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.155" y1="3.055" x2="-1.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.055" x2="-1.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.345" y1="3.60295" x2="-1.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.25" y1="3.5593" x2="-1.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-1.66" y1="3.5916" x2="-1.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.66" y1="3.06" x2="-1.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.06" x2="-1.84" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.84" y1="3.5916" x2="-1.66" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-1.75" y1="3.567" x2="-1.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-1.655" y1="3.60295" x2="-1.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.655" y1="3.055" x2="-1.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.055" x2="-1.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.845" y1="3.60295" x2="-1.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-1.75" y1="3.572" x2="-1.75" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.16" y1="3.5916" x2="-2.16" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.16" y1="3.06" x2="-2.34" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.06" x2="-2.34" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.34" y1="3.5916" x2="-2.16" y2="3.5916" width="0.1016" layer="31"/>
+<wire x1="-2.25" y1="3.5416" x2="-2.25" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.155" y1="3.60295" x2="-2.155" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.155" y1="3.055" x2="-2.345" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.055" x2="-2.345" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.345" y1="3.60295" x2="-2.155" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.25" y1="3.5593" x2="-2.25" y2="3.105" width="0.1016" layer="29"/>
+<wire x1="-2.66" y1="3.5941" x2="-2.66" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.66" y1="3.06" x2="-2.84" y2="3.06" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.06" x2="-2.84" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.84" y1="3.5941" x2="-2.75" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.66" y2="3.5941" width="0.1016" layer="31"/>
+<wire x1="-2.75" y1="3.5941" x2="-2.75" y2="3.11" width="0.1016" layer="31"/>
+<wire x1="-2.655" y1="3.60295" x2="-2.655" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.655" y1="3.055" x2="-2.845" y2="3.055" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.055" x2="-2.845" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.845" y1="3.60295" x2="-2.655" y2="3.60295" width="0.1016" layer="29"/>
+<wire x1="-2.75" y1="3.572" x2="-2.75" y2="3.105" width="0.1016" layer="29"/>
+<circle x="-3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="-3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="-3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="-0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="0.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="1.75" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.25" radius="0.1151" width="0" layer="51"/>
+<circle x="3.115" y="2.75" radius="0.1151" width="0" layer="51"/>
+<circle x="2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-0.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-1.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.25" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.75" y="3.115" radius="0.1151" width="0" layer="51"/>
+<circle x="-2.5" y="2.5" radius="0.4" width="0" layer="51"/>
+<smd name="EXP" x="0" y="0" dx="4.572" dy="4.572" layer="1" roundness="5" stop="no" cream="no"/>
+<smd name="1" x="-3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="2" x="-3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="-3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="-3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="5" x="-3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="-3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="7" x="-3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="8" x="-3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="9" x="-3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="10" x="-3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="11" x="-3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="12" x="-3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R270" stop="no" cream="no"/>
+<smd name="13" x="-2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="14" x="-2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="15" x="-1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="16" x="-1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="17" x="-0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="18" x="-0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="19" x="0.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="20" x="0.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="21" x="1.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="22" x="1.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="23" x="2.25" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="24" x="2.75" y="-3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" stop="no" cream="no"/>
+<smd name="25" x="3.3274" y="-2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="26" x="3.3274" y="-2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="27" x="3.3274" y="-1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="28" x="3.3274" y="-1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="29" x="3.3274" y="-0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="30" x="3.3274" y="-0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="31" x="3.3274" y="0.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="32" x="3.3274" y="0.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="33" x="3.3274" y="1.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="34" x="3.3274" y="1.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="35" x="3.3274" y="2.25" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="36" x="3.3274" y="2.75" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R90" stop="no" cream="no"/>
+<smd name="37" x="2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="38" x="2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="39" x="1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="40" x="1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="41" x="0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="42" x="0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="43" x="-0.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="44" x="-0.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="45" x="-1.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="46" x="-1.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="47" x="-2.25" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<smd name="48" x="-2.75" y="3.3274" dx="0.3" dy="0.6604" layer="1" roundness="30" rot="R180" stop="no" cream="no"/>
+<text x="-3" y="4" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3" y="-5" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-3.45" y1="2.535" x2="-3.22" y2="2.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="2.035" x2="-3.22" y2="2.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.535" x2="-3.22" y2="1.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="1.035" x2="-3.22" y2="1.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.535" x2="-3.22" y2="0.965" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="0.035" x2="-3.22" y2="0.465" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.465" x2="-3.22" y2="-0.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-0.965" x2="-3.22" y2="-0.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.465" x2="-3.22" y2="-1.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-1.965" x2="-3.22" y2="-1.535" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.465" x2="-3.22" y2="-2.035" layer="51" rot="R270"/>
+<rectangle x1="-3.45" y1="-2.965" x2="-3.22" y2="-2.535" layer="51" rot="R270"/>
+<rectangle x1="-2.865" y1="-3.55" x2="-2.635" y2="-3.12" layer="51"/>
+<rectangle x1="-2.365" y1="-3.55" x2="-2.135" y2="-3.12" layer="51"/>
+<rectangle x1="-1.865" y1="-3.55" x2="-1.635" y2="-3.12" layer="51"/>
+<rectangle x1="-1.365" y1="-3.55" x2="-1.135" y2="-3.12" layer="51"/>
+<rectangle x1="-0.865" y1="-3.55" x2="-0.635" y2="-3.12" layer="51"/>
+<rectangle x1="-0.365" y1="-3.55" x2="-0.135" y2="-3.12" layer="51"/>
+<rectangle x1="0.135" y1="-3.55" x2="0.365" y2="-3.12" layer="51"/>
+<rectangle x1="0.635" y1="-3.55" x2="0.865" y2="-3.12" layer="51"/>
+<rectangle x1="1.135" y1="-3.55" x2="1.365" y2="-3.12" layer="51"/>
+<rectangle x1="1.635" y1="-3.55" x2="1.865" y2="-3.12" layer="51"/>
+<rectangle x1="2.135" y1="-3.55" x2="2.365" y2="-3.12" layer="51"/>
+<rectangle x1="2.635" y1="-3.55" x2="2.865" y2="-3.12" layer="51"/>
+<rectangle x1="3.22" y1="-2.965" x2="3.45" y2="-2.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-2.465" x2="3.45" y2="-2.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.965" x2="3.45" y2="-1.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-1.465" x2="3.45" y2="-1.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.965" x2="3.45" y2="-0.535" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="-0.465" x2="3.45" y2="-0.035" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.035" x2="3.45" y2="0.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="0.535" x2="3.45" y2="0.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.035" x2="3.45" y2="1.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="1.535" x2="3.45" y2="1.965" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.035" x2="3.45" y2="2.465" layer="51" rot="R90"/>
+<rectangle x1="3.22" y1="2.535" x2="3.45" y2="2.965" layer="51" rot="R90"/>
+<rectangle x1="2.635" y1="3.12" x2="2.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="2.135" y1="3.12" x2="2.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.635" y1="3.12" x2="1.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="1.135" y1="3.12" x2="1.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.635" y1="3.12" x2="0.865" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="0.135" y1="3.12" x2="0.365" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.365" y1="3.12" x2="-0.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-0.865" y1="3.12" x2="-0.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.365" y1="3.12" x2="-1.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-1.865" y1="3.12" x2="-1.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.365" y1="3.12" x2="-2.135" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.865" y1="3.12" x2="-2.635" y2="3.55" layer="51" rot="R180"/>
+<rectangle x1="-2.286" y1="-2.286" x2="2.286" y2="2.286" layer="29"/>
+<wire x1="-2.667" y1="1.27" x2="-2.667" y2="2.667" width="0.127" layer="25"/>
+<wire x1="-2.667" y1="2.667" x2="-1.27" y2="2.667" width="0.127" layer="25"/>
+<rectangle x1="-2.159" y1="1.016" x2="-1.016" y2="2.159" layer="31"/>
+<rectangle x1="1.016" y1="1.016" x2="2.159" y2="2.159" layer="31"/>
+<rectangle x1="-0.5715" y1="1.016" x2="0.5715" y2="2.159" layer="31"/>
+<rectangle x1="1.016" y1="-2.159" x2="2.159" y2="-1.016" layer="31"/>
+<rectangle x1="-2.159" y1="-2.159" x2="-1.016" y2="-1.016" layer="31"/>
+<rectangle x1="-0.5715" y1="-2.159" x2="0.5715" y2="-1.016" layer="31"/>
+<rectangle x1="-2.159" y1="-0.5715" x2="-1.016" y2="0.5715" layer="31"/>
+<rectangle x1="-0.5715" y1="-0.5715" x2="0.5715" y2="0.5715" layer="31"/>
+<rectangle x1="1.016" y1="-0.5715" x2="2.159" y2="0.5715" layer="31"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="SOP8" urn="urn:adsk.eagle:package:26262/1" locally_modified="yes" type="box">
+<description>SOP8
+Source: http://www.rohm.com/products/databook/motor/pdf/bd623x_series-e.pdf</description>
+<packageinstances>
+<packageinstance name="SOP8"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="LY68L6400SLIT">
+<wire x1="-7.62" y1="10.16" x2="10.16" y2="10.16" width="0.254" layer="94"/>
+<wire x1="10.16" y1="10.16" x2="10.16" y2="-10.16" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-10.16" x2="-7.62" y2="-10.16" width="0.254" layer="94"/>
+<wire x1="-7.62" y1="-10.16" x2="-7.62" y2="10.16" width="0.254" layer="94"/>
+<text x="-7.62" y="11.43" size="1.778" layer="95">&gt;NAME</text>
+<text x="-7.62" y="-12.7" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="CE" x="-10.16" y="7.62" length="short" direction="out"/>
+<pin name="SIO3" x="12.7" y="2.54" length="short" direction="out" rot="R180"/>
+<pin name="GND" x="-10.16" y="-7.62" length="short" direction="in"/>
+<pin name="SIO0" x="12.7" y="-7.62" length="short" direction="in" rot="R180"/>
+<pin name="SCLK" x="12.7" y="-2.54" length="short" direction="pas" rot="R180"/>
+<pin name="SIO1" x="-10.16" y="2.54" length="short" direction="pwr"/>
+<pin name="SIO2" x="-10.16" y="-2.54" length="short" direction="pwr"/>
+<pin name="VCC" x="12.7" y="7.62" length="short" direction="pwr" rot="R180"/>
+</symbol>
+<symbol name="CY8C29666">
+<wire x1="-30.48" y1="22.86" x2="-30.48" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-25.4" x2="30.48" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="30.48" y1="-25.4" x2="30.48" y2="25.4" width="0.254" layer="94"/>
+<wire x1="30.48" y1="25.4" x2="-27.94" y2="25.4" width="0.254" layer="94"/>
+<wire x1="-27.94" y1="25.4" x2="-30.48" y2="22.86" width="0.254" layer="94"/>
+<text x="-22.86" y="-20.32" size="1.27" layer="95">&gt;NAME</text>
+<text x="-22.86" y="-22.86" size="1.27" layer="95">&gt;VALUE</text>
+<pin name="VDDA_3" x="-15.24" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="CAP2_NC" x="-17.78" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="CAP1_NC" x="-20.32" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="VDDA" x="-33.02" y="12.7" visible="pin" length="short" swaplevel="1"/>
+<pin name="LNA_IN" x="-33.02" y="10.16" visible="pin" length="short" swaplevel="1"/>
+<pin name="SENSOR_CAPN" x="-33.02" y="-2.54" visible="pin" length="short" direction="pwr" swaplevel="1"/>
+<pin name="IO34" x="-33.02" y="-10.16" visible="pin" length="short" swaplevel="1"/>
+<pin name="VDDA3P3_1" x="-33.02" y="7.62" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO26" x="-2.54" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO27" x="0" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO14" x="2.54" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO12" x="5.08" y="-27.94" visible="pin" length="short" direction="pwr" rot="R90"/>
+<pin name="VDD3P3_RTC" x="7.62" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO13" x="10.16" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO15" x="12.7" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO2" x="15.24" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="SD3" x="33.02" y="0" visible="pin" length="short" rot="R180"/>
+<pin name="IO16" x="33.02" y="-10.16" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="VDD_SDIO_NC" x="33.02" y="-7.62" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO5" x="33.02" y="12.7" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO18" x="33.02" y="15.24" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO23" x="33.02" y="17.78" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="VDD3P3_CPU" x="7.62" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="IO19" x="5.08" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="IO22" x="2.54" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="U0RXD" x="0" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="U0TXD" x="-2.54" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="IO21" x="-5.08" y="27.94" visible="pin" length="short" direction="pwr" rot="R270"/>
+<pin name="VDDA_2" x="-7.62" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="XTAL_N_NC" x="-10.16" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="XTAL_P_NC" x="-12.7" y="27.94" visible="pin" length="short" swaplevel="1" rot="R270"/>
+<pin name="CMD" x="33.02" y="2.54" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="VDDA_3P3" x="-33.02" y="5.08" visible="pin" length="short" swaplevel="1"/>
+<pin name="SENSOR_VP" x="-33.02" y="2.54" visible="pin" length="short" swaplevel="1"/>
+<pin name="SENSOR_CAPP" x="-33.02" y="0" visible="pin" length="short" swaplevel="1"/>
+<pin name="EN" x="-33.02" y="-7.62" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO35" x="-33.02" y="-12.7" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO25" x="-5.08" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="CLK" x="33.02" y="5.08" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD0" x="33.02" y="7.62" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD1" x="33.02" y="10.16" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SENSOR_VN" x="-33.02" y="-5.08" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO17" x="33.02" y="-5.08" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="SD2" x="33.02" y="-2.54" visible="pin" length="short" swaplevel="1" rot="R180"/>
+<pin name="IO32" x="-33.02" y="-15.24" visible="pin" length="short" swaplevel="1"/>
+<pin name="IO33" x="-7.62" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO0" x="17.78" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+<pin name="IO4" x="20.32" y="-27.94" visible="pin" length="short" swaplevel="1" rot="R90"/>
+</symbol>
+<symbol name="GNDPAD">
+<wire x1="0" y1="0" x2="-2.54" y2="2.54" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="2.54" x2="-2.54" y2="12.7" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="12.7" x2="2.54" y2="12.7" width="0.254" layer="94"/>
+<wire x1="2.54" y1="12.7" x2="2.54" y2="2.54" width="0.254" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="0" y2="0" width="0.254" layer="94"/>
+<pin name="GNDPAD" x="0" y="-2.54" visible="pin" length="short" direction="pwr" rot="R90"/>
+</symbol>
+<symbol name="FRAME_A4_TINYPICO">
+<wire x1="256.54" y1="3.81" x2="256.54" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="256.54" y1="13.97" x2="256.54" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="256.54" y1="19.05" x2="256.54" y2="40.33" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="3.81" x2="170.18" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="8.89" x2="170.18" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="13.97" x2="170.18" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="19.05" x2="170.18" y2="40.33" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="40.33" x2="256.54" y2="40.33" width="0.1016" layer="94"/>
+<wire x1="214.63" y1="13.97" x2="214.63" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="214.63" y1="8.89" x2="170.18" y2="8.89" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="13.97" x2="214.63" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="214.63" y1="13.97" x2="232.41" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="232.41" y1="13.97" x2="256.54" y2="13.97" width="0.1016" layer="94"/>
+<wire x1="170.18" y1="19.05" x2="232.41" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="232.41" y1="19.05" x2="256.54" y2="19.05" width="0.1016" layer="94"/>
+<wire x1="214.63" y1="8.89" x2="214.63" y2="3.81" width="0.1016" layer="94"/>
+<text x="182.88" y="15.24" size="2.54" layer="94" font="vector">&gt;TITLE</text>
+<text x="171.45" y="10.16" size="2.286" layer="94" font="vector">&gt;CDATE</text>
+<text x="182.88" y="5.21" size="2.54" layer="94" font="vector">&gt;SHEET_NUM</text>
+<text x="171.416" y="5.083" size="2.54" layer="94" font="vector">Sheet:</text>
+<text x="224.876" y="9.353" size="2.54" layer="94" font="vector">Unexpected Maker</text>
+<frame x1="0" y1="0" x2="260.35" y2="186.69" columns="5" rows="5" layer="94"/>
+<rectangle x1="193.025" y1="20.775" x2="193.325" y2="20.825" layer="94"/>
+<rectangle x1="198.825" y1="20.775" x2="199.325" y2="20.825" layer="94"/>
+<rectangle x1="202.675" y1="20.775" x2="203.025" y2="20.825" layer="94"/>
+<rectangle x1="193.025" y1="20.825" x2="193.425" y2="20.875" layer="94"/>
+<rectangle x1="198.725" y1="20.825" x2="199.475" y2="20.875" layer="94"/>
+<rectangle x1="202.675" y1="20.825" x2="203.075" y2="20.875" layer="94"/>
+<rectangle x1="224.525" y1="20.825" x2="224.825" y2="20.875" layer="94"/>
+<rectangle x1="193.025" y1="20.875" x2="193.475" y2="20.925" layer="94"/>
+<rectangle x1="198.625" y1="20.875" x2="199.525" y2="20.925" layer="94"/>
+<rectangle x1="202.675" y1="20.875" x2="203.175" y2="20.925" layer="94"/>
+<rectangle x1="224.525" y1="20.875" x2="224.825" y2="20.925" layer="94"/>
+<rectangle x1="192.975" y1="20.925" x2="193.525" y2="20.975" layer="94"/>
+<rectangle x1="198.575" y1="20.925" x2="199.625" y2="20.975" layer="94"/>
+<rectangle x1="202.675" y1="20.925" x2="203.175" y2="20.975" layer="94"/>
+<rectangle x1="224.525" y1="20.925" x2="224.825" y2="20.975" layer="94"/>
+<rectangle x1="192.975" y1="20.975" x2="193.575" y2="21.025" layer="94"/>
+<rectangle x1="198.525" y1="20.975" x2="198.975" y2="21.025" layer="94"/>
+<rectangle x1="199.225" y1="20.975" x2="199.675" y2="21.025" layer="94"/>
+<rectangle x1="202.675" y1="20.975" x2="203.225" y2="21.025" layer="94"/>
+<rectangle x1="224.525" y1="20.975" x2="224.825" y2="21.025" layer="94"/>
+<rectangle x1="193.275" y1="21.025" x2="193.575" y2="21.075" layer="94"/>
+<rectangle x1="198.525" y1="21.025" x2="198.825" y2="21.075" layer="94"/>
+<rectangle x1="199.375" y1="21.025" x2="199.675" y2="21.075" layer="94"/>
+<rectangle x1="202.925" y1="21.025" x2="203.225" y2="21.075" layer="94"/>
+<rectangle x1="224.525" y1="21.025" x2="224.825" y2="21.075" layer="94"/>
+<rectangle x1="193.325" y1="21.075" x2="193.575" y2="21.125" layer="94"/>
+<rectangle x1="198.525" y1="21.075" x2="198.775" y2="21.125" layer="94"/>
+<rectangle x1="199.425" y1="21.075" x2="199.725" y2="21.125" layer="94"/>
+<rectangle x1="202.975" y1="21.075" x2="203.275" y2="21.125" layer="94"/>
+<rectangle x1="224.525" y1="21.075" x2="224.825" y2="21.125" layer="94"/>
+<rectangle x1="193.375" y1="21.125" x2="193.625" y2="21.175" layer="94"/>
+<rectangle x1="198.475" y1="21.125" x2="198.775" y2="21.175" layer="94"/>
+<rectangle x1="199.475" y1="21.125" x2="199.725" y2="21.175" layer="94"/>
+<rectangle x1="203.025" y1="21.125" x2="203.275" y2="21.175" layer="94"/>
+<rectangle x1="224.525" y1="21.125" x2="224.825" y2="21.175" layer="94"/>
+<rectangle x1="193.375" y1="21.175" x2="193.625" y2="21.225" layer="94"/>
+<rectangle x1="198.475" y1="21.175" x2="198.725" y2="21.225" layer="94"/>
+<rectangle x1="199.475" y1="21.175" x2="199.775" y2="21.225" layer="94"/>
+<rectangle x1="203.075" y1="21.175" x2="203.325" y2="21.225" layer="94"/>
+<rectangle x1="224.525" y1="21.175" x2="224.825" y2="21.225" layer="94"/>
+<rectangle x1="193.425" y1="21.225" x2="193.675" y2="21.275" layer="94"/>
+<rectangle x1="198.475" y1="21.225" x2="198.575" y2="21.275" layer="94"/>
+<rectangle x1="199.525" y1="21.225" x2="199.775" y2="21.275" layer="94"/>
+<rectangle x1="203.075" y1="21.225" x2="203.325" y2="21.275" layer="94"/>
+<rectangle x1="224.525" y1="21.225" x2="224.825" y2="21.275" layer="94"/>
+<rectangle x1="193.425" y1="21.275" x2="193.675" y2="21.325" layer="94"/>
+<rectangle x1="199.525" y1="21.275" x2="199.775" y2="21.325" layer="94"/>
+<rectangle x1="203.125" y1="21.275" x2="203.375" y2="21.325" layer="94"/>
+<rectangle x1="224.525" y1="21.275" x2="224.825" y2="21.325" layer="94"/>
+<rectangle x1="193.475" y1="21.325" x2="193.725" y2="21.375" layer="94"/>
+<rectangle x1="199.525" y1="21.325" x2="199.775" y2="21.375" layer="94"/>
+<rectangle x1="203.125" y1="21.325" x2="203.375" y2="21.375" layer="94"/>
+<rectangle x1="224.525" y1="21.325" x2="224.825" y2="21.375" layer="94"/>
+<rectangle x1="186.175" y1="21.375" x2="186.425" y2="21.425" layer="94"/>
+<rectangle x1="187.875" y1="21.375" x2="188.125" y2="21.425" layer="94"/>
+<rectangle x1="189.575" y1="21.375" x2="189.825" y2="21.425" layer="94"/>
+<rectangle x1="190.725" y1="21.375" x2="190.925" y2="21.425" layer="94"/>
+<rectangle x1="191.375" y1="21.375" x2="191.625" y2="21.425" layer="94"/>
+<rectangle x1="192.375" y1="21.375" x2="192.625" y2="21.425" layer="94"/>
+<rectangle x1="193.475" y1="21.375" x2="193.725" y2="21.425" layer="94"/>
+<rectangle x1="195.425" y1="21.375" x2="195.625" y2="21.425" layer="94"/>
+<rectangle x1="196.275" y1="21.375" x2="196.525" y2="21.425" layer="94"/>
+<rectangle x1="197.175" y1="21.375" x2="197.425" y2="21.425" layer="94"/>
+<rectangle x1="197.875" y1="21.375" x2="198.125" y2="21.425" layer="94"/>
+<rectangle x1="199.075" y1="21.375" x2="199.125" y2="21.425" layer="94"/>
+<rectangle x1="199.525" y1="21.375" x2="199.775" y2="21.425" layer="94"/>
+<rectangle x1="200.225" y1="21.375" x2="200.425" y2="21.425" layer="94"/>
+<rectangle x1="201.225" y1="21.375" x2="201.425" y2="21.425" layer="94"/>
+<rectangle x1="202.125" y1="21.375" x2="202.475" y2="21.425" layer="94"/>
+<rectangle x1="203.125" y1="21.375" x2="203.375" y2="21.425" layer="94"/>
+<rectangle x1="205.075" y1="21.375" x2="206.675" y2="21.425" layer="94"/>
+<rectangle x1="207.575" y1="21.375" x2="208.175" y2="21.425" layer="94"/>
+<rectangle x1="209.075" y1="21.375" x2="209.325" y2="21.425" layer="94"/>
+<rectangle x1="211.375" y1="21.375" x2="211.925" y2="21.425" layer="94"/>
+<rectangle x1="212.625" y1="21.375" x2="213.975" y2="21.425" layer="94"/>
+<rectangle x1="215.275" y1="21.375" x2="216.025" y2="21.425" layer="94"/>
+<rectangle x1="217.775" y1="21.375" x2="218.275" y2="21.425" layer="94"/>
+<rectangle x1="219.475" y1="21.375" x2="219.725" y2="21.425" layer="94"/>
+<rectangle x1="220.925" y1="21.375" x2="221.425" y2="21.425" layer="94"/>
+<rectangle x1="222.225" y1="21.375" x2="222.425" y2="21.425" layer="94"/>
+<rectangle x1="223.275" y1="21.375" x2="223.725" y2="21.425" layer="94"/>
+<rectangle x1="224.525" y1="21.375" x2="224.825" y2="21.425" layer="94"/>
+<rectangle x1="225.025" y1="21.375" x2="225.425" y2="21.425" layer="94"/>
+<rectangle x1="226.225" y1="21.375" x2="226.475" y2="21.425" layer="94"/>
+<rectangle x1="227.175" y1="21.375" x2="227.375" y2="21.425" layer="94"/>
+<rectangle x1="228.075" y1="21.375" x2="228.275" y2="21.425" layer="94"/>
+<rectangle x1="229.125" y1="21.375" x2="229.625" y2="21.425" layer="94"/>
+<rectangle x1="230.375" y1="21.375" x2="230.625" y2="21.425" layer="94"/>
+<rectangle x1="231.375" y1="21.375" x2="231.625" y2="21.425" layer="94"/>
+<rectangle x1="232.275" y1="21.375" x2="232.625" y2="21.425" layer="94"/>
+<rectangle x1="233.775" y1="21.375" x2="234.575" y2="21.425" layer="94"/>
+<rectangle x1="236.075" y1="21.375" x2="236.575" y2="21.425" layer="94"/>
+<rectangle x1="237.575" y1="21.375" x2="238.075" y2="21.425" layer="94"/>
+<rectangle x1="238.475" y1="21.375" x2="238.725" y2="21.425" layer="94"/>
+<rectangle x1="239.075" y1="21.375" x2="239.275" y2="21.425" layer="94"/>
+<rectangle x1="240.425" y1="21.375" x2="240.825" y2="21.425" layer="94"/>
+<rectangle x1="241.075" y1="21.375" x2="241.275" y2="21.425" layer="94"/>
+<rectangle x1="186.175" y1="21.425" x2="186.475" y2="21.475" layer="94"/>
+<rectangle x1="187.825" y1="21.425" x2="188.125" y2="21.475" layer="94"/>
+<rectangle x1="189.575" y1="21.425" x2="189.825" y2="21.475" layer="94"/>
+<rectangle x1="190.675" y1="21.425" x2="190.975" y2="21.475" layer="94"/>
+<rectangle x1="191.375" y1="21.425" x2="191.625" y2="21.475" layer="94"/>
+<rectangle x1="192.375" y1="21.425" x2="192.625" y2="21.475" layer="94"/>
+<rectangle x1="193.425" y1="21.425" x2="193.725" y2="21.475" layer="94"/>
+<rectangle x1="195.375" y1="21.425" x2="195.675" y2="21.475" layer="94"/>
+<rectangle x1="196.275" y1="21.425" x2="196.575" y2="21.475" layer="94"/>
+<rectangle x1="197.175" y1="21.425" x2="197.425" y2="21.475" layer="94"/>
+<rectangle x1="197.875" y1="21.425" x2="198.125" y2="21.475" layer="94"/>
+<rectangle x1="198.825" y1="21.425" x2="199.325" y2="21.475" layer="94"/>
+<rectangle x1="199.525" y1="21.425" x2="199.775" y2="21.475" layer="94"/>
+<rectangle x1="200.175" y1="21.425" x2="200.475" y2="21.475" layer="94"/>
+<rectangle x1="201.175" y1="21.425" x2="201.475" y2="21.475" layer="94"/>
+<rectangle x1="202.025" y1="21.425" x2="202.475" y2="21.475" layer="94"/>
+<rectangle x1="203.125" y1="21.425" x2="203.425" y2="21.475" layer="94"/>
+<rectangle x1="205.075" y1="21.425" x2="206.675" y2="21.475" layer="94"/>
+<rectangle x1="207.375" y1="21.425" x2="208.325" y2="21.475" layer="94"/>
+<rectangle x1="209.075" y1="21.425" x2="209.325" y2="21.475" layer="94"/>
+<rectangle x1="211.325" y1="21.425" x2="212.025" y2="21.475" layer="94"/>
+<rectangle x1="212.625" y1="21.425" x2="214.025" y2="21.475" layer="94"/>
+<rectangle x1="215.225" y1="21.425" x2="216.375" y2="21.475" layer="94"/>
+<rectangle x1="217.625" y1="21.425" x2="218.375" y2="21.475" layer="94"/>
+<rectangle x1="219.425" y1="21.425" x2="219.725" y2="21.475" layer="94"/>
+<rectangle x1="220.825" y1="21.425" x2="221.525" y2="21.475" layer="94"/>
+<rectangle x1="222.225" y1="21.425" x2="222.475" y2="21.475" layer="94"/>
+<rectangle x1="223.125" y1="21.425" x2="223.875" y2="21.475" layer="94"/>
+<rectangle x1="224.525" y1="21.425" x2="224.825" y2="21.475" layer="94"/>
+<rectangle x1="224.925" y1="21.425" x2="225.525" y2="21.475" layer="94"/>
+<rectangle x1="226.225" y1="21.425" x2="226.475" y2="21.475" layer="94"/>
+<rectangle x1="227.125" y1="21.425" x2="227.375" y2="21.475" layer="94"/>
+<rectangle x1="228.075" y1="21.425" x2="228.325" y2="21.475" layer="94"/>
+<rectangle x1="228.975" y1="21.425" x2="229.725" y2="21.475" layer="94"/>
+<rectangle x1="230.375" y1="21.425" x2="230.625" y2="21.475" layer="94"/>
+<rectangle x1="231.375" y1="21.425" x2="231.625" y2="21.475" layer="94"/>
+<rectangle x1="232.225" y1="21.425" x2="232.675" y2="21.475" layer="94"/>
+<rectangle x1="233.725" y1="21.425" x2="234.975" y2="21.475" layer="94"/>
+<rectangle x1="235.975" y1="21.425" x2="236.725" y2="21.475" layer="94"/>
+<rectangle x1="237.475" y1="21.425" x2="238.175" y2="21.475" layer="94"/>
+<rectangle x1="238.425" y1="21.425" x2="238.725" y2="21.475" layer="94"/>
+<rectangle x1="239.025" y1="21.425" x2="239.325" y2="21.475" layer="94"/>
+<rectangle x1="240.325" y1="21.425" x2="240.925" y2="21.475" layer="94"/>
+<rectangle x1="241.075" y1="21.425" x2="241.325" y2="21.475" layer="94"/>
+<rectangle x1="186.175" y1="21.475" x2="186.475" y2="21.525" layer="94"/>
+<rectangle x1="187.775" y1="21.475" x2="188.125" y2="21.525" layer="94"/>
+<rectangle x1="189.575" y1="21.475" x2="189.825" y2="21.525" layer="94"/>
+<rectangle x1="190.675" y1="21.475" x2="190.975" y2="21.525" layer="94"/>
+<rectangle x1="191.375" y1="21.475" x2="191.625" y2="21.525" layer="94"/>
+<rectangle x1="192.375" y1="21.475" x2="192.625" y2="21.525" layer="94"/>
+<rectangle x1="193.425" y1="21.475" x2="193.775" y2="21.525" layer="94"/>
+<rectangle x1="195.375" y1="21.475" x2="195.675" y2="21.525" layer="94"/>
+<rectangle x1="196.225" y1="21.475" x2="196.575" y2="21.525" layer="94"/>
+<rectangle x1="197.175" y1="21.475" x2="197.425" y2="21.525" layer="94"/>
+<rectangle x1="197.875" y1="21.475" x2="198.125" y2="21.525" layer="94"/>
+<rectangle x1="198.725" y1="21.475" x2="199.425" y2="21.525" layer="94"/>
+<rectangle x1="199.525" y1="21.475" x2="199.775" y2="21.525" layer="94"/>
+<rectangle x1="200.175" y1="21.475" x2="200.475" y2="21.525" layer="94"/>
+<rectangle x1="201.175" y1="21.475" x2="201.475" y2="21.525" layer="94"/>
+<rectangle x1="201.975" y1="21.475" x2="202.475" y2="21.525" layer="94"/>
+<rectangle x1="203.075" y1="21.475" x2="203.425" y2="21.525" layer="94"/>
+<rectangle x1="205.075" y1="21.475" x2="206.675" y2="21.525" layer="94"/>
+<rectangle x1="207.325" y1="21.475" x2="208.375" y2="21.525" layer="94"/>
+<rectangle x1="209.075" y1="21.475" x2="209.325" y2="21.525" layer="94"/>
+<rectangle x1="211.225" y1="21.475" x2="212.075" y2="21.525" layer="94"/>
+<rectangle x1="212.625" y1="21.475" x2="214.025" y2="21.525" layer="94"/>
+<rectangle x1="215.225" y1="21.475" x2="216.525" y2="21.525" layer="94"/>
+<rectangle x1="217.575" y1="21.475" x2="218.475" y2="21.525" layer="94"/>
+<rectangle x1="219.425" y1="21.475" x2="219.775" y2="21.525" layer="94"/>
+<rectangle x1="220.725" y1="21.475" x2="221.625" y2="21.525" layer="94"/>
+<rectangle x1="222.225" y1="21.475" x2="222.475" y2="21.525" layer="94"/>
+<rectangle x1="223.075" y1="21.475" x2="223.925" y2="21.525" layer="94"/>
+<rectangle x1="224.525" y1="21.475" x2="224.825" y2="21.525" layer="94"/>
+<rectangle x1="224.875" y1="21.475" x2="225.575" y2="21.525" layer="94"/>
+<rectangle x1="226.225" y1="21.475" x2="226.475" y2="21.525" layer="94"/>
+<rectangle x1="227.125" y1="21.475" x2="227.375" y2="21.525" layer="94"/>
+<rectangle x1="228.075" y1="21.475" x2="228.325" y2="21.525" layer="94"/>
+<rectangle x1="228.925" y1="21.475" x2="229.825" y2="21.525" layer="94"/>
+<rectangle x1="230.375" y1="21.475" x2="230.625" y2="21.525" layer="94"/>
+<rectangle x1="231.375" y1="21.475" x2="231.625" y2="21.525" layer="94"/>
+<rectangle x1="232.175" y1="21.475" x2="232.625" y2="21.525" layer="94"/>
+<rectangle x1="233.725" y1="21.475" x2="235.075" y2="21.525" layer="94"/>
+<rectangle x1="235.925" y1="21.475" x2="236.775" y2="21.525" layer="94"/>
+<rectangle x1="237.425" y1="21.475" x2="238.275" y2="21.525" layer="94"/>
+<rectangle x1="238.425" y1="21.475" x2="238.675" y2="21.525" layer="94"/>
+<rectangle x1="239.025" y1="21.475" x2="239.325" y2="21.525" layer="94"/>
+<rectangle x1="240.225" y1="21.475" x2="240.975" y2="21.525" layer="94"/>
+<rectangle x1="241.075" y1="21.475" x2="241.325" y2="21.525" layer="94"/>
+<rectangle x1="186.225" y1="21.525" x2="186.525" y2="21.575" layer="94"/>
+<rectangle x1="187.775" y1="21.525" x2="188.125" y2="21.575" layer="94"/>
+<rectangle x1="189.575" y1="21.525" x2="189.825" y2="21.575" layer="94"/>
+<rectangle x1="190.675" y1="21.525" x2="190.975" y2="21.575" layer="94"/>
+<rectangle x1="191.375" y1="21.525" x2="191.625" y2="21.575" layer="94"/>
+<rectangle x1="192.375" y1="21.525" x2="192.625" y2="21.575" layer="94"/>
+<rectangle x1="193.425" y1="21.525" x2="193.775" y2="21.575" layer="94"/>
+<rectangle x1="195.375" y1="21.525" x2="195.675" y2="21.575" layer="94"/>
+<rectangle x1="196.225" y1="21.525" x2="196.575" y2="21.575" layer="94"/>
+<rectangle x1="197.175" y1="21.525" x2="197.425" y2="21.575" layer="94"/>
+<rectangle x1="197.875" y1="21.525" x2="198.125" y2="21.575" layer="94"/>
+<rectangle x1="198.675" y1="21.525" x2="199.475" y2="21.575" layer="94"/>
+<rectangle x1="199.525" y1="21.525" x2="199.775" y2="21.575" layer="94"/>
+<rectangle x1="200.175" y1="21.525" x2="200.475" y2="21.575" layer="94"/>
+<rectangle x1="201.175" y1="21.525" x2="201.475" y2="21.575" layer="94"/>
+<rectangle x1="201.925" y1="21.525" x2="202.475" y2="21.575" layer="94"/>
+<rectangle x1="203.075" y1="21.525" x2="203.425" y2="21.575" layer="94"/>
+<rectangle x1="205.075" y1="21.525" x2="206.675" y2="21.575" layer="94"/>
+<rectangle x1="207.225" y1="21.525" x2="208.475" y2="21.575" layer="94"/>
+<rectangle x1="209.075" y1="21.525" x2="209.325" y2="21.575" layer="94"/>
+<rectangle x1="211.175" y1="21.525" x2="212.175" y2="21.575" layer="94"/>
+<rectangle x1="212.625" y1="21.525" x2="214.025" y2="21.575" layer="94"/>
+<rectangle x1="215.225" y1="21.525" x2="216.625" y2="21.575" layer="94"/>
+<rectangle x1="217.525" y1="21.525" x2="218.525" y2="21.575" layer="94"/>
+<rectangle x1="219.425" y1="21.525" x2="219.775" y2="21.575" layer="94"/>
+<rectangle x1="220.675" y1="21.525" x2="221.675" y2="21.575" layer="94"/>
+<rectangle x1="222.225" y1="21.525" x2="222.475" y2="21.575" layer="94"/>
+<rectangle x1="223.025" y1="21.525" x2="224.025" y2="21.575" layer="94"/>
+<rectangle x1="224.525" y1="21.525" x2="225.675" y2="21.575" layer="94"/>
+<rectangle x1="226.225" y1="21.525" x2="226.475" y2="21.575" layer="94"/>
+<rectangle x1="227.125" y1="21.525" x2="227.375" y2="21.575" layer="94"/>
+<rectangle x1="228.075" y1="21.525" x2="228.325" y2="21.575" layer="94"/>
+<rectangle x1="228.825" y1="21.525" x2="229.875" y2="21.575" layer="94"/>
+<rectangle x1="230.375" y1="21.525" x2="230.625" y2="21.575" layer="94"/>
+<rectangle x1="231.375" y1="21.525" x2="231.625" y2="21.575" layer="94"/>
+<rectangle x1="232.125" y1="21.525" x2="232.625" y2="21.575" layer="94"/>
+<rectangle x1="233.725" y1="21.525" x2="235.125" y2="21.575" layer="94"/>
+<rectangle x1="235.825" y1="21.525" x2="236.825" y2="21.575" layer="94"/>
+<rectangle x1="237.375" y1="21.525" x2="238.325" y2="21.575" layer="94"/>
+<rectangle x1="238.425" y1="21.525" x2="238.675" y2="21.575" layer="94"/>
+<rectangle x1="239.025" y1="21.525" x2="239.325" y2="21.575" layer="94"/>
+<rectangle x1="240.175" y1="21.525" x2="241.025" y2="21.575" layer="94"/>
+<rectangle x1="241.075" y1="21.525" x2="241.325" y2="21.575" layer="94"/>
+<rectangle x1="186.225" y1="21.575" x2="186.525" y2="21.625" layer="94"/>
+<rectangle x1="187.775" y1="21.575" x2="188.075" y2="21.625" layer="94"/>
+<rectangle x1="189.575" y1="21.575" x2="189.825" y2="21.625" layer="94"/>
+<rectangle x1="190.675" y1="21.575" x2="190.975" y2="21.625" layer="94"/>
+<rectangle x1="191.375" y1="21.575" x2="191.625" y2="21.625" layer="94"/>
+<rectangle x1="192.375" y1="21.575" x2="192.625" y2="21.625" layer="94"/>
+<rectangle x1="193.375" y1="21.575" x2="193.775" y2="21.625" layer="94"/>
+<rectangle x1="195.375" y1="21.575" x2="195.675" y2="21.625" layer="94"/>
+<rectangle x1="196.225" y1="21.575" x2="196.625" y2="21.625" layer="94"/>
+<rectangle x1="197.175" y1="21.575" x2="197.425" y2="21.625" layer="94"/>
+<rectangle x1="197.875" y1="21.575" x2="198.125" y2="21.625" layer="94"/>
+<rectangle x1="198.625" y1="21.575" x2="199.775" y2="21.625" layer="94"/>
+<rectangle x1="200.175" y1="21.575" x2="200.475" y2="21.625" layer="94"/>
+<rectangle x1="201.175" y1="21.575" x2="201.475" y2="21.625" layer="94"/>
+<rectangle x1="201.925" y1="21.575" x2="202.425" y2="21.625" layer="94"/>
+<rectangle x1="203.075" y1="21.575" x2="203.475" y2="21.625" layer="94"/>
+<rectangle x1="205.075" y1="21.575" x2="206.675" y2="21.625" layer="94"/>
+<rectangle x1="207.175" y1="21.575" x2="208.525" y2="21.625" layer="94"/>
+<rectangle x1="209.075" y1="21.575" x2="209.325" y2="21.625" layer="94"/>
+<rectangle x1="211.125" y1="21.575" x2="211.525" y2="21.625" layer="94"/>
+<rectangle x1="211.775" y1="21.575" x2="212.225" y2="21.625" layer="94"/>
+<rectangle x1="212.625" y1="21.575" x2="214.025" y2="21.625" layer="94"/>
+<rectangle x1="215.225" y1="21.575" x2="216.675" y2="21.625" layer="94"/>
+<rectangle x1="217.475" y1="21.575" x2="217.925" y2="21.625" layer="94"/>
+<rectangle x1="218.175" y1="21.575" x2="218.575" y2="21.625" layer="94"/>
+<rectangle x1="219.375" y1="21.575" x2="219.775" y2="21.625" layer="94"/>
+<rectangle x1="220.625" y1="21.575" x2="221.075" y2="21.625" layer="94"/>
+<rectangle x1="221.325" y1="21.575" x2="221.725" y2="21.625" layer="94"/>
+<rectangle x1="222.225" y1="21.575" x2="222.475" y2="21.625" layer="94"/>
+<rectangle x1="222.975" y1="21.575" x2="223.375" y2="21.625" layer="94"/>
+<rectangle x1="223.625" y1="21.575" x2="224.075" y2="21.625" layer="94"/>
+<rectangle x1="224.525" y1="21.575" x2="225.075" y2="21.625" layer="94"/>
+<rectangle x1="225.275" y1="21.575" x2="225.725" y2="21.625" layer="94"/>
+<rectangle x1="226.225" y1="21.575" x2="226.475" y2="21.625" layer="94"/>
+<rectangle x1="227.125" y1="21.575" x2="227.375" y2="21.625" layer="94"/>
+<rectangle x1="228.075" y1="21.575" x2="228.325" y2="21.625" layer="94"/>
+<rectangle x1="228.775" y1="21.575" x2="229.275" y2="21.625" layer="94"/>
+<rectangle x1="229.475" y1="21.575" x2="229.925" y2="21.625" layer="94"/>
+<rectangle x1="230.375" y1="21.575" x2="230.625" y2="21.625" layer="94"/>
+<rectangle x1="231.375" y1="21.575" x2="231.625" y2="21.625" layer="94"/>
+<rectangle x1="232.125" y1="21.575" x2="232.625" y2="21.625" layer="94"/>
+<rectangle x1="233.725" y1="21.575" x2="235.175" y2="21.625" layer="94"/>
+<rectangle x1="235.775" y1="21.575" x2="236.225" y2="21.625" layer="94"/>
+<rectangle x1="236.425" y1="21.575" x2="236.875" y2="21.625" layer="94"/>
+<rectangle x1="237.325" y1="21.575" x2="237.725" y2="21.625" layer="94"/>
+<rectangle x1="238.075" y1="21.575" x2="238.675" y2="21.625" layer="94"/>
+<rectangle x1="239.025" y1="21.575" x2="239.325" y2="21.625" layer="94"/>
+<rectangle x1="240.125" y1="21.575" x2="240.575" y2="21.625" layer="94"/>
+<rectangle x1="240.725" y1="21.575" x2="241.325" y2="21.625" layer="94"/>
+<rectangle x1="186.275" y1="21.625" x2="186.525" y2="21.675" layer="94"/>
+<rectangle x1="187.725" y1="21.625" x2="188.075" y2="21.675" layer="94"/>
+<rectangle x1="189.575" y1="21.625" x2="189.825" y2="21.675" layer="94"/>
+<rectangle x1="190.675" y1="21.625" x2="190.975" y2="21.675" layer="94"/>
+<rectangle x1="191.375" y1="21.625" x2="191.625" y2="21.675" layer="94"/>
+<rectangle x1="192.375" y1="21.625" x2="192.625" y2="21.675" layer="94"/>
+<rectangle x1="193.375" y1="21.625" x2="193.825" y2="21.675" layer="94"/>
+<rectangle x1="195.375" y1="21.625" x2="195.675" y2="21.675" layer="94"/>
+<rectangle x1="196.175" y1="21.625" x2="196.625" y2="21.675" layer="94"/>
+<rectangle x1="197.175" y1="21.625" x2="197.425" y2="21.675" layer="94"/>
+<rectangle x1="197.875" y1="21.625" x2="198.125" y2="21.675" layer="94"/>
+<rectangle x1="198.575" y1="21.625" x2="198.975" y2="21.675" layer="94"/>
+<rectangle x1="199.275" y1="21.625" x2="199.775" y2="21.675" layer="94"/>
+<rectangle x1="200.175" y1="21.625" x2="200.475" y2="21.675" layer="94"/>
+<rectangle x1="201.175" y1="21.625" x2="201.475" y2="21.675" layer="94"/>
+<rectangle x1="201.925" y1="21.625" x2="202.225" y2="21.675" layer="94"/>
+<rectangle x1="203.025" y1="21.625" x2="203.475" y2="21.675" layer="94"/>
+<rectangle x1="205.075" y1="21.625" x2="206.625" y2="21.675" layer="94"/>
+<rectangle x1="207.125" y1="21.625" x2="207.625" y2="21.675" layer="94"/>
+<rectangle x1="208.125" y1="21.625" x2="208.575" y2="21.675" layer="94"/>
+<rectangle x1="209.075" y1="21.625" x2="209.325" y2="21.675" layer="94"/>
+<rectangle x1="211.075" y1="21.625" x2="211.425" y2="21.675" layer="94"/>
+<rectangle x1="211.875" y1="21.625" x2="212.225" y2="21.675" layer="94"/>
+<rectangle x1="212.675" y1="21.625" x2="213.975" y2="21.675" layer="94"/>
+<rectangle x1="215.225" y1="21.625" x2="216.725" y2="21.675" layer="94"/>
+<rectangle x1="217.425" y1="21.625" x2="217.775" y2="21.675" layer="94"/>
+<rectangle x1="218.275" y1="21.625" x2="218.625" y2="21.675" layer="94"/>
+<rectangle x1="219.375" y1="21.625" x2="219.825" y2="21.675" layer="94"/>
+<rectangle x1="220.575" y1="21.625" x2="220.975" y2="21.675" layer="94"/>
+<rectangle x1="221.425" y1="21.625" x2="221.775" y2="21.675" layer="94"/>
+<rectangle x1="222.225" y1="21.625" x2="222.475" y2="21.675" layer="94"/>
+<rectangle x1="222.925" y1="21.625" x2="223.275" y2="21.675" layer="94"/>
+<rectangle x1="223.725" y1="21.625" x2="224.075" y2="21.675" layer="94"/>
+<rectangle x1="224.525" y1="21.625" x2="224.975" y2="21.675" layer="94"/>
+<rectangle x1="225.425" y1="21.625" x2="225.725" y2="21.675" layer="94"/>
+<rectangle x1="226.225" y1="21.625" x2="226.475" y2="21.675" layer="94"/>
+<rectangle x1="227.125" y1="21.625" x2="227.375" y2="21.675" layer="94"/>
+<rectangle x1="228.075" y1="21.625" x2="228.325" y2="21.675" layer="94"/>
+<rectangle x1="228.775" y1="21.625" x2="229.125" y2="21.675" layer="94"/>
+<rectangle x1="229.575" y1="21.625" x2="229.975" y2="21.675" layer="94"/>
+<rectangle x1="230.375" y1="21.625" x2="230.625" y2="21.675" layer="94"/>
+<rectangle x1="231.375" y1="21.625" x2="231.625" y2="21.675" layer="94"/>
+<rectangle x1="232.125" y1="21.625" x2="232.425" y2="21.675" layer="94"/>
+<rectangle x1="233.725" y1="21.625" x2="235.225" y2="21.675" layer="94"/>
+<rectangle x1="235.775" y1="21.625" x2="236.125" y2="21.675" layer="94"/>
+<rectangle x1="236.575" y1="21.625" x2="236.925" y2="21.675" layer="94"/>
+<rectangle x1="237.325" y1="21.625" x2="237.625" y2="21.675" layer="94"/>
+<rectangle x1="238.175" y1="21.625" x2="238.675" y2="21.675" layer="94"/>
+<rectangle x1="239.025" y1="21.625" x2="239.325" y2="21.675" layer="94"/>
+<rectangle x1="240.125" y1="21.625" x2="240.425" y2="21.675" layer="94"/>
+<rectangle x1="240.875" y1="21.625" x2="241.325" y2="21.675" layer="94"/>
+<rectangle x1="186.275" y1="21.675" x2="186.575" y2="21.725" layer="94"/>
+<rectangle x1="187.725" y1="21.675" x2="188.025" y2="21.725" layer="94"/>
+<rectangle x1="189.575" y1="21.675" x2="189.825" y2="21.725" layer="94"/>
+<rectangle x1="190.675" y1="21.675" x2="190.975" y2="21.725" layer="94"/>
+<rectangle x1="191.375" y1="21.675" x2="191.625" y2="21.725" layer="94"/>
+<rectangle x1="192.375" y1="21.675" x2="192.625" y2="21.725" layer="94"/>
+<rectangle x1="193.375" y1="21.675" x2="193.825" y2="21.725" layer="94"/>
+<rectangle x1="195.375" y1="21.675" x2="195.675" y2="21.725" layer="94"/>
+<rectangle x1="196.175" y1="21.675" x2="196.625" y2="21.725" layer="94"/>
+<rectangle x1="197.175" y1="21.675" x2="197.425" y2="21.725" layer="94"/>
+<rectangle x1="197.875" y1="21.675" x2="198.125" y2="21.725" layer="94"/>
+<rectangle x1="198.575" y1="21.675" x2="198.875" y2="21.725" layer="94"/>
+<rectangle x1="199.375" y1="21.675" x2="199.775" y2="21.725" layer="94"/>
+<rectangle x1="200.175" y1="21.675" x2="200.475" y2="21.725" layer="94"/>
+<rectangle x1="201.175" y1="21.675" x2="201.475" y2="21.725" layer="94"/>
+<rectangle x1="201.925" y1="21.675" x2="202.175" y2="21.725" layer="94"/>
+<rectangle x1="203.025" y1="21.675" x2="203.525" y2="21.725" layer="94"/>
+<rectangle x1="205.075" y1="21.675" x2="205.375" y2="21.725" layer="94"/>
+<rectangle x1="207.075" y1="21.675" x2="207.525" y2="21.725" layer="94"/>
+<rectangle x1="208.225" y1="21.675" x2="208.575" y2="21.725" layer="94"/>
+<rectangle x1="209.075" y1="21.675" x2="209.325" y2="21.725" layer="94"/>
+<rectangle x1="211.025" y1="21.675" x2="211.375" y2="21.725" layer="94"/>
+<rectangle x1="211.925" y1="21.675" x2="212.275" y2="21.725" layer="94"/>
+<rectangle x1="212.675" y1="21.675" x2="212.975" y2="21.725" layer="94"/>
+<rectangle x1="215.225" y1="21.675" x2="215.525" y2="21.725" layer="94"/>
+<rectangle x1="216.325" y1="21.675" x2="216.775" y2="21.725" layer="94"/>
+<rectangle x1="217.375" y1="21.675" x2="217.725" y2="21.725" layer="94"/>
+<rectangle x1="218.325" y1="21.675" x2="218.625" y2="21.725" layer="94"/>
+<rectangle x1="219.375" y1="21.675" x2="219.825" y2="21.725" layer="94"/>
+<rectangle x1="220.575" y1="21.675" x2="220.875" y2="21.725" layer="94"/>
+<rectangle x1="221.475" y1="21.675" x2="221.825" y2="21.725" layer="94"/>
+<rectangle x1="222.225" y1="21.675" x2="222.475" y2="21.725" layer="94"/>
+<rectangle x1="222.875" y1="21.675" x2="223.225" y2="21.725" layer="94"/>
+<rectangle x1="223.775" y1="21.675" x2="224.125" y2="21.725" layer="94"/>
+<rectangle x1="224.525" y1="21.675" x2="224.925" y2="21.725" layer="94"/>
+<rectangle x1="225.475" y1="21.675" x2="225.775" y2="21.725" layer="94"/>
+<rectangle x1="226.225" y1="21.675" x2="226.475" y2="21.725" layer="94"/>
+<rectangle x1="227.125" y1="21.675" x2="227.375" y2="21.725" layer="94"/>
+<rectangle x1="228.075" y1="21.675" x2="228.325" y2="21.725" layer="94"/>
+<rectangle x1="228.725" y1="21.675" x2="229.075" y2="21.725" layer="94"/>
+<rectangle x1="229.675" y1="21.675" x2="229.975" y2="21.725" layer="94"/>
+<rectangle x1="230.375" y1="21.675" x2="230.625" y2="21.725" layer="94"/>
+<rectangle x1="231.375" y1="21.675" x2="231.625" y2="21.725" layer="94"/>
+<rectangle x1="232.125" y1="21.675" x2="232.375" y2="21.725" layer="94"/>
+<rectangle x1="233.725" y1="21.675" x2="234.025" y2="21.725" layer="94"/>
+<rectangle x1="234.875" y1="21.675" x2="235.275" y2="21.725" layer="94"/>
+<rectangle x1="235.725" y1="21.675" x2="236.075" y2="21.725" layer="94"/>
+<rectangle x1="236.625" y1="21.675" x2="236.975" y2="21.725" layer="94"/>
+<rectangle x1="237.325" y1="21.675" x2="237.625" y2="21.725" layer="94"/>
+<rectangle x1="238.225" y1="21.675" x2="238.675" y2="21.725" layer="94"/>
+<rectangle x1="239.025" y1="21.675" x2="239.325" y2="21.725" layer="94"/>
+<rectangle x1="240.075" y1="21.675" x2="240.375" y2="21.725" layer="94"/>
+<rectangle x1="240.925" y1="21.675" x2="241.325" y2="21.725" layer="94"/>
+<rectangle x1="186.275" y1="21.725" x2="186.575" y2="21.775" layer="94"/>
+<rectangle x1="187.725" y1="21.725" x2="188.025" y2="21.775" layer="94"/>
+<rectangle x1="189.575" y1="21.725" x2="189.825" y2="21.775" layer="94"/>
+<rectangle x1="190.675" y1="21.725" x2="190.975" y2="21.775" layer="94"/>
+<rectangle x1="191.375" y1="21.725" x2="191.625" y2="21.775" layer="94"/>
+<rectangle x1="192.375" y1="21.725" x2="192.625" y2="21.775" layer="94"/>
+<rectangle x1="193.325" y1="21.725" x2="193.575" y2="21.775" layer="94"/>
+<rectangle x1="193.625" y1="21.725" x2="193.875" y2="21.775" layer="94"/>
+<rectangle x1="195.375" y1="21.725" x2="195.675" y2="21.775" layer="94"/>
+<rectangle x1="196.175" y1="21.725" x2="196.675" y2="21.775" layer="94"/>
+<rectangle x1="197.175" y1="21.725" x2="197.425" y2="21.775" layer="94"/>
+<rectangle x1="197.875" y1="21.725" x2="198.125" y2="21.775" layer="94"/>
+<rectangle x1="198.525" y1="21.725" x2="198.825" y2="21.775" layer="94"/>
+<rectangle x1="199.425" y1="21.725" x2="199.775" y2="21.775" layer="94"/>
+<rectangle x1="200.175" y1="21.725" x2="200.475" y2="21.775" layer="94"/>
+<rectangle x1="201.175" y1="21.725" x2="201.475" y2="21.775" layer="94"/>
+<rectangle x1="201.925" y1="21.725" x2="202.175" y2="21.775" layer="94"/>
+<rectangle x1="203.025" y1="21.725" x2="203.225" y2="21.775" layer="94"/>
+<rectangle x1="203.275" y1="21.725" x2="203.525" y2="21.775" layer="94"/>
+<rectangle x1="205.075" y1="21.725" x2="205.375" y2="21.775" layer="94"/>
+<rectangle x1="207.075" y1="21.725" x2="207.425" y2="21.775" layer="94"/>
+<rectangle x1="208.275" y1="21.725" x2="208.625" y2="21.775" layer="94"/>
+<rectangle x1="209.075" y1="21.725" x2="209.325" y2="21.775" layer="94"/>
+<rectangle x1="211.025" y1="21.725" x2="211.325" y2="21.775" layer="94"/>
+<rectangle x1="211.975" y1="21.725" x2="212.325" y2="21.775" layer="94"/>
+<rectangle x1="212.725" y1="21.725" x2="213.025" y2="21.775" layer="94"/>
+<rectangle x1="215.225" y1="21.725" x2="215.525" y2="21.775" layer="94"/>
+<rectangle x1="216.425" y1="21.725" x2="216.825" y2="21.775" layer="94"/>
+<rectangle x1="217.375" y1="21.725" x2="217.675" y2="21.775" layer="94"/>
+<rectangle x1="218.375" y1="21.725" x2="218.675" y2="21.775" layer="94"/>
+<rectangle x1="219.325" y1="21.725" x2="219.575" y2="21.775" layer="94"/>
+<rectangle x1="219.625" y1="21.725" x2="219.875" y2="21.775" layer="94"/>
+<rectangle x1="220.525" y1="21.725" x2="220.825" y2="21.775" layer="94"/>
+<rectangle x1="221.525" y1="21.725" x2="221.825" y2="21.775" layer="94"/>
+<rectangle x1="222.225" y1="21.725" x2="222.475" y2="21.775" layer="94"/>
+<rectangle x1="222.875" y1="21.725" x2="223.175" y2="21.775" layer="94"/>
+<rectangle x1="223.825" y1="21.725" x2="224.175" y2="21.775" layer="94"/>
+<rectangle x1="224.525" y1="21.725" x2="224.875" y2="21.775" layer="94"/>
+<rectangle x1="225.525" y1="21.725" x2="225.825" y2="21.775" layer="94"/>
+<rectangle x1="226.225" y1="21.725" x2="226.475" y2="21.775" layer="94"/>
+<rectangle x1="227.125" y1="21.725" x2="227.375" y2="21.775" layer="94"/>
+<rectangle x1="228.075" y1="21.725" x2="228.325" y2="21.775" layer="94"/>
+<rectangle x1="228.725" y1="21.725" x2="229.025" y2="21.775" layer="94"/>
+<rectangle x1="229.675" y1="21.725" x2="229.975" y2="21.775" layer="94"/>
+<rectangle x1="230.375" y1="21.725" x2="230.625" y2="21.775" layer="94"/>
+<rectangle x1="231.375" y1="21.725" x2="231.625" y2="21.775" layer="94"/>
+<rectangle x1="232.125" y1="21.725" x2="232.375" y2="21.775" layer="94"/>
+<rectangle x1="233.725" y1="21.725" x2="234.025" y2="21.775" layer="94"/>
+<rectangle x1="234.925" y1="21.725" x2="235.275" y2="21.775" layer="94"/>
+<rectangle x1="235.725" y1="21.725" x2="236.025" y2="21.775" layer="94"/>
+<rectangle x1="236.675" y1="21.725" x2="236.975" y2="21.775" layer="94"/>
+<rectangle x1="237.325" y1="21.725" x2="237.575" y2="21.775" layer="94"/>
+<rectangle x1="238.275" y1="21.725" x2="238.675" y2="21.775" layer="94"/>
+<rectangle x1="239.025" y1="21.725" x2="239.325" y2="21.775" layer="94"/>
+<rectangle x1="240.025" y1="21.725" x2="240.325" y2="21.775" layer="94"/>
+<rectangle x1="240.975" y1="21.725" x2="241.325" y2="21.775" layer="94"/>
+<rectangle x1="186.325" y1="21.775" x2="186.625" y2="21.825" layer="94"/>
+<rectangle x1="187.675" y1="21.775" x2="187.975" y2="21.825" layer="94"/>
+<rectangle x1="189.575" y1="21.775" x2="189.825" y2="21.825" layer="94"/>
+<rectangle x1="190.675" y1="21.775" x2="190.975" y2="21.825" layer="94"/>
+<rectangle x1="191.375" y1="21.775" x2="191.625" y2="21.825" layer="94"/>
+<rectangle x1="192.375" y1="21.775" x2="192.625" y2="21.825" layer="94"/>
+<rectangle x1="193.325" y1="21.775" x2="193.575" y2="21.825" layer="94"/>
+<rectangle x1="193.625" y1="21.775" x2="193.875" y2="21.825" layer="94"/>
+<rectangle x1="195.375" y1="21.775" x2="195.675" y2="21.825" layer="94"/>
+<rectangle x1="196.125" y1="21.775" x2="196.375" y2="21.825" layer="94"/>
+<rectangle x1="196.475" y1="21.775" x2="196.675" y2="21.825" layer="94"/>
+<rectangle x1="197.175" y1="21.775" x2="197.425" y2="21.825" layer="94"/>
+<rectangle x1="197.875" y1="21.775" x2="198.125" y2="21.825" layer="94"/>
+<rectangle x1="198.525" y1="21.775" x2="198.775" y2="21.825" layer="94"/>
+<rectangle x1="199.425" y1="21.775" x2="199.775" y2="21.825" layer="94"/>
+<rectangle x1="200.175" y1="21.775" x2="200.475" y2="21.825" layer="94"/>
+<rectangle x1="201.175" y1="21.775" x2="201.475" y2="21.825" layer="94"/>
+<rectangle x1="201.925" y1="21.775" x2="202.175" y2="21.825" layer="94"/>
+<rectangle x1="202.975" y1="21.775" x2="203.225" y2="21.825" layer="94"/>
+<rectangle x1="203.325" y1="21.775" x2="203.525" y2="21.825" layer="94"/>
+<rectangle x1="205.075" y1="21.775" x2="205.375" y2="21.825" layer="94"/>
+<rectangle x1="207.025" y1="21.775" x2="207.375" y2="21.825" layer="94"/>
+<rectangle x1="208.325" y1="21.775" x2="208.625" y2="21.825" layer="94"/>
+<rectangle x1="209.075" y1="21.775" x2="209.325" y2="21.825" layer="94"/>
+<rectangle x1="211.025" y1="21.775" x2="211.275" y2="21.825" layer="94"/>
+<rectangle x1="212.025" y1="21.775" x2="212.325" y2="21.825" layer="94"/>
+<rectangle x1="212.775" y1="21.775" x2="213.075" y2="21.825" layer="94"/>
+<rectangle x1="215.225" y1="21.775" x2="215.525" y2="21.825" layer="94"/>
+<rectangle x1="216.525" y1="21.775" x2="216.825" y2="21.825" layer="94"/>
+<rectangle x1="217.325" y1="21.775" x2="217.625" y2="21.825" layer="94"/>
+<rectangle x1="218.375" y1="21.775" x2="218.675" y2="21.825" layer="94"/>
+<rectangle x1="219.325" y1="21.775" x2="219.575" y2="21.825" layer="94"/>
+<rectangle x1="219.625" y1="21.775" x2="219.875" y2="21.825" layer="94"/>
+<rectangle x1="220.525" y1="21.775" x2="220.825" y2="21.825" layer="94"/>
+<rectangle x1="221.575" y1="21.775" x2="221.825" y2="21.825" layer="94"/>
+<rectangle x1="222.225" y1="21.775" x2="222.475" y2="21.825" layer="94"/>
+<rectangle x1="222.825" y1="21.775" x2="223.125" y2="21.825" layer="94"/>
+<rectangle x1="223.875" y1="21.775" x2="224.175" y2="21.825" layer="94"/>
+<rectangle x1="224.525" y1="21.775" x2="224.875" y2="21.825" layer="94"/>
+<rectangle x1="225.525" y1="21.775" x2="225.825" y2="21.825" layer="94"/>
+<rectangle x1="226.225" y1="21.775" x2="226.475" y2="21.825" layer="94"/>
+<rectangle x1="227.125" y1="21.775" x2="227.375" y2="21.825" layer="94"/>
+<rectangle x1="228.075" y1="21.775" x2="228.325" y2="21.825" layer="94"/>
+<rectangle x1="228.675" y1="21.775" x2="228.975" y2="21.825" layer="94"/>
+<rectangle x1="229.725" y1="21.775" x2="230.025" y2="21.825" layer="94"/>
+<rectangle x1="230.375" y1="21.775" x2="230.625" y2="21.825" layer="94"/>
+<rectangle x1="231.375" y1="21.775" x2="231.625" y2="21.825" layer="94"/>
+<rectangle x1="232.075" y1="21.775" x2="232.375" y2="21.825" layer="94"/>
+<rectangle x1="233.725" y1="21.775" x2="234.025" y2="21.825" layer="94"/>
+<rectangle x1="234.975" y1="21.775" x2="235.325" y2="21.825" layer="94"/>
+<rectangle x1="235.675" y1="21.775" x2="235.975" y2="21.825" layer="94"/>
+<rectangle x1="236.725" y1="21.775" x2="237.025" y2="21.825" layer="94"/>
+<rectangle x1="237.275" y1="21.775" x2="237.575" y2="21.825" layer="94"/>
+<rectangle x1="238.325" y1="21.775" x2="238.675" y2="21.825" layer="94"/>
+<rectangle x1="239.025" y1="21.775" x2="239.325" y2="21.825" layer="94"/>
+<rectangle x1="240.025" y1="21.775" x2="240.325" y2="21.825" layer="94"/>
+<rectangle x1="240.975" y1="21.775" x2="241.325" y2="21.825" layer="94"/>
+<rectangle x1="186.325" y1="21.825" x2="186.625" y2="21.875" layer="94"/>
+<rectangle x1="187.675" y1="21.825" x2="187.975" y2="21.875" layer="94"/>
+<rectangle x1="189.575" y1="21.825" x2="189.825" y2="21.875" layer="94"/>
+<rectangle x1="190.675" y1="21.825" x2="190.975" y2="21.875" layer="94"/>
+<rectangle x1="191.375" y1="21.825" x2="191.625" y2="21.875" layer="94"/>
+<rectangle x1="192.375" y1="21.825" x2="192.625" y2="21.875" layer="94"/>
+<rectangle x1="193.275" y1="21.825" x2="193.525" y2="21.875" layer="94"/>
+<rectangle x1="193.625" y1="21.825" x2="193.875" y2="21.875" layer="94"/>
+<rectangle x1="195.375" y1="21.825" x2="195.675" y2="21.875" layer="94"/>
+<rectangle x1="196.125" y1="21.825" x2="196.375" y2="21.875" layer="94"/>
+<rectangle x1="196.475" y1="21.825" x2="196.675" y2="21.875" layer="94"/>
+<rectangle x1="197.175" y1="21.825" x2="197.425" y2="21.875" layer="94"/>
+<rectangle x1="197.875" y1="21.825" x2="198.125" y2="21.875" layer="94"/>
+<rectangle x1="198.475" y1="21.825" x2="198.775" y2="21.875" layer="94"/>
+<rectangle x1="199.475" y1="21.825" x2="199.775" y2="21.875" layer="94"/>
+<rectangle x1="200.175" y1="21.825" x2="200.475" y2="21.875" layer="94"/>
+<rectangle x1="201.175" y1="21.825" x2="201.475" y2="21.875" layer="94"/>
+<rectangle x1="201.925" y1="21.825" x2="202.175" y2="21.875" layer="94"/>
+<rectangle x1="202.975" y1="21.825" x2="203.225" y2="21.875" layer="94"/>
+<rectangle x1="203.325" y1="21.825" x2="203.575" y2="21.875" layer="94"/>
+<rectangle x1="205.075" y1="21.825" x2="205.375" y2="21.875" layer="94"/>
+<rectangle x1="207.025" y1="21.825" x2="207.325" y2="21.875" layer="94"/>
+<rectangle x1="208.375" y1="21.825" x2="208.675" y2="21.875" layer="94"/>
+<rectangle x1="209.075" y1="21.825" x2="209.325" y2="21.875" layer="94"/>
+<rectangle x1="210.975" y1="21.825" x2="211.275" y2="21.875" layer="94"/>
+<rectangle x1="212.075" y1="21.825" x2="212.325" y2="21.875" layer="94"/>
+<rectangle x1="212.775" y1="21.825" x2="213.125" y2="21.875" layer="94"/>
+<rectangle x1="215.225" y1="21.825" x2="215.525" y2="21.875" layer="94"/>
+<rectangle x1="216.525" y1="21.825" x2="216.875" y2="21.875" layer="94"/>
+<rectangle x1="217.325" y1="21.825" x2="217.625" y2="21.875" layer="94"/>
+<rectangle x1="218.425" y1="21.825" x2="218.675" y2="21.875" layer="94"/>
+<rectangle x1="219.275" y1="21.825" x2="219.525" y2="21.875" layer="94"/>
+<rectangle x1="219.625" y1="21.825" x2="219.875" y2="21.875" layer="94"/>
+<rectangle x1="220.475" y1="21.825" x2="220.775" y2="21.875" layer="94"/>
+<rectangle x1="221.575" y1="21.825" x2="221.875" y2="21.875" layer="94"/>
+<rectangle x1="222.225" y1="21.825" x2="222.475" y2="21.875" layer="94"/>
+<rectangle x1="222.825" y1="21.825" x2="223.125" y2="21.875" layer="94"/>
+<rectangle x1="223.875" y1="21.825" x2="224.175" y2="21.875" layer="94"/>
+<rectangle x1="224.525" y1="21.825" x2="224.825" y2="21.875" layer="94"/>
+<rectangle x1="225.575" y1="21.825" x2="225.825" y2="21.875" layer="94"/>
+<rectangle x1="226.225" y1="21.825" x2="226.475" y2="21.875" layer="94"/>
+<rectangle x1="227.125" y1="21.825" x2="227.375" y2="21.875" layer="94"/>
+<rectangle x1="228.075" y1="21.825" x2="228.325" y2="21.875" layer="94"/>
+<rectangle x1="228.675" y1="21.825" x2="228.975" y2="21.875" layer="94"/>
+<rectangle x1="229.775" y1="21.825" x2="230.025" y2="21.875" layer="94"/>
+<rectangle x1="230.375" y1="21.825" x2="230.625" y2="21.875" layer="94"/>
+<rectangle x1="231.375" y1="21.825" x2="231.625" y2="21.875" layer="94"/>
+<rectangle x1="232.075" y1="21.825" x2="232.375" y2="21.875" layer="94"/>
+<rectangle x1="233.725" y1="21.825" x2="234.025" y2="21.875" layer="94"/>
+<rectangle x1="235.025" y1="21.825" x2="235.325" y2="21.875" layer="94"/>
+<rectangle x1="235.675" y1="21.825" x2="235.975" y2="21.875" layer="94"/>
+<rectangle x1="236.725" y1="21.825" x2="237.025" y2="21.875" layer="94"/>
+<rectangle x1="237.275" y1="21.825" x2="237.575" y2="21.875" layer="94"/>
+<rectangle x1="238.325" y1="21.825" x2="238.625" y2="21.875" layer="94"/>
+<rectangle x1="239.025" y1="21.825" x2="239.325" y2="21.875" layer="94"/>
+<rectangle x1="240.025" y1="21.825" x2="240.275" y2="21.875" layer="94"/>
+<rectangle x1="241.025" y1="21.825" x2="241.325" y2="21.875" layer="94"/>
+<rectangle x1="186.325" y1="21.875" x2="186.625" y2="21.925" layer="94"/>
+<rectangle x1="187.625" y1="21.875" x2="187.975" y2="21.925" layer="94"/>
+<rectangle x1="189.575" y1="21.875" x2="189.825" y2="21.925" layer="94"/>
+<rectangle x1="190.675" y1="21.875" x2="190.975" y2="21.925" layer="94"/>
+<rectangle x1="191.375" y1="21.875" x2="191.625" y2="21.925" layer="94"/>
+<rectangle x1="192.375" y1="21.875" x2="192.625" y2="21.925" layer="94"/>
+<rectangle x1="193.275" y1="21.875" x2="193.525" y2="21.925" layer="94"/>
+<rectangle x1="193.675" y1="21.875" x2="193.925" y2="21.925" layer="94"/>
+<rectangle x1="195.375" y1="21.875" x2="195.675" y2="21.925" layer="94"/>
+<rectangle x1="196.125" y1="21.875" x2="196.375" y2="21.925" layer="94"/>
+<rectangle x1="196.475" y1="21.875" x2="196.725" y2="21.925" layer="94"/>
+<rectangle x1="197.175" y1="21.875" x2="197.425" y2="21.925" layer="94"/>
+<rectangle x1="197.875" y1="21.875" x2="198.125" y2="21.925" layer="94"/>
+<rectangle x1="198.475" y1="21.875" x2="198.725" y2="21.925" layer="94"/>
+<rectangle x1="199.525" y1="21.875" x2="199.775" y2="21.925" layer="94"/>
+<rectangle x1="200.175" y1="21.875" x2="200.475" y2="21.925" layer="94"/>
+<rectangle x1="201.175" y1="21.875" x2="201.475" y2="21.925" layer="94"/>
+<rectangle x1="201.925" y1="21.875" x2="202.175" y2="21.925" layer="94"/>
+<rectangle x1="202.925" y1="21.875" x2="203.225" y2="21.925" layer="94"/>
+<rectangle x1="203.325" y1="21.875" x2="203.575" y2="21.925" layer="94"/>
+<rectangle x1="205.075" y1="21.875" x2="205.375" y2="21.925" layer="94"/>
+<rectangle x1="206.975" y1="21.875" x2="207.275" y2="21.925" layer="94"/>
+<rectangle x1="208.375" y1="21.875" x2="208.675" y2="21.925" layer="94"/>
+<rectangle x1="209.075" y1="21.875" x2="209.325" y2="21.925" layer="94"/>
+<rectangle x1="210.975" y1="21.875" x2="211.275" y2="21.925" layer="94"/>
+<rectangle x1="212.075" y1="21.875" x2="212.375" y2="21.925" layer="94"/>
+<rectangle x1="212.825" y1="21.875" x2="213.175" y2="21.925" layer="94"/>
+<rectangle x1="215.225" y1="21.875" x2="215.525" y2="21.925" layer="94"/>
+<rectangle x1="216.575" y1="21.875" x2="216.875" y2="21.925" layer="94"/>
+<rectangle x1="217.325" y1="21.875" x2="217.575" y2="21.925" layer="94"/>
+<rectangle x1="219.275" y1="21.875" x2="219.525" y2="21.925" layer="94"/>
+<rectangle x1="219.675" y1="21.875" x2="219.925" y2="21.925" layer="94"/>
+<rectangle x1="220.475" y1="21.875" x2="220.775" y2="21.925" layer="94"/>
+<rectangle x1="222.225" y1="21.875" x2="222.475" y2="21.925" layer="94"/>
+<rectangle x1="222.825" y1="21.875" x2="223.075" y2="21.925" layer="94"/>
+<rectangle x1="223.925" y1="21.875" x2="224.225" y2="21.925" layer="94"/>
+<rectangle x1="224.525" y1="21.875" x2="224.825" y2="21.925" layer="94"/>
+<rectangle x1="225.575" y1="21.875" x2="225.875" y2="21.925" layer="94"/>
+<rectangle x1="226.225" y1="21.875" x2="226.475" y2="21.925" layer="94"/>
+<rectangle x1="227.125" y1="21.875" x2="227.375" y2="21.925" layer="94"/>
+<rectangle x1="228.075" y1="21.875" x2="228.325" y2="21.925" layer="94"/>
+<rectangle x1="228.675" y1="21.875" x2="228.925" y2="21.925" layer="94"/>
+<rectangle x1="230.375" y1="21.875" x2="230.625" y2="21.925" layer="94"/>
+<rectangle x1="231.375" y1="21.875" x2="231.625" y2="21.925" layer="94"/>
+<rectangle x1="232.075" y1="21.875" x2="232.375" y2="21.925" layer="94"/>
+<rectangle x1="233.725" y1="21.875" x2="234.025" y2="21.925" layer="94"/>
+<rectangle x1="235.025" y1="21.875" x2="235.325" y2="21.925" layer="94"/>
+<rectangle x1="235.625" y1="21.875" x2="235.925" y2="21.925" layer="94"/>
+<rectangle x1="236.775" y1="21.875" x2="237.025" y2="21.925" layer="94"/>
+<rectangle x1="237.325" y1="21.875" x2="237.575" y2="21.925" layer="94"/>
+<rectangle x1="238.375" y1="21.875" x2="238.625" y2="21.925" layer="94"/>
+<rectangle x1="239.025" y1="21.875" x2="239.325" y2="21.925" layer="94"/>
+<rectangle x1="239.975" y1="21.875" x2="240.275" y2="21.925" layer="94"/>
+<rectangle x1="241.025" y1="21.875" x2="241.325" y2="21.925" layer="94"/>
+<rectangle x1="186.375" y1="21.925" x2="186.675" y2="21.975" layer="94"/>
+<rectangle x1="187.625" y1="21.925" x2="187.925" y2="21.975" layer="94"/>
+<rectangle x1="189.575" y1="21.925" x2="189.825" y2="21.975" layer="94"/>
+<rectangle x1="190.675" y1="21.925" x2="190.975" y2="21.975" layer="94"/>
+<rectangle x1="191.375" y1="21.925" x2="191.625" y2="21.975" layer="94"/>
+<rectangle x1="192.375" y1="21.925" x2="192.625" y2="21.975" layer="94"/>
+<rectangle x1="193.275" y1="21.925" x2="193.525" y2="21.975" layer="94"/>
+<rectangle x1="193.675" y1="21.925" x2="193.925" y2="21.975" layer="94"/>
+<rectangle x1="195.375" y1="21.925" x2="195.675" y2="21.975" layer="94"/>
+<rectangle x1="196.075" y1="21.925" x2="196.325" y2="21.975" layer="94"/>
+<rectangle x1="196.525" y1="21.925" x2="196.725" y2="21.975" layer="94"/>
+<rectangle x1="197.175" y1="21.925" x2="197.425" y2="21.975" layer="94"/>
+<rectangle x1="197.875" y1="21.925" x2="198.125" y2="21.975" layer="94"/>
+<rectangle x1="198.475" y1="21.925" x2="198.725" y2="21.975" layer="94"/>
+<rectangle x1="199.525" y1="21.925" x2="199.775" y2="21.975" layer="94"/>
+<rectangle x1="200.175" y1="21.925" x2="200.475" y2="21.975" layer="94"/>
+<rectangle x1="201.175" y1="21.925" x2="201.475" y2="21.975" layer="94"/>
+<rectangle x1="201.925" y1="21.925" x2="202.175" y2="21.975" layer="94"/>
+<rectangle x1="202.925" y1="21.925" x2="203.175" y2="21.975" layer="94"/>
+<rectangle x1="203.325" y1="21.925" x2="203.575" y2="21.975" layer="94"/>
+<rectangle x1="205.075" y1="21.925" x2="205.375" y2="21.975" layer="94"/>
+<rectangle x1="206.975" y1="21.925" x2="207.275" y2="21.975" layer="94"/>
+<rectangle x1="208.375" y1="21.925" x2="208.675" y2="21.975" layer="94"/>
+<rectangle x1="209.075" y1="21.925" x2="209.325" y2="21.975" layer="94"/>
+<rectangle x1="210.975" y1="21.925" x2="211.225" y2="21.975" layer="94"/>
+<rectangle x1="212.075" y1="21.925" x2="212.375" y2="21.975" layer="94"/>
+<rectangle x1="212.875" y1="21.925" x2="213.225" y2="21.975" layer="94"/>
+<rectangle x1="215.225" y1="21.925" x2="215.525" y2="21.975" layer="94"/>
+<rectangle x1="216.625" y1="21.925" x2="216.925" y2="21.975" layer="94"/>
+<rectangle x1="217.325" y1="21.925" x2="217.575" y2="21.975" layer="94"/>
+<rectangle x1="219.275" y1="21.925" x2="219.525" y2="21.975" layer="94"/>
+<rectangle x1="219.675" y1="21.925" x2="219.925" y2="21.975" layer="94"/>
+<rectangle x1="220.475" y1="21.925" x2="220.775" y2="21.975" layer="94"/>
+<rectangle x1="222.225" y1="21.925" x2="222.475" y2="21.975" layer="94"/>
+<rectangle x1="222.775" y1="21.925" x2="223.075" y2="21.975" layer="94"/>
+<rectangle x1="223.925" y1="21.925" x2="224.225" y2="21.975" layer="94"/>
+<rectangle x1="224.525" y1="21.925" x2="224.825" y2="21.975" layer="94"/>
+<rectangle x1="225.575" y1="21.925" x2="225.875" y2="21.975" layer="94"/>
+<rectangle x1="226.225" y1="21.925" x2="226.475" y2="21.975" layer="94"/>
+<rectangle x1="227.125" y1="21.925" x2="227.375" y2="21.975" layer="94"/>
+<rectangle x1="228.075" y1="21.925" x2="228.325" y2="21.975" layer="94"/>
+<rectangle x1="228.625" y1="21.925" x2="228.925" y2="21.975" layer="94"/>
+<rectangle x1="230.375" y1="21.925" x2="230.625" y2="21.975" layer="94"/>
+<rectangle x1="231.375" y1="21.925" x2="231.625" y2="21.975" layer="94"/>
+<rectangle x1="232.075" y1="21.925" x2="232.375" y2="21.975" layer="94"/>
+<rectangle x1="233.725" y1="21.925" x2="234.025" y2="21.975" layer="94"/>
+<rectangle x1="235.025" y1="21.925" x2="235.325" y2="21.975" layer="94"/>
+<rectangle x1="235.625" y1="21.925" x2="235.925" y2="21.975" layer="94"/>
+<rectangle x1="236.775" y1="21.925" x2="237.075" y2="21.975" layer="94"/>
+<rectangle x1="237.325" y1="21.925" x2="237.625" y2="21.975" layer="94"/>
+<rectangle x1="238.375" y1="21.925" x2="238.625" y2="21.975" layer="94"/>
+<rectangle x1="239.025" y1="21.925" x2="239.325" y2="21.975" layer="94"/>
+<rectangle x1="239.975" y1="21.925" x2="240.275" y2="21.975" layer="94"/>
+<rectangle x1="241.025" y1="21.925" x2="241.325" y2="21.975" layer="94"/>
+<rectangle x1="186.375" y1="21.975" x2="186.675" y2="22.025" layer="94"/>
+<rectangle x1="187.625" y1="21.975" x2="187.925" y2="22.025" layer="94"/>
+<rectangle x1="189.575" y1="21.975" x2="189.825" y2="22.025" layer="94"/>
+<rectangle x1="190.675" y1="21.975" x2="190.975" y2="22.025" layer="94"/>
+<rectangle x1="191.375" y1="21.975" x2="191.625" y2="22.025" layer="94"/>
+<rectangle x1="192.375" y1="21.975" x2="192.625" y2="22.025" layer="94"/>
+<rectangle x1="193.225" y1="21.975" x2="193.525" y2="22.025" layer="94"/>
+<rectangle x1="193.675" y1="21.975" x2="193.925" y2="22.025" layer="94"/>
+<rectangle x1="195.375" y1="21.975" x2="195.675" y2="22.025" layer="94"/>
+<rectangle x1="196.075" y1="21.975" x2="196.325" y2="22.025" layer="94"/>
+<rectangle x1="196.525" y1="21.975" x2="196.725" y2="22.025" layer="94"/>
+<rectangle x1="197.175" y1="21.975" x2="197.425" y2="22.025" layer="94"/>
+<rectangle x1="197.875" y1="21.975" x2="198.125" y2="22.025" layer="94"/>
+<rectangle x1="198.475" y1="21.975" x2="198.725" y2="22.025" layer="94"/>
+<rectangle x1="199.525" y1="21.975" x2="199.775" y2="22.025" layer="94"/>
+<rectangle x1="200.175" y1="21.975" x2="200.475" y2="22.025" layer="94"/>
+<rectangle x1="201.175" y1="21.975" x2="201.475" y2="22.025" layer="94"/>
+<rectangle x1="201.925" y1="21.975" x2="202.175" y2="22.025" layer="94"/>
+<rectangle x1="202.925" y1="21.975" x2="203.175" y2="22.025" layer="94"/>
+<rectangle x1="203.375" y1="21.975" x2="203.625" y2="22.025" layer="94"/>
+<rectangle x1="205.075" y1="21.975" x2="205.375" y2="22.025" layer="94"/>
+<rectangle x1="206.975" y1="21.975" x2="207.275" y2="22.025" layer="94"/>
+<rectangle x1="208.375" y1="21.975" x2="208.675" y2="22.025" layer="94"/>
+<rectangle x1="209.075" y1="21.975" x2="209.325" y2="22.025" layer="94"/>
+<rectangle x1="212.075" y1="21.975" x2="212.375" y2="22.025" layer="94"/>
+<rectangle x1="212.925" y1="21.975" x2="213.325" y2="22.025" layer="94"/>
+<rectangle x1="215.225" y1="21.975" x2="215.525" y2="22.025" layer="94"/>
+<rectangle x1="216.625" y1="21.975" x2="216.925" y2="22.025" layer="94"/>
+<rectangle x1="217.275" y1="21.975" x2="217.575" y2="22.025" layer="94"/>
+<rectangle x1="219.225" y1="21.975" x2="219.475" y2="22.025" layer="94"/>
+<rectangle x1="219.675" y1="21.975" x2="219.925" y2="22.025" layer="94"/>
+<rectangle x1="220.475" y1="21.975" x2="220.725" y2="22.025" layer="94"/>
+<rectangle x1="222.225" y1="21.975" x2="222.475" y2="22.025" layer="94"/>
+<rectangle x1="222.775" y1="21.975" x2="223.075" y2="22.025" layer="94"/>
+<rectangle x1="223.925" y1="21.975" x2="224.225" y2="22.025" layer="94"/>
+<rectangle x1="224.525" y1="21.975" x2="224.775" y2="22.025" layer="94"/>
+<rectangle x1="225.625" y1="21.975" x2="225.875" y2="22.025" layer="94"/>
+<rectangle x1="226.225" y1="21.975" x2="226.475" y2="22.025" layer="94"/>
+<rectangle x1="227.125" y1="21.975" x2="227.375" y2="22.025" layer="94"/>
+<rectangle x1="228.075" y1="21.975" x2="228.325" y2="22.025" layer="94"/>
+<rectangle x1="228.625" y1="21.975" x2="228.925" y2="22.025" layer="94"/>
+<rectangle x1="230.375" y1="21.975" x2="230.625" y2="22.025" layer="94"/>
+<rectangle x1="231.375" y1="21.975" x2="231.625" y2="22.025" layer="94"/>
+<rectangle x1="232.075" y1="21.975" x2="232.375" y2="22.025" layer="94"/>
+<rectangle x1="233.725" y1="21.975" x2="234.025" y2="22.025" layer="94"/>
+<rectangle x1="235.075" y1="21.975" x2="235.375" y2="22.025" layer="94"/>
+<rectangle x1="235.625" y1="21.975" x2="235.925" y2="22.025" layer="94"/>
+<rectangle x1="236.775" y1="21.975" x2="237.075" y2="22.025" layer="94"/>
+<rectangle x1="237.325" y1="21.975" x2="237.675" y2="22.025" layer="94"/>
+<rectangle x1="238.375" y1="21.975" x2="238.625" y2="22.025" layer="94"/>
+<rectangle x1="239.025" y1="21.975" x2="239.325" y2="22.025" layer="94"/>
+<rectangle x1="239.975" y1="21.975" x2="240.225" y2="22.025" layer="94"/>
+<rectangle x1="241.025" y1="21.975" x2="241.325" y2="22.025" layer="94"/>
+<rectangle x1="186.425" y1="22.025" x2="187.875" y2="22.075" layer="94"/>
+<rectangle x1="189.575" y1="22.025" x2="189.825" y2="22.075" layer="94"/>
+<rectangle x1="190.675" y1="22.025" x2="190.975" y2="22.075" layer="94"/>
+<rectangle x1="191.375" y1="22.025" x2="191.625" y2="22.075" layer="94"/>
+<rectangle x1="192.375" y1="22.025" x2="192.625" y2="22.075" layer="94"/>
+<rectangle x1="193.225" y1="22.025" x2="193.475" y2="22.075" layer="94"/>
+<rectangle x1="193.725" y1="22.025" x2="193.975" y2="22.075" layer="94"/>
+<rectangle x1="195.375" y1="22.025" x2="195.675" y2="22.075" layer="94"/>
+<rectangle x1="196.075" y1="22.025" x2="196.325" y2="22.075" layer="94"/>
+<rectangle x1="196.525" y1="22.025" x2="196.775" y2="22.075" layer="94"/>
+<rectangle x1="197.175" y1="22.025" x2="197.425" y2="22.075" layer="94"/>
+<rectangle x1="197.875" y1="22.025" x2="198.125" y2="22.075" layer="94"/>
+<rectangle x1="198.425" y1="22.025" x2="198.725" y2="22.075" layer="94"/>
+<rectangle x1="199.525" y1="22.025" x2="199.775" y2="22.075" layer="94"/>
+<rectangle x1="200.175" y1="22.025" x2="200.475" y2="22.075" layer="94"/>
+<rectangle x1="201.175" y1="22.025" x2="201.475" y2="22.075" layer="94"/>
+<rectangle x1="201.925" y1="22.025" x2="202.175" y2="22.075" layer="94"/>
+<rectangle x1="202.875" y1="22.025" x2="203.175" y2="22.075" layer="94"/>
+<rectangle x1="203.375" y1="22.025" x2="203.625" y2="22.075" layer="94"/>
+<rectangle x1="205.075" y1="22.025" x2="205.375" y2="22.075" layer="94"/>
+<rectangle x1="206.975" y1="22.025" x2="207.225" y2="22.075" layer="94"/>
+<rectangle x1="208.375" y1="22.025" x2="208.675" y2="22.075" layer="94"/>
+<rectangle x1="209.075" y1="22.025" x2="209.325" y2="22.075" layer="94"/>
+<rectangle x1="212.075" y1="22.025" x2="212.375" y2="22.075" layer="94"/>
+<rectangle x1="212.975" y1="22.025" x2="213.375" y2="22.075" layer="94"/>
+<rectangle x1="215.225" y1="22.025" x2="215.525" y2="22.075" layer="94"/>
+<rectangle x1="216.675" y1="22.025" x2="216.975" y2="22.075" layer="94"/>
+<rectangle x1="217.275" y1="22.025" x2="217.575" y2="22.075" layer="94"/>
+<rectangle x1="219.225" y1="22.025" x2="219.475" y2="22.075" layer="94"/>
+<rectangle x1="219.725" y1="22.025" x2="219.975" y2="22.075" layer="94"/>
+<rectangle x1="220.475" y1="22.025" x2="220.725" y2="22.075" layer="94"/>
+<rectangle x1="222.225" y1="22.025" x2="222.475" y2="22.075" layer="94"/>
+<rectangle x1="222.775" y1="22.025" x2="223.075" y2="22.075" layer="94"/>
+<rectangle x1="223.925" y1="22.025" x2="224.225" y2="22.075" layer="94"/>
+<rectangle x1="224.525" y1="22.025" x2="224.775" y2="22.075" layer="94"/>
+<rectangle x1="225.625" y1="22.025" x2="225.875" y2="22.075" layer="94"/>
+<rectangle x1="226.225" y1="22.025" x2="226.475" y2="22.075" layer="94"/>
+<rectangle x1="227.125" y1="22.025" x2="227.375" y2="22.075" layer="94"/>
+<rectangle x1="228.075" y1="22.025" x2="228.325" y2="22.075" layer="94"/>
+<rectangle x1="228.625" y1="22.025" x2="228.925" y2="22.075" layer="94"/>
+<rectangle x1="230.375" y1="22.025" x2="230.625" y2="22.075" layer="94"/>
+<rectangle x1="231.375" y1="22.025" x2="231.625" y2="22.075" layer="94"/>
+<rectangle x1="232.075" y1="22.025" x2="232.375" y2="22.075" layer="94"/>
+<rectangle x1="233.725" y1="22.025" x2="234.025" y2="22.075" layer="94"/>
+<rectangle x1="235.075" y1="22.025" x2="235.375" y2="22.075" layer="94"/>
+<rectangle x1="235.625" y1="22.025" x2="235.925" y2="22.075" layer="94"/>
+<rectangle x1="236.775" y1="22.025" x2="237.075" y2="22.075" layer="94"/>
+<rectangle x1="237.375" y1="22.025" x2="237.825" y2="22.075" layer="94"/>
+<rectangle x1="238.375" y1="22.025" x2="238.625" y2="22.075" layer="94"/>
+<rectangle x1="239.025" y1="22.025" x2="239.325" y2="22.075" layer="94"/>
+<rectangle x1="239.975" y1="22.025" x2="240.225" y2="22.075" layer="94"/>
+<rectangle x1="241.075" y1="22.025" x2="241.325" y2="22.075" layer="94"/>
+<rectangle x1="186.425" y1="22.075" x2="187.875" y2="22.125" layer="94"/>
+<rectangle x1="189.575" y1="22.075" x2="189.825" y2="22.125" layer="94"/>
+<rectangle x1="190.675" y1="22.075" x2="190.975" y2="22.125" layer="94"/>
+<rectangle x1="191.375" y1="22.075" x2="191.625" y2="22.125" layer="94"/>
+<rectangle x1="192.375" y1="22.075" x2="192.625" y2="22.125" layer="94"/>
+<rectangle x1="193.175" y1="22.075" x2="193.475" y2="22.125" layer="94"/>
+<rectangle x1="193.725" y1="22.075" x2="193.975" y2="22.125" layer="94"/>
+<rectangle x1="195.375" y1="22.075" x2="195.675" y2="22.125" layer="94"/>
+<rectangle x1="196.025" y1="22.075" x2="196.275" y2="22.125" layer="94"/>
+<rectangle x1="196.575" y1="22.075" x2="196.775" y2="22.125" layer="94"/>
+<rectangle x1="197.175" y1="22.075" x2="197.425" y2="22.125" layer="94"/>
+<rectangle x1="197.875" y1="22.075" x2="198.125" y2="22.125" layer="94"/>
+<rectangle x1="198.425" y1="22.075" x2="198.725" y2="22.125" layer="94"/>
+<rectangle x1="199.525" y1="22.075" x2="199.775" y2="22.125" layer="94"/>
+<rectangle x1="200.175" y1="22.075" x2="200.475" y2="22.125" layer="94"/>
+<rectangle x1="201.175" y1="22.075" x2="201.475" y2="22.125" layer="94"/>
+<rectangle x1="201.925" y1="22.075" x2="202.175" y2="22.125" layer="94"/>
+<rectangle x1="202.875" y1="22.075" x2="203.125" y2="22.125" layer="94"/>
+<rectangle x1="203.375" y1="22.075" x2="203.675" y2="22.125" layer="94"/>
+<rectangle x1="205.075" y1="22.075" x2="205.375" y2="22.125" layer="94"/>
+<rectangle x1="207.125" y1="22.075" x2="207.225" y2="22.125" layer="94"/>
+<rectangle x1="208.375" y1="22.075" x2="208.675" y2="22.125" layer="94"/>
+<rectangle x1="209.075" y1="22.075" x2="209.325" y2="22.125" layer="94"/>
+<rectangle x1="212.075" y1="22.075" x2="212.375" y2="22.125" layer="94"/>
+<rectangle x1="213.025" y1="22.075" x2="213.425" y2="22.125" layer="94"/>
+<rectangle x1="215.225" y1="22.075" x2="215.525" y2="22.125" layer="94"/>
+<rectangle x1="216.675" y1="22.075" x2="216.975" y2="22.125" layer="94"/>
+<rectangle x1="217.275" y1="22.075" x2="217.575" y2="22.125" layer="94"/>
+<rectangle x1="219.225" y1="22.075" x2="219.475" y2="22.125" layer="94"/>
+<rectangle x1="219.725" y1="22.075" x2="219.975" y2="22.125" layer="94"/>
+<rectangle x1="220.475" y1="22.075" x2="220.725" y2="22.125" layer="94"/>
+<rectangle x1="222.225" y1="22.075" x2="222.475" y2="22.125" layer="94"/>
+<rectangle x1="222.775" y1="22.075" x2="223.075" y2="22.125" layer="94"/>
+<rectangle x1="223.975" y1="22.075" x2="224.225" y2="22.125" layer="94"/>
+<rectangle x1="224.525" y1="22.075" x2="224.775" y2="22.125" layer="94"/>
+<rectangle x1="225.625" y1="22.075" x2="225.875" y2="22.125" layer="94"/>
+<rectangle x1="226.225" y1="22.075" x2="226.475" y2="22.125" layer="94"/>
+<rectangle x1="227.125" y1="22.075" x2="227.375" y2="22.125" layer="94"/>
+<rectangle x1="228.075" y1="22.075" x2="228.325" y2="22.125" layer="94"/>
+<rectangle x1="228.625" y1="22.075" x2="228.925" y2="22.125" layer="94"/>
+<rectangle x1="230.375" y1="22.075" x2="230.625" y2="22.125" layer="94"/>
+<rectangle x1="231.375" y1="22.075" x2="231.625" y2="22.125" layer="94"/>
+<rectangle x1="232.075" y1="22.075" x2="232.375" y2="22.125" layer="94"/>
+<rectangle x1="233.725" y1="22.075" x2="234.025" y2="22.125" layer="94"/>
+<rectangle x1="235.075" y1="22.075" x2="235.325" y2="22.125" layer="94"/>
+<rectangle x1="235.625" y1="22.075" x2="235.875" y2="22.125" layer="94"/>
+<rectangle x1="236.775" y1="22.075" x2="237.075" y2="22.125" layer="94"/>
+<rectangle x1="237.425" y1="22.075" x2="238.025" y2="22.125" layer="94"/>
+<rectangle x1="238.375" y1="22.075" x2="238.625" y2="22.125" layer="94"/>
+<rectangle x1="239.025" y1="22.075" x2="239.325" y2="22.125" layer="94"/>
+<rectangle x1="239.975" y1="22.075" x2="240.225" y2="22.125" layer="94"/>
+<rectangle x1="241.075" y1="22.075" x2="241.325" y2="22.125" layer="94"/>
+<rectangle x1="186.425" y1="22.125" x2="187.875" y2="22.175" layer="94"/>
+<rectangle x1="189.575" y1="22.125" x2="189.825" y2="22.175" layer="94"/>
+<rectangle x1="190.675" y1="22.125" x2="190.975" y2="22.175" layer="94"/>
+<rectangle x1="191.375" y1="22.125" x2="191.625" y2="22.175" layer="94"/>
+<rectangle x1="192.375" y1="22.125" x2="192.625" y2="22.175" layer="94"/>
+<rectangle x1="193.175" y1="22.125" x2="193.425" y2="22.175" layer="94"/>
+<rectangle x1="193.725" y1="22.125" x2="194.025" y2="22.175" layer="94"/>
+<rectangle x1="195.375" y1="22.125" x2="195.675" y2="22.175" layer="94"/>
+<rectangle x1="196.025" y1="22.125" x2="196.275" y2="22.175" layer="94"/>
+<rectangle x1="196.575" y1="22.125" x2="196.775" y2="22.175" layer="94"/>
+<rectangle x1="197.175" y1="22.125" x2="197.425" y2="22.175" layer="94"/>
+<rectangle x1="197.875" y1="22.125" x2="198.125" y2="22.175" layer="94"/>
+<rectangle x1="198.425" y1="22.125" x2="198.725" y2="22.175" layer="94"/>
+<rectangle x1="199.525" y1="22.125" x2="199.775" y2="22.175" layer="94"/>
+<rectangle x1="200.175" y1="22.125" x2="200.475" y2="22.175" layer="94"/>
+<rectangle x1="201.175" y1="22.125" x2="201.475" y2="22.175" layer="94"/>
+<rectangle x1="201.925" y1="22.125" x2="202.175" y2="22.175" layer="94"/>
+<rectangle x1="202.875" y1="22.125" x2="203.125" y2="22.175" layer="94"/>
+<rectangle x1="203.425" y1="22.125" x2="203.675" y2="22.175" layer="94"/>
+<rectangle x1="205.075" y1="22.125" x2="205.375" y2="22.175" layer="94"/>
+<rectangle x1="208.325" y1="22.125" x2="208.675" y2="22.175" layer="94"/>
+<rectangle x1="209.075" y1="22.125" x2="209.325" y2="22.175" layer="94"/>
+<rectangle x1="212.075" y1="22.125" x2="212.375" y2="22.175" layer="94"/>
+<rectangle x1="213.125" y1="22.125" x2="213.475" y2="22.175" layer="94"/>
+<rectangle x1="215.225" y1="22.125" x2="215.525" y2="22.175" layer="94"/>
+<rectangle x1="216.675" y1="22.125" x2="216.975" y2="22.175" layer="94"/>
+<rectangle x1="217.275" y1="22.125" x2="218.725" y2="22.175" layer="94"/>
+<rectangle x1="219.175" y1="22.125" x2="219.425" y2="22.175" layer="94"/>
+<rectangle x1="219.725" y1="22.125" x2="220.025" y2="22.175" layer="94"/>
+<rectangle x1="220.475" y1="22.125" x2="221.875" y2="22.175" layer="94"/>
+<rectangle x1="222.225" y1="22.125" x2="222.475" y2="22.175" layer="94"/>
+<rectangle x1="222.775" y1="22.125" x2="223.025" y2="22.175" layer="94"/>
+<rectangle x1="223.975" y1="22.125" x2="224.225" y2="22.175" layer="94"/>
+<rectangle x1="224.525" y1="22.125" x2="224.775" y2="22.175" layer="94"/>
+<rectangle x1="225.625" y1="22.125" x2="225.875" y2="22.175" layer="94"/>
+<rectangle x1="226.225" y1="22.125" x2="226.475" y2="22.175" layer="94"/>
+<rectangle x1="227.125" y1="22.125" x2="227.375" y2="22.175" layer="94"/>
+<rectangle x1="228.075" y1="22.125" x2="228.325" y2="22.175" layer="94"/>
+<rectangle x1="228.625" y1="22.125" x2="230.075" y2="22.175" layer="94"/>
+<rectangle x1="230.375" y1="22.125" x2="230.625" y2="22.175" layer="94"/>
+<rectangle x1="231.375" y1="22.125" x2="231.625" y2="22.175" layer="94"/>
+<rectangle x1="232.075" y1="22.125" x2="232.375" y2="22.175" layer="94"/>
+<rectangle x1="233.725" y1="22.125" x2="234.025" y2="22.175" layer="94"/>
+<rectangle x1="235.025" y1="22.125" x2="235.325" y2="22.175" layer="94"/>
+<rectangle x1="235.625" y1="22.125" x2="235.875" y2="22.175" layer="94"/>
+<rectangle x1="236.775" y1="22.125" x2="237.075" y2="22.175" layer="94"/>
+<rectangle x1="237.475" y1="22.125" x2="238.275" y2="22.175" layer="94"/>
+<rectangle x1="238.375" y1="22.125" x2="238.625" y2="22.175" layer="94"/>
+<rectangle x1="239.025" y1="22.125" x2="239.325" y2="22.175" layer="94"/>
+<rectangle x1="239.975" y1="22.125" x2="240.225" y2="22.175" layer="94"/>
+<rectangle x1="241.075" y1="22.125" x2="241.325" y2="22.175" layer="94"/>
+<rectangle x1="186.475" y1="22.175" x2="187.825" y2="22.225" layer="94"/>
+<rectangle x1="189.575" y1="22.175" x2="189.825" y2="22.225" layer="94"/>
+<rectangle x1="190.675" y1="22.175" x2="190.975" y2="22.225" layer="94"/>
+<rectangle x1="191.375" y1="22.175" x2="191.625" y2="22.225" layer="94"/>
+<rectangle x1="192.375" y1="22.175" x2="192.625" y2="22.225" layer="94"/>
+<rectangle x1="193.175" y1="22.175" x2="193.425" y2="22.225" layer="94"/>
+<rectangle x1="193.775" y1="22.175" x2="194.025" y2="22.225" layer="94"/>
+<rectangle x1="195.375" y1="22.175" x2="195.675" y2="22.225" layer="94"/>
+<rectangle x1="196.025" y1="22.175" x2="196.275" y2="22.225" layer="94"/>
+<rectangle x1="196.575" y1="22.175" x2="196.825" y2="22.225" layer="94"/>
+<rectangle x1="197.175" y1="22.175" x2="197.425" y2="22.225" layer="94"/>
+<rectangle x1="197.875" y1="22.175" x2="198.125" y2="22.225" layer="94"/>
+<rectangle x1="198.425" y1="22.175" x2="198.675" y2="22.225" layer="94"/>
+<rectangle x1="199.525" y1="22.175" x2="199.775" y2="22.225" layer="94"/>
+<rectangle x1="200.175" y1="22.175" x2="200.475" y2="22.225" layer="94"/>
+<rectangle x1="201.175" y1="22.175" x2="201.475" y2="22.225" layer="94"/>
+<rectangle x1="201.925" y1="22.175" x2="202.175" y2="22.225" layer="94"/>
+<rectangle x1="202.825" y1="22.175" x2="203.125" y2="22.225" layer="94"/>
+<rectangle x1="203.425" y1="22.175" x2="203.675" y2="22.225" layer="94"/>
+<rectangle x1="205.075" y1="22.175" x2="205.375" y2="22.225" layer="94"/>
+<rectangle x1="208.275" y1="22.175" x2="208.625" y2="22.225" layer="94"/>
+<rectangle x1="209.075" y1="22.175" x2="209.325" y2="22.225" layer="94"/>
+<rectangle x1="212.025" y1="22.175" x2="212.325" y2="22.225" layer="94"/>
+<rectangle x1="213.175" y1="22.175" x2="213.525" y2="22.225" layer="94"/>
+<rectangle x1="215.225" y1="22.175" x2="215.525" y2="22.225" layer="94"/>
+<rectangle x1="216.675" y1="22.175" x2="216.975" y2="22.225" layer="94"/>
+<rectangle x1="217.275" y1="22.175" x2="218.725" y2="22.225" layer="94"/>
+<rectangle x1="219.175" y1="22.175" x2="219.425" y2="22.225" layer="94"/>
+<rectangle x1="219.775" y1="22.175" x2="220.025" y2="22.225" layer="94"/>
+<rectangle x1="220.475" y1="22.175" x2="221.875" y2="22.225" layer="94"/>
+<rectangle x1="222.225" y1="22.175" x2="222.475" y2="22.225" layer="94"/>
+<rectangle x1="222.775" y1="22.175" x2="223.025" y2="22.225" layer="94"/>
+<rectangle x1="223.975" y1="22.175" x2="224.225" y2="22.225" layer="94"/>
+<rectangle x1="224.525" y1="22.175" x2="224.775" y2="22.225" layer="94"/>
+<rectangle x1="225.625" y1="22.175" x2="225.875" y2="22.225" layer="94"/>
+<rectangle x1="226.225" y1="22.175" x2="226.475" y2="22.225" layer="94"/>
+<rectangle x1="227.125" y1="22.175" x2="227.375" y2="22.225" layer="94"/>
+<rectangle x1="228.075" y1="22.175" x2="228.325" y2="22.225" layer="94"/>
+<rectangle x1="228.625" y1="22.175" x2="230.075" y2="22.225" layer="94"/>
+<rectangle x1="230.375" y1="22.175" x2="230.625" y2="22.225" layer="94"/>
+<rectangle x1="231.375" y1="22.175" x2="231.625" y2="22.225" layer="94"/>
+<rectangle x1="232.075" y1="22.175" x2="232.375" y2="22.225" layer="94"/>
+<rectangle x1="233.725" y1="22.175" x2="234.025" y2="22.225" layer="94"/>
+<rectangle x1="235.025" y1="22.175" x2="235.325" y2="22.225" layer="94"/>
+<rectangle x1="235.625" y1="22.175" x2="235.875" y2="22.225" layer="94"/>
+<rectangle x1="236.775" y1="22.175" x2="237.075" y2="22.225" layer="94"/>
+<rectangle x1="237.575" y1="22.175" x2="238.625" y2="22.225" layer="94"/>
+<rectangle x1="239.025" y1="22.175" x2="239.325" y2="22.225" layer="94"/>
+<rectangle x1="239.975" y1="22.175" x2="240.225" y2="22.225" layer="94"/>
+<rectangle x1="241.075" y1="22.175" x2="241.325" y2="22.225" layer="94"/>
+<rectangle x1="186.475" y1="22.225" x2="187.825" y2="22.275" layer="94"/>
+<rectangle x1="189.575" y1="22.225" x2="189.825" y2="22.275" layer="94"/>
+<rectangle x1="190.675" y1="22.225" x2="190.975" y2="22.275" layer="94"/>
+<rectangle x1="191.375" y1="22.225" x2="191.625" y2="22.275" layer="94"/>
+<rectangle x1="192.375" y1="22.225" x2="192.625" y2="22.275" layer="94"/>
+<rectangle x1="193.125" y1="22.225" x2="193.425" y2="22.275" layer="94"/>
+<rectangle x1="193.775" y1="22.225" x2="194.025" y2="22.275" layer="94"/>
+<rectangle x1="195.375" y1="22.225" x2="195.675" y2="22.275" layer="94"/>
+<rectangle x1="195.975" y1="22.225" x2="196.225" y2="22.275" layer="94"/>
+<rectangle x1="196.625" y1="22.225" x2="196.825" y2="22.275" layer="94"/>
+<rectangle x1="197.175" y1="22.225" x2="197.425" y2="22.275" layer="94"/>
+<rectangle x1="197.875" y1="22.225" x2="198.125" y2="22.275" layer="94"/>
+<rectangle x1="198.425" y1="22.225" x2="198.725" y2="22.275" layer="94"/>
+<rectangle x1="199.525" y1="22.225" x2="199.775" y2="22.275" layer="94"/>
+<rectangle x1="200.175" y1="22.225" x2="200.475" y2="22.275" layer="94"/>
+<rectangle x1="201.175" y1="22.225" x2="201.475" y2="22.275" layer="94"/>
+<rectangle x1="201.925" y1="22.225" x2="202.175" y2="22.275" layer="94"/>
+<rectangle x1="202.825" y1="22.225" x2="203.075" y2="22.275" layer="94"/>
+<rectangle x1="203.475" y1="22.225" x2="203.725" y2="22.275" layer="94"/>
+<rectangle x1="205.075" y1="22.225" x2="205.375" y2="22.275" layer="94"/>
+<rectangle x1="208.225" y1="22.225" x2="208.625" y2="22.275" layer="94"/>
+<rectangle x1="209.075" y1="22.225" x2="209.375" y2="22.275" layer="94"/>
+<rectangle x1="212.025" y1="22.225" x2="212.325" y2="22.275" layer="94"/>
+<rectangle x1="213.225" y1="22.225" x2="213.575" y2="22.275" layer="94"/>
+<rectangle x1="215.225" y1="22.225" x2="215.525" y2="22.275" layer="94"/>
+<rectangle x1="216.725" y1="22.225" x2="216.975" y2="22.275" layer="94"/>
+<rectangle x1="217.275" y1="22.225" x2="218.725" y2="22.275" layer="94"/>
+<rectangle x1="219.125" y1="22.225" x2="219.425" y2="22.275" layer="94"/>
+<rectangle x1="219.775" y1="22.225" x2="220.025" y2="22.275" layer="94"/>
+<rectangle x1="220.475" y1="22.225" x2="221.875" y2="22.275" layer="94"/>
+<rectangle x1="222.225" y1="22.225" x2="222.475" y2="22.275" layer="94"/>
+<rectangle x1="222.775" y1="22.225" x2="223.075" y2="22.275" layer="94"/>
+<rectangle x1="223.975" y1="22.225" x2="224.225" y2="22.275" layer="94"/>
+<rectangle x1="224.525" y1="22.225" x2="224.775" y2="22.275" layer="94"/>
+<rectangle x1="225.625" y1="22.225" x2="225.875" y2="22.275" layer="94"/>
+<rectangle x1="226.225" y1="22.225" x2="226.475" y2="22.275" layer="94"/>
+<rectangle x1="227.125" y1="22.225" x2="227.375" y2="22.275" layer="94"/>
+<rectangle x1="228.075" y1="22.225" x2="228.325" y2="22.275" layer="94"/>
+<rectangle x1="228.625" y1="22.225" x2="230.075" y2="22.275" layer="94"/>
+<rectangle x1="230.375" y1="22.225" x2="230.625" y2="22.275" layer="94"/>
+<rectangle x1="231.375" y1="22.225" x2="231.625" y2="22.275" layer="94"/>
+<rectangle x1="232.075" y1="22.225" x2="232.375" y2="22.275" layer="94"/>
+<rectangle x1="233.725" y1="22.225" x2="234.025" y2="22.275" layer="94"/>
+<rectangle x1="234.975" y1="22.225" x2="235.325" y2="22.275" layer="94"/>
+<rectangle x1="235.625" y1="22.225" x2="235.875" y2="22.275" layer="94"/>
+<rectangle x1="236.775" y1="22.225" x2="237.075" y2="22.275" layer="94"/>
+<rectangle x1="237.675" y1="22.225" x2="238.625" y2="22.275" layer="94"/>
+<rectangle x1="239.025" y1="22.225" x2="239.325" y2="22.275" layer="94"/>
+<rectangle x1="239.975" y1="22.225" x2="240.225" y2="22.275" layer="94"/>
+<rectangle x1="241.075" y1="22.225" x2="241.325" y2="22.275" layer="94"/>
+<rectangle x1="186.525" y1="22.275" x2="186.775" y2="22.325" layer="94"/>
+<rectangle x1="187.475" y1="22.275" x2="187.775" y2="22.325" layer="94"/>
+<rectangle x1="189.575" y1="22.275" x2="189.825" y2="22.325" layer="94"/>
+<rectangle x1="190.675" y1="22.275" x2="190.975" y2="22.325" layer="94"/>
+<rectangle x1="191.375" y1="22.275" x2="191.625" y2="22.325" layer="94"/>
+<rectangle x1="192.375" y1="22.275" x2="192.625" y2="22.325" layer="94"/>
+<rectangle x1="193.125" y1="22.275" x2="193.375" y2="22.325" layer="94"/>
+<rectangle x1="193.775" y1="22.275" x2="194.075" y2="22.325" layer="94"/>
+<rectangle x1="195.375" y1="22.275" x2="195.675" y2="22.325" layer="94"/>
+<rectangle x1="195.975" y1="22.275" x2="196.225" y2="22.325" layer="94"/>
+<rectangle x1="196.625" y1="22.275" x2="196.875" y2="22.325" layer="94"/>
+<rectangle x1="197.175" y1="22.275" x2="197.425" y2="22.325" layer="94"/>
+<rectangle x1="197.875" y1="22.275" x2="198.125" y2="22.325" layer="94"/>
+<rectangle x1="198.425" y1="22.275" x2="198.725" y2="22.325" layer="94"/>
+<rectangle x1="199.525" y1="22.275" x2="199.775" y2="22.325" layer="94"/>
+<rectangle x1="200.175" y1="22.275" x2="200.475" y2="22.325" layer="94"/>
+<rectangle x1="201.175" y1="22.275" x2="201.475" y2="22.325" layer="94"/>
+<rectangle x1="201.925" y1="22.275" x2="202.175" y2="22.325" layer="94"/>
+<rectangle x1="202.775" y1="22.275" x2="203.075" y2="22.325" layer="94"/>
+<rectangle x1="203.475" y1="22.275" x2="203.725" y2="22.325" layer="94"/>
+<rectangle x1="205.075" y1="22.275" x2="205.375" y2="22.325" layer="94"/>
+<rectangle x1="208.075" y1="22.275" x2="208.575" y2="22.325" layer="94"/>
+<rectangle x1="209.075" y1="22.275" x2="210.225" y2="22.325" layer="94"/>
+<rectangle x1="211.975" y1="22.275" x2="212.325" y2="22.325" layer="94"/>
+<rectangle x1="213.275" y1="22.275" x2="213.625" y2="22.325" layer="94"/>
+<rectangle x1="215.225" y1="22.275" x2="215.525" y2="22.325" layer="94"/>
+<rectangle x1="216.725" y1="22.275" x2="217.025" y2="22.325" layer="94"/>
+<rectangle x1="217.275" y1="22.275" x2="218.725" y2="22.325" layer="94"/>
+<rectangle x1="219.125" y1="22.275" x2="219.375" y2="22.325" layer="94"/>
+<rectangle x1="219.775" y1="22.275" x2="220.075" y2="22.325" layer="94"/>
+<rectangle x1="220.475" y1="22.275" x2="221.875" y2="22.325" layer="94"/>
+<rectangle x1="222.225" y1="22.275" x2="222.475" y2="22.325" layer="94"/>
+<rectangle x1="222.775" y1="22.275" x2="223.075" y2="22.325" layer="94"/>
+<rectangle x1="223.925" y1="22.275" x2="224.225" y2="22.325" layer="94"/>
+<rectangle x1="224.525" y1="22.275" x2="224.775" y2="22.325" layer="94"/>
+<rectangle x1="225.625" y1="22.275" x2="225.875" y2="22.325" layer="94"/>
+<rectangle x1="226.225" y1="22.275" x2="226.475" y2="22.325" layer="94"/>
+<rectangle x1="227.125" y1="22.275" x2="227.375" y2="22.325" layer="94"/>
+<rectangle x1="228.075" y1="22.275" x2="228.325" y2="22.325" layer="94"/>
+<rectangle x1="228.625" y1="22.275" x2="230.025" y2="22.325" layer="94"/>
+<rectangle x1="230.375" y1="22.275" x2="230.625" y2="22.325" layer="94"/>
+<rectangle x1="231.375" y1="22.275" x2="231.625" y2="22.325" layer="94"/>
+<rectangle x1="232.075" y1="22.275" x2="232.375" y2="22.325" layer="94"/>
+<rectangle x1="233.725" y1="22.275" x2="234.025" y2="22.325" layer="94"/>
+<rectangle x1="234.925" y1="22.275" x2="235.275" y2="22.325" layer="94"/>
+<rectangle x1="235.625" y1="22.275" x2="235.925" y2="22.325" layer="94"/>
+<rectangle x1="236.775" y1="22.275" x2="237.075" y2="22.325" layer="94"/>
+<rectangle x1="237.925" y1="22.275" x2="238.625" y2="22.325" layer="94"/>
+<rectangle x1="239.025" y1="22.275" x2="239.325" y2="22.325" layer="94"/>
+<rectangle x1="239.975" y1="22.275" x2="240.225" y2="22.325" layer="94"/>
+<rectangle x1="241.025" y1="22.275" x2="241.325" y2="22.325" layer="94"/>
+<rectangle x1="186.525" y1="22.325" x2="186.825" y2="22.375" layer="94"/>
+<rectangle x1="187.475" y1="22.325" x2="187.775" y2="22.375" layer="94"/>
+<rectangle x1="189.575" y1="22.325" x2="189.825" y2="22.375" layer="94"/>
+<rectangle x1="190.675" y1="22.325" x2="190.975" y2="22.375" layer="94"/>
+<rectangle x1="191.375" y1="22.325" x2="191.625" y2="22.375" layer="94"/>
+<rectangle x1="192.375" y1="22.325" x2="192.625" y2="22.375" layer="94"/>
+<rectangle x1="193.125" y1="22.325" x2="193.375" y2="22.375" layer="94"/>
+<rectangle x1="193.825" y1="22.325" x2="194.075" y2="22.375" layer="94"/>
+<rectangle x1="195.375" y1="22.325" x2="195.675" y2="22.375" layer="94"/>
+<rectangle x1="195.975" y1="22.325" x2="196.225" y2="22.375" layer="94"/>
+<rectangle x1="196.625" y1="22.325" x2="196.875" y2="22.375" layer="94"/>
+<rectangle x1="197.175" y1="22.325" x2="197.425" y2="22.375" layer="94"/>
+<rectangle x1="197.875" y1="22.325" x2="198.125" y2="22.375" layer="94"/>
+<rectangle x1="198.425" y1="22.325" x2="198.725" y2="22.375" layer="94"/>
+<rectangle x1="199.525" y1="22.325" x2="199.775" y2="22.375" layer="94"/>
+<rectangle x1="200.175" y1="22.325" x2="200.475" y2="22.375" layer="94"/>
+<rectangle x1="201.175" y1="22.325" x2="201.475" y2="22.375" layer="94"/>
+<rectangle x1="201.925" y1="22.325" x2="202.175" y2="22.375" layer="94"/>
+<rectangle x1="202.775" y1="22.325" x2="203.025" y2="22.375" layer="94"/>
+<rectangle x1="203.475" y1="22.325" x2="203.725" y2="22.375" layer="94"/>
+<rectangle x1="205.075" y1="22.325" x2="205.375" y2="22.375" layer="94"/>
+<rectangle x1="207.925" y1="22.325" x2="208.525" y2="22.375" layer="94"/>
+<rectangle x1="209.075" y1="22.325" x2="210.375" y2="22.375" layer="94"/>
+<rectangle x1="211.925" y1="22.325" x2="212.275" y2="22.375" layer="94"/>
+<rectangle x1="213.325" y1="22.325" x2="213.675" y2="22.375" layer="94"/>
+<rectangle x1="215.225" y1="22.325" x2="215.525" y2="22.375" layer="94"/>
+<rectangle x1="216.725" y1="22.325" x2="217.025" y2="22.375" layer="94"/>
+<rectangle x1="217.275" y1="22.325" x2="217.575" y2="22.375" layer="94"/>
+<rectangle x1="218.425" y1="22.325" x2="218.725" y2="22.375" layer="94"/>
+<rectangle x1="219.125" y1="22.325" x2="219.375" y2="22.375" layer="94"/>
+<rectangle x1="219.825" y1="22.325" x2="220.075" y2="22.375" layer="94"/>
+<rectangle x1="220.475" y1="22.325" x2="220.725" y2="22.375" layer="94"/>
+<rectangle x1="221.625" y1="22.325" x2="221.875" y2="22.375" layer="94"/>
+<rectangle x1="222.225" y1="22.325" x2="222.475" y2="22.375" layer="94"/>
+<rectangle x1="222.775" y1="22.325" x2="223.075" y2="22.375" layer="94"/>
+<rectangle x1="223.925" y1="22.325" x2="224.225" y2="22.375" layer="94"/>
+<rectangle x1="224.525" y1="22.325" x2="224.825" y2="22.375" layer="94"/>
+<rectangle x1="225.625" y1="22.325" x2="225.875" y2="22.375" layer="94"/>
+<rectangle x1="226.225" y1="22.325" x2="226.475" y2="22.375" layer="94"/>
+<rectangle x1="227.125" y1="22.325" x2="227.425" y2="22.375" layer="94"/>
+<rectangle x1="228.075" y1="22.325" x2="228.325" y2="22.375" layer="94"/>
+<rectangle x1="228.625" y1="22.325" x2="228.925" y2="22.375" layer="94"/>
+<rectangle x1="229.775" y1="22.325" x2="230.025" y2="22.375" layer="94"/>
+<rectangle x1="230.375" y1="22.325" x2="230.675" y2="22.375" layer="94"/>
+<rectangle x1="231.375" y1="22.325" x2="231.625" y2="22.375" layer="94"/>
+<rectangle x1="232.075" y1="22.325" x2="232.375" y2="22.375" layer="94"/>
+<rectangle x1="233.725" y1="22.325" x2="234.025" y2="22.375" layer="94"/>
+<rectangle x1="234.825" y1="22.325" x2="235.225" y2="22.375" layer="94"/>
+<rectangle x1="235.625" y1="22.325" x2="235.925" y2="22.375" layer="94"/>
+<rectangle x1="236.775" y1="22.325" x2="237.075" y2="22.375" layer="94"/>
+<rectangle x1="238.175" y1="22.325" x2="238.625" y2="22.375" layer="94"/>
+<rectangle x1="239.025" y1="22.325" x2="239.325" y2="22.375" layer="94"/>
+<rectangle x1="239.975" y1="22.325" x2="240.225" y2="22.375" layer="94"/>
+<rectangle x1="241.025" y1="22.325" x2="241.325" y2="22.375" layer="94"/>
+<rectangle x1="186.525" y1="22.375" x2="186.825" y2="22.425" layer="94"/>
+<rectangle x1="187.475" y1="22.375" x2="187.775" y2="22.425" layer="94"/>
+<rectangle x1="189.575" y1="22.375" x2="189.825" y2="22.425" layer="94"/>
+<rectangle x1="190.675" y1="22.375" x2="190.975" y2="22.425" layer="94"/>
+<rectangle x1="191.375" y1="22.375" x2="191.625" y2="22.425" layer="94"/>
+<rectangle x1="192.375" y1="22.375" x2="192.625" y2="22.425" layer="94"/>
+<rectangle x1="193.075" y1="22.375" x2="193.375" y2="22.425" layer="94"/>
+<rectangle x1="193.825" y1="22.375" x2="194.075" y2="22.425" layer="94"/>
+<rectangle x1="195.375" y1="22.375" x2="195.675" y2="22.425" layer="94"/>
+<rectangle x1="195.925" y1="22.375" x2="196.175" y2="22.425" layer="94"/>
+<rectangle x1="196.675" y1="22.375" x2="196.875" y2="22.425" layer="94"/>
+<rectangle x1="197.175" y1="22.375" x2="197.425" y2="22.425" layer="94"/>
+<rectangle x1="197.875" y1="22.375" x2="198.125" y2="22.425" layer="94"/>
+<rectangle x1="198.425" y1="22.375" x2="198.725" y2="22.425" layer="94"/>
+<rectangle x1="199.525" y1="22.375" x2="199.775" y2="22.425" layer="94"/>
+<rectangle x1="200.175" y1="22.375" x2="200.475" y2="22.425" layer="94"/>
+<rectangle x1="201.175" y1="22.375" x2="201.475" y2="22.425" layer="94"/>
+<rectangle x1="201.925" y1="22.375" x2="202.175" y2="22.425" layer="94"/>
+<rectangle x1="202.775" y1="22.375" x2="203.025" y2="22.425" layer="94"/>
+<rectangle x1="203.525" y1="22.375" x2="203.775" y2="22.425" layer="94"/>
+<rectangle x1="205.075" y1="22.375" x2="206.525" y2="22.425" layer="94"/>
+<rectangle x1="207.725" y1="22.375" x2="208.525" y2="22.425" layer="94"/>
+<rectangle x1="209.075" y1="22.375" x2="210.475" y2="22.425" layer="94"/>
+<rectangle x1="211.875" y1="22.375" x2="212.225" y2="22.425" layer="94"/>
+<rectangle x1="213.375" y1="22.375" x2="213.725" y2="22.425" layer="94"/>
+<rectangle x1="215.225" y1="22.375" x2="215.525" y2="22.425" layer="94"/>
+<rectangle x1="216.725" y1="22.375" x2="217.025" y2="22.425" layer="94"/>
+<rectangle x1="217.325" y1="22.375" x2="217.575" y2="22.425" layer="94"/>
+<rectangle x1="218.425" y1="22.375" x2="218.675" y2="22.425" layer="94"/>
+<rectangle x1="219.075" y1="22.375" x2="219.375" y2="22.425" layer="94"/>
+<rectangle x1="219.825" y1="22.375" x2="220.075" y2="22.425" layer="94"/>
+<rectangle x1="220.475" y1="22.375" x2="220.775" y2="22.425" layer="94"/>
+<rectangle x1="221.575" y1="22.375" x2="221.875" y2="22.425" layer="94"/>
+<rectangle x1="222.225" y1="22.375" x2="222.475" y2="22.425" layer="94"/>
+<rectangle x1="222.775" y1="22.375" x2="223.075" y2="22.425" layer="94"/>
+<rectangle x1="223.925" y1="22.375" x2="224.225" y2="22.425" layer="94"/>
+<rectangle x1="224.525" y1="22.375" x2="224.825" y2="22.425" layer="94"/>
+<rectangle x1="225.575" y1="22.375" x2="225.875" y2="22.425" layer="94"/>
+<rectangle x1="226.225" y1="22.375" x2="226.475" y2="22.425" layer="94"/>
+<rectangle x1="227.125" y1="22.375" x2="227.425" y2="22.425" layer="94"/>
+<rectangle x1="228.075" y1="22.375" x2="228.325" y2="22.425" layer="94"/>
+<rectangle x1="228.625" y1="22.375" x2="228.925" y2="22.425" layer="94"/>
+<rectangle x1="229.775" y1="22.375" x2="230.025" y2="22.425" layer="94"/>
+<rectangle x1="230.375" y1="22.375" x2="230.675" y2="22.425" layer="94"/>
+<rectangle x1="231.375" y1="22.375" x2="231.625" y2="22.425" layer="94"/>
+<rectangle x1="232.075" y1="22.375" x2="232.375" y2="22.425" layer="94"/>
+<rectangle x1="233.725" y1="22.375" x2="235.175" y2="22.425" layer="94"/>
+<rectangle x1="235.625" y1="22.375" x2="235.925" y2="22.425" layer="94"/>
+<rectangle x1="236.775" y1="22.375" x2="237.075" y2="22.425" layer="94"/>
+<rectangle x1="238.375" y1="22.375" x2="238.625" y2="22.425" layer="94"/>
+<rectangle x1="239.025" y1="22.375" x2="239.325" y2="22.425" layer="94"/>
+<rectangle x1="239.975" y1="22.375" x2="240.275" y2="22.425" layer="94"/>
+<rectangle x1="241.025" y1="22.375" x2="241.325" y2="22.425" layer="94"/>
+<rectangle x1="186.575" y1="22.425" x2="186.825" y2="22.475" layer="94"/>
+<rectangle x1="187.425" y1="22.425" x2="187.725" y2="22.475" layer="94"/>
+<rectangle x1="189.575" y1="22.425" x2="189.825" y2="22.475" layer="94"/>
+<rectangle x1="190.675" y1="22.425" x2="190.975" y2="22.475" layer="94"/>
+<rectangle x1="191.375" y1="22.425" x2="191.625" y2="22.475" layer="94"/>
+<rectangle x1="192.325" y1="22.425" x2="192.625" y2="22.475" layer="94"/>
+<rectangle x1="193.075" y1="22.425" x2="193.325" y2="22.475" layer="94"/>
+<rectangle x1="193.875" y1="22.425" x2="194.125" y2="22.475" layer="94"/>
+<rectangle x1="195.375" y1="22.425" x2="195.675" y2="22.475" layer="94"/>
+<rectangle x1="195.925" y1="22.425" x2="196.175" y2="22.475" layer="94"/>
+<rectangle x1="196.675" y1="22.425" x2="196.925" y2="22.475" layer="94"/>
+<rectangle x1="197.175" y1="22.425" x2="197.425" y2="22.475" layer="94"/>
+<rectangle x1="197.875" y1="22.425" x2="198.125" y2="22.475" layer="94"/>
+<rectangle x1="198.475" y1="22.425" x2="198.725" y2="22.475" layer="94"/>
+<rectangle x1="199.525" y1="22.425" x2="199.775" y2="22.475" layer="94"/>
+<rectangle x1="200.175" y1="22.425" x2="200.475" y2="22.475" layer="94"/>
+<rectangle x1="201.175" y1="22.425" x2="201.475" y2="22.475" layer="94"/>
+<rectangle x1="201.925" y1="22.425" x2="202.175" y2="22.475" layer="94"/>
+<rectangle x1="202.725" y1="22.425" x2="203.025" y2="22.475" layer="94"/>
+<rectangle x1="203.525" y1="22.425" x2="203.775" y2="22.475" layer="94"/>
+<rectangle x1="205.075" y1="22.425" x2="206.525" y2="22.475" layer="94"/>
+<rectangle x1="207.575" y1="22.425" x2="208.425" y2="22.475" layer="94"/>
+<rectangle x1="209.075" y1="22.425" x2="210.525" y2="22.475" layer="94"/>
+<rectangle x1="211.475" y1="22.425" x2="212.175" y2="22.475" layer="94"/>
+<rectangle x1="213.425" y1="22.425" x2="213.775" y2="22.475" layer="94"/>
+<rectangle x1="215.225" y1="22.425" x2="215.525" y2="22.475" layer="94"/>
+<rectangle x1="216.725" y1="22.425" x2="217.025" y2="22.475" layer="94"/>
+<rectangle x1="217.325" y1="22.425" x2="217.575" y2="22.475" layer="94"/>
+<rectangle x1="218.425" y1="22.425" x2="218.675" y2="22.475" layer="94"/>
+<rectangle x1="219.075" y1="22.425" x2="219.325" y2="22.475" layer="94"/>
+<rectangle x1="219.875" y1="22.425" x2="220.125" y2="22.475" layer="94"/>
+<rectangle x1="220.475" y1="22.425" x2="220.775" y2="22.475" layer="94"/>
+<rectangle x1="221.575" y1="22.425" x2="221.875" y2="22.475" layer="94"/>
+<rectangle x1="222.225" y1="22.425" x2="222.475" y2="22.475" layer="94"/>
+<rectangle x1="222.825" y1="22.425" x2="223.075" y2="22.475" layer="94"/>
+<rectangle x1="223.925" y1="22.425" x2="224.225" y2="22.475" layer="94"/>
+<rectangle x1="224.525" y1="22.425" x2="224.825" y2="22.475" layer="94"/>
+<rectangle x1="225.575" y1="22.425" x2="225.875" y2="22.475" layer="94"/>
+<rectangle x1="226.225" y1="22.425" x2="226.475" y2="22.475" layer="94"/>
+<rectangle x1="227.125" y1="22.425" x2="227.425" y2="22.475" layer="94"/>
+<rectangle x1="228.025" y1="22.425" x2="228.325" y2="22.475" layer="94"/>
+<rectangle x1="228.675" y1="22.425" x2="228.925" y2="22.475" layer="94"/>
+<rectangle x1="229.775" y1="22.425" x2="230.025" y2="22.475" layer="94"/>
+<rectangle x1="230.375" y1="22.425" x2="230.675" y2="22.475" layer="94"/>
+<rectangle x1="231.375" y1="22.425" x2="231.625" y2="22.475" layer="94"/>
+<rectangle x1="232.075" y1="22.425" x2="232.375" y2="22.475" layer="94"/>
+<rectangle x1="233.725" y1="22.425" x2="235.125" y2="22.475" layer="94"/>
+<rectangle x1="235.625" y1="22.425" x2="235.925" y2="22.475" layer="94"/>
+<rectangle x1="236.775" y1="22.425" x2="237.025" y2="22.475" layer="94"/>
+<rectangle x1="238.375" y1="22.425" x2="238.625" y2="22.475" layer="94"/>
+<rectangle x1="239.025" y1="22.425" x2="239.325" y2="22.475" layer="94"/>
+<rectangle x1="239.975" y1="22.425" x2="240.275" y2="22.475" layer="94"/>
+<rectangle x1="241.025" y1="22.425" x2="241.325" y2="22.475" layer="94"/>
+<rectangle x1="186.575" y1="22.475" x2="186.875" y2="22.525" layer="94"/>
+<rectangle x1="187.425" y1="22.475" x2="187.725" y2="22.525" layer="94"/>
+<rectangle x1="189.575" y1="22.475" x2="189.825" y2="22.525" layer="94"/>
+<rectangle x1="190.675" y1="22.475" x2="190.975" y2="22.525" layer="94"/>
+<rectangle x1="191.375" y1="22.475" x2="191.675" y2="22.525" layer="94"/>
+<rectangle x1="192.325" y1="22.475" x2="192.625" y2="22.525" layer="94"/>
+<rectangle x1="193.025" y1="22.475" x2="193.325" y2="22.525" layer="94"/>
+<rectangle x1="193.875" y1="22.475" x2="194.125" y2="22.525" layer="94"/>
+<rectangle x1="195.375" y1="22.475" x2="195.675" y2="22.525" layer="94"/>
+<rectangle x1="195.925" y1="22.475" x2="196.175" y2="22.525" layer="94"/>
+<rectangle x1="196.675" y1="22.475" x2="196.925" y2="22.525" layer="94"/>
+<rectangle x1="197.175" y1="22.475" x2="197.425" y2="22.525" layer="94"/>
+<rectangle x1="197.875" y1="22.475" x2="198.125" y2="22.525" layer="94"/>
+<rectangle x1="198.475" y1="22.475" x2="198.775" y2="22.525" layer="94"/>
+<rectangle x1="199.475" y1="22.475" x2="199.775" y2="22.525" layer="94"/>
+<rectangle x1="200.175" y1="22.475" x2="200.475" y2="22.525" layer="94"/>
+<rectangle x1="201.175" y1="22.475" x2="201.475" y2="22.525" layer="94"/>
+<rectangle x1="201.925" y1="22.475" x2="202.175" y2="22.525" layer="94"/>
+<rectangle x1="202.725" y1="22.475" x2="202.975" y2="22.525" layer="94"/>
+<rectangle x1="203.525" y1="22.475" x2="203.825" y2="22.525" layer="94"/>
+<rectangle x1="205.075" y1="22.475" x2="206.525" y2="22.525" layer="94"/>
+<rectangle x1="207.425" y1="22.475" x2="208.375" y2="22.525" layer="94"/>
+<rectangle x1="209.075" y1="22.475" x2="210.575" y2="22.525" layer="94"/>
+<rectangle x1="211.475" y1="22.475" x2="212.125" y2="22.525" layer="94"/>
+<rectangle x1="213.475" y1="22.475" x2="213.825" y2="22.525" layer="94"/>
+<rectangle x1="215.225" y1="22.475" x2="215.525" y2="22.525" layer="94"/>
+<rectangle x1="216.725" y1="22.475" x2="217.025" y2="22.525" layer="94"/>
+<rectangle x1="217.325" y1="22.475" x2="217.625" y2="22.525" layer="94"/>
+<rectangle x1="218.375" y1="22.475" x2="218.675" y2="22.525" layer="94"/>
+<rectangle x1="219.075" y1="22.475" x2="219.325" y2="22.525" layer="94"/>
+<rectangle x1="219.875" y1="22.475" x2="220.125" y2="22.525" layer="94"/>
+<rectangle x1="220.475" y1="22.475" x2="220.775" y2="22.525" layer="94"/>
+<rectangle x1="221.575" y1="22.475" x2="221.825" y2="22.525" layer="94"/>
+<rectangle x1="222.225" y1="22.475" x2="222.475" y2="22.525" layer="94"/>
+<rectangle x1="222.825" y1="22.475" x2="223.125" y2="22.525" layer="94"/>
+<rectangle x1="223.875" y1="22.475" x2="224.175" y2="22.525" layer="94"/>
+<rectangle x1="224.525" y1="22.475" x2="224.825" y2="22.525" layer="94"/>
+<rectangle x1="225.575" y1="22.475" x2="225.825" y2="22.525" layer="94"/>
+<rectangle x1="226.225" y1="22.475" x2="226.525" y2="22.525" layer="94"/>
+<rectangle x1="227.125" y1="22.475" x2="227.425" y2="22.525" layer="94"/>
+<rectangle x1="228.025" y1="22.475" x2="228.325" y2="22.525" layer="94"/>
+<rectangle x1="228.675" y1="22.475" x2="228.925" y2="22.525" layer="94"/>
+<rectangle x1="229.725" y1="22.475" x2="230.025" y2="22.525" layer="94"/>
+<rectangle x1="230.375" y1="22.475" x2="230.675" y2="22.525" layer="94"/>
+<rectangle x1="231.375" y1="22.475" x2="231.625" y2="22.525" layer="94"/>
+<rectangle x1="232.075" y1="22.475" x2="232.375" y2="22.525" layer="94"/>
+<rectangle x1="233.725" y1="22.475" x2="235.025" y2="22.525" layer="94"/>
+<rectangle x1="235.675" y1="22.475" x2="235.975" y2="22.525" layer="94"/>
+<rectangle x1="236.725" y1="22.475" x2="237.025" y2="22.525" layer="94"/>
+<rectangle x1="237.375" y1="22.475" x2="237.625" y2="22.525" layer="94"/>
+<rectangle x1="238.375" y1="22.475" x2="238.625" y2="22.525" layer="94"/>
+<rectangle x1="239.025" y1="22.475" x2="239.375" y2="22.525" layer="94"/>
+<rectangle x1="240.025" y1="22.475" x2="240.275" y2="22.525" layer="94"/>
+<rectangle x1="240.975" y1="22.475" x2="241.325" y2="22.525" layer="94"/>
+<rectangle x1="186.575" y1="22.525" x2="186.875" y2="22.575" layer="94"/>
+<rectangle x1="187.375" y1="22.525" x2="187.675" y2="22.575" layer="94"/>
+<rectangle x1="189.575" y1="22.525" x2="189.825" y2="22.575" layer="94"/>
+<rectangle x1="190.675" y1="22.525" x2="190.975" y2="22.575" layer="94"/>
+<rectangle x1="191.375" y1="22.525" x2="191.675" y2="22.575" layer="94"/>
+<rectangle x1="192.325" y1="22.525" x2="192.625" y2="22.575" layer="94"/>
+<rectangle x1="193.025" y1="22.525" x2="193.325" y2="22.575" layer="94"/>
+<rectangle x1="193.875" y1="22.525" x2="194.175" y2="22.575" layer="94"/>
+<rectangle x1="195.375" y1="22.525" x2="195.675" y2="22.575" layer="94"/>
+<rectangle x1="195.875" y1="22.525" x2="196.125" y2="22.575" layer="94"/>
+<rectangle x1="196.725" y1="22.525" x2="196.925" y2="22.575" layer="94"/>
+<rectangle x1="197.175" y1="22.525" x2="197.425" y2="22.575" layer="94"/>
+<rectangle x1="197.875" y1="22.525" x2="198.125" y2="22.575" layer="94"/>
+<rectangle x1="198.475" y1="22.525" x2="198.775" y2="22.575" layer="94"/>
+<rectangle x1="199.475" y1="22.525" x2="199.775" y2="22.575" layer="94"/>
+<rectangle x1="200.175" y1="22.525" x2="200.525" y2="22.575" layer="94"/>
+<rectangle x1="201.175" y1="22.525" x2="201.425" y2="22.575" layer="94"/>
+<rectangle x1="201.925" y1="22.525" x2="202.175" y2="22.575" layer="94"/>
+<rectangle x1="202.675" y1="22.525" x2="202.975" y2="22.575" layer="94"/>
+<rectangle x1="203.575" y1="22.525" x2="203.825" y2="22.575" layer="94"/>
+<rectangle x1="205.075" y1="22.525" x2="206.525" y2="22.575" layer="94"/>
+<rectangle x1="207.325" y1="22.525" x2="208.225" y2="22.575" layer="94"/>
+<rectangle x1="209.075" y1="22.525" x2="209.325" y2="22.575" layer="94"/>
+<rectangle x1="210.125" y1="22.525" x2="210.575" y2="22.575" layer="94"/>
+<rectangle x1="211.475" y1="22.525" x2="211.975" y2="22.575" layer="94"/>
+<rectangle x1="213.525" y1="22.525" x2="213.875" y2="22.575" layer="94"/>
+<rectangle x1="215.225" y1="22.525" x2="215.525" y2="22.575" layer="94"/>
+<rectangle x1="216.725" y1="22.525" x2="217.025" y2="22.575" layer="94"/>
+<rectangle x1="217.325" y1="22.525" x2="217.625" y2="22.575" layer="94"/>
+<rectangle x1="218.375" y1="22.525" x2="218.675" y2="22.575" layer="94"/>
+<rectangle x1="219.025" y1="22.525" x2="219.325" y2="22.575" layer="94"/>
+<rectangle x1="219.875" y1="22.525" x2="220.175" y2="22.575" layer="94"/>
+<rectangle x1="220.525" y1="22.525" x2="220.825" y2="22.575" layer="94"/>
+<rectangle x1="221.525" y1="22.525" x2="221.825" y2="22.575" layer="94"/>
+<rectangle x1="222.225" y1="22.525" x2="222.475" y2="22.575" layer="94"/>
+<rectangle x1="222.825" y1="22.525" x2="223.125" y2="22.575" layer="94"/>
+<rectangle x1="223.875" y1="22.525" x2="224.175" y2="22.575" layer="94"/>
+<rectangle x1="224.525" y1="22.525" x2="224.875" y2="22.575" layer="94"/>
+<rectangle x1="225.525" y1="22.525" x2="225.825" y2="22.575" layer="94"/>
+<rectangle x1="226.225" y1="22.525" x2="226.525" y2="22.575" layer="94"/>
+<rectangle x1="227.125" y1="22.525" x2="227.425" y2="22.575" layer="94"/>
+<rectangle x1="228.025" y1="22.525" x2="228.325" y2="22.575" layer="94"/>
+<rectangle x1="228.675" y1="22.525" x2="228.975" y2="22.575" layer="94"/>
+<rectangle x1="229.725" y1="22.525" x2="229.975" y2="22.575" layer="94"/>
+<rectangle x1="230.375" y1="22.525" x2="230.675" y2="22.575" layer="94"/>
+<rectangle x1="231.375" y1="22.525" x2="231.625" y2="22.575" layer="94"/>
+<rectangle x1="232.075" y1="22.525" x2="232.375" y2="22.575" layer="94"/>
+<rectangle x1="233.725" y1="22.525" x2="234.975" y2="22.575" layer="94"/>
+<rectangle x1="235.675" y1="22.525" x2="235.975" y2="22.575" layer="94"/>
+<rectangle x1="236.725" y1="22.525" x2="237.025" y2="22.575" layer="94"/>
+<rectangle x1="237.375" y1="22.525" x2="237.625" y2="22.575" layer="94"/>
+<rectangle x1="238.375" y1="22.525" x2="238.625" y2="22.575" layer="94"/>
+<rectangle x1="239.025" y1="22.525" x2="239.375" y2="22.575" layer="94"/>
+<rectangle x1="240.025" y1="22.525" x2="240.325" y2="22.575" layer="94"/>
+<rectangle x1="240.975" y1="22.525" x2="241.325" y2="22.575" layer="94"/>
+<rectangle x1="186.625" y1="22.575" x2="186.875" y2="22.625" layer="94"/>
+<rectangle x1="187.375" y1="22.575" x2="187.675" y2="22.625" layer="94"/>
+<rectangle x1="189.575" y1="22.575" x2="189.825" y2="22.625" layer="94"/>
+<rectangle x1="190.675" y1="22.575" x2="190.975" y2="22.625" layer="94"/>
+<rectangle x1="191.375" y1="22.575" x2="191.725" y2="22.625" layer="94"/>
+<rectangle x1="192.325" y1="22.575" x2="192.625" y2="22.625" layer="94"/>
+<rectangle x1="193.025" y1="22.575" x2="193.275" y2="22.625" layer="94"/>
+<rectangle x1="193.925" y1="22.575" x2="194.175" y2="22.625" layer="94"/>
+<rectangle x1="195.375" y1="22.575" x2="195.675" y2="22.625" layer="94"/>
+<rectangle x1="195.875" y1="22.575" x2="196.125" y2="22.625" layer="94"/>
+<rectangle x1="196.725" y1="22.575" x2="196.975" y2="22.625" layer="94"/>
+<rectangle x1="197.175" y1="22.575" x2="197.425" y2="22.625" layer="94"/>
+<rectangle x1="197.875" y1="22.575" x2="198.125" y2="22.625" layer="94"/>
+<rectangle x1="198.525" y1="22.575" x2="198.825" y2="22.625" layer="94"/>
+<rectangle x1="199.425" y1="22.575" x2="199.775" y2="22.625" layer="94"/>
+<rectangle x1="200.175" y1="22.575" x2="200.525" y2="22.625" layer="94"/>
+<rectangle x1="201.175" y1="22.575" x2="201.425" y2="22.625" layer="94"/>
+<rectangle x1="201.925" y1="22.575" x2="202.175" y2="22.625" layer="94"/>
+<rectangle x1="202.675" y1="22.575" x2="202.975" y2="22.625" layer="94"/>
+<rectangle x1="203.575" y1="22.575" x2="203.825" y2="22.625" layer="94"/>
+<rectangle x1="205.075" y1="22.575" x2="206.525" y2="22.625" layer="94"/>
+<rectangle x1="207.225" y1="22.575" x2="208.075" y2="22.625" layer="94"/>
+<rectangle x1="209.075" y1="22.575" x2="209.325" y2="22.625" layer="94"/>
+<rectangle x1="210.225" y1="22.575" x2="210.625" y2="22.625" layer="94"/>
+<rectangle x1="211.525" y1="22.575" x2="212.025" y2="22.625" layer="94"/>
+<rectangle x1="213.575" y1="22.575" x2="213.925" y2="22.625" layer="94"/>
+<rectangle x1="215.225" y1="22.575" x2="215.525" y2="22.625" layer="94"/>
+<rectangle x1="216.725" y1="22.575" x2="217.025" y2="22.625" layer="94"/>
+<rectangle x1="217.375" y1="22.575" x2="217.675" y2="22.625" layer="94"/>
+<rectangle x1="218.325" y1="22.575" x2="218.625" y2="22.625" layer="94"/>
+<rectangle x1="219.025" y1="22.575" x2="219.275" y2="22.625" layer="94"/>
+<rectangle x1="219.925" y1="22.575" x2="220.175" y2="22.625" layer="94"/>
+<rectangle x1="220.525" y1="22.575" x2="220.825" y2="22.625" layer="94"/>
+<rectangle x1="221.525" y1="22.575" x2="221.775" y2="22.625" layer="94"/>
+<rectangle x1="222.225" y1="22.575" x2="222.475" y2="22.625" layer="94"/>
+<rectangle x1="222.875" y1="22.575" x2="223.175" y2="22.625" layer="94"/>
+<rectangle x1="223.825" y1="22.575" x2="224.125" y2="22.625" layer="94"/>
+<rectangle x1="224.525" y1="22.575" x2="224.875" y2="22.625" layer="94"/>
+<rectangle x1="225.525" y1="22.575" x2="225.825" y2="22.625" layer="94"/>
+<rectangle x1="226.225" y1="22.575" x2="226.575" y2="22.625" layer="94"/>
+<rectangle x1="227.125" y1="22.575" x2="227.475" y2="22.625" layer="94"/>
+<rectangle x1="228.025" y1="22.575" x2="228.275" y2="22.625" layer="94"/>
+<rectangle x1="228.725" y1="22.575" x2="229.025" y2="22.625" layer="94"/>
+<rectangle x1="229.675" y1="22.575" x2="229.975" y2="22.625" layer="94"/>
+<rectangle x1="230.375" y1="22.575" x2="230.725" y2="22.625" layer="94"/>
+<rectangle x1="231.325" y1="22.575" x2="231.625" y2="22.625" layer="94"/>
+<rectangle x1="232.075" y1="22.575" x2="232.375" y2="22.625" layer="94"/>
+<rectangle x1="233.725" y1="22.575" x2="235.025" y2="22.625" layer="94"/>
+<rectangle x1="235.725" y1="22.575" x2="236.025" y2="22.625" layer="94"/>
+<rectangle x1="236.675" y1="22.575" x2="236.975" y2="22.625" layer="94"/>
+<rectangle x1="237.375" y1="22.575" x2="237.625" y2="22.625" layer="94"/>
+<rectangle x1="238.375" y1="22.575" x2="238.625" y2="22.625" layer="94"/>
+<rectangle x1="239.025" y1="22.575" x2="239.375" y2="22.625" layer="94"/>
+<rectangle x1="240.025" y1="22.575" x2="240.325" y2="22.625" layer="94"/>
+<rectangle x1="240.925" y1="22.575" x2="241.325" y2="22.625" layer="94"/>
+<rectangle x1="186.625" y1="22.625" x2="186.925" y2="22.675" layer="94"/>
+<rectangle x1="187.375" y1="22.625" x2="187.675" y2="22.675" layer="94"/>
+<rectangle x1="189.575" y1="22.625" x2="189.825" y2="22.675" layer="94"/>
+<rectangle x1="190.675" y1="22.625" x2="190.975" y2="22.675" layer="94"/>
+<rectangle x1="191.375" y1="22.625" x2="191.725" y2="22.675" layer="94"/>
+<rectangle x1="192.275" y1="22.625" x2="192.575" y2="22.675" layer="94"/>
+<rectangle x1="192.975" y1="22.625" x2="193.275" y2="22.675" layer="94"/>
+<rectangle x1="193.925" y1="22.625" x2="194.175" y2="22.675" layer="94"/>
+<rectangle x1="195.375" y1="22.625" x2="195.675" y2="22.675" layer="94"/>
+<rectangle x1="195.875" y1="22.625" x2="196.125" y2="22.675" layer="94"/>
+<rectangle x1="196.725" y1="22.625" x2="196.975" y2="22.675" layer="94"/>
+<rectangle x1="197.175" y1="22.625" x2="197.425" y2="22.675" layer="94"/>
+<rectangle x1="197.875" y1="22.625" x2="198.125" y2="22.675" layer="94"/>
+<rectangle x1="198.525" y1="22.625" x2="198.825" y2="22.675" layer="94"/>
+<rectangle x1="199.375" y1="22.625" x2="199.775" y2="22.675" layer="94"/>
+<rectangle x1="200.175" y1="22.625" x2="200.575" y2="22.675" layer="94"/>
+<rectangle x1="201.125" y1="22.625" x2="201.425" y2="22.675" layer="94"/>
+<rectangle x1="201.925" y1="22.625" x2="202.175" y2="22.675" layer="94"/>
+<rectangle x1="202.675" y1="22.625" x2="202.925" y2="22.675" layer="94"/>
+<rectangle x1="203.575" y1="22.625" x2="203.875" y2="22.675" layer="94"/>
+<rectangle x1="205.075" y1="22.625" x2="205.375" y2="22.675" layer="94"/>
+<rectangle x1="207.175" y1="22.625" x2="207.875" y2="22.675" layer="94"/>
+<rectangle x1="209.075" y1="22.625" x2="209.325" y2="22.675" layer="94"/>
+<rectangle x1="210.325" y1="22.625" x2="210.625" y2="22.675" layer="94"/>
+<rectangle x1="211.625" y1="22.625" x2="212.125" y2="22.675" layer="94"/>
+<rectangle x1="213.625" y1="22.625" x2="213.925" y2="22.675" layer="94"/>
+<rectangle x1="215.225" y1="22.625" x2="215.525" y2="22.675" layer="94"/>
+<rectangle x1="216.725" y1="22.625" x2="216.975" y2="22.675" layer="94"/>
+<rectangle x1="217.375" y1="22.625" x2="217.725" y2="22.675" layer="94"/>
+<rectangle x1="218.275" y1="22.625" x2="218.625" y2="22.675" layer="94"/>
+<rectangle x1="218.975" y1="22.625" x2="219.275" y2="22.675" layer="94"/>
+<rectangle x1="219.925" y1="22.625" x2="220.175" y2="22.675" layer="94"/>
+<rectangle x1="220.575" y1="22.625" x2="220.875" y2="22.675" layer="94"/>
+<rectangle x1="221.475" y1="22.625" x2="221.775" y2="22.675" layer="94"/>
+<rectangle x1="222.225" y1="22.625" x2="222.475" y2="22.675" layer="94"/>
+<rectangle x1="222.875" y1="22.625" x2="223.225" y2="22.675" layer="94"/>
+<rectangle x1="223.775" y1="22.625" x2="224.125" y2="22.675" layer="94"/>
+<rectangle x1="224.525" y1="22.625" x2="224.925" y2="22.675" layer="94"/>
+<rectangle x1="225.475" y1="22.625" x2="225.775" y2="22.675" layer="94"/>
+<rectangle x1="226.225" y1="22.625" x2="226.575" y2="22.675" layer="94"/>
+<rectangle x1="227.075" y1="22.625" x2="227.525" y2="22.675" layer="94"/>
+<rectangle x1="227.975" y1="22.625" x2="228.275" y2="22.675" layer="94"/>
+<rectangle x1="228.725" y1="22.625" x2="229.075" y2="22.675" layer="94"/>
+<rectangle x1="229.625" y1="22.625" x2="229.925" y2="22.675" layer="94"/>
+<rectangle x1="230.375" y1="22.625" x2="230.775" y2="22.675" layer="94"/>
+<rectangle x1="231.325" y1="22.625" x2="231.625" y2="22.675" layer="94"/>
+<rectangle x1="232.075" y1="22.625" x2="232.375" y2="22.675" layer="94"/>
+<rectangle x1="233.725" y1="22.625" x2="234.025" y2="22.675" layer="94"/>
+<rectangle x1="234.575" y1="22.625" x2="235.125" y2="22.675" layer="94"/>
+<rectangle x1="235.725" y1="22.625" x2="236.075" y2="22.675" layer="94"/>
+<rectangle x1="236.625" y1="22.625" x2="236.975" y2="22.675" layer="94"/>
+<rectangle x1="237.375" y1="22.625" x2="237.675" y2="22.675" layer="94"/>
+<rectangle x1="238.325" y1="22.625" x2="238.625" y2="22.675" layer="94"/>
+<rectangle x1="239.025" y1="22.625" x2="239.425" y2="22.675" layer="94"/>
+<rectangle x1="240.075" y1="22.625" x2="240.375" y2="22.675" layer="94"/>
+<rectangle x1="240.925" y1="22.625" x2="241.325" y2="22.675" layer="94"/>
+<rectangle x1="186.675" y1="22.675" x2="186.925" y2="22.725" layer="94"/>
+<rectangle x1="187.325" y1="22.675" x2="187.625" y2="22.725" layer="94"/>
+<rectangle x1="189.575" y1="22.675" x2="189.825" y2="22.725" layer="94"/>
+<rectangle x1="190.675" y1="22.675" x2="190.975" y2="22.725" layer="94"/>
+<rectangle x1="191.375" y1="22.675" x2="191.825" y2="22.725" layer="94"/>
+<rectangle x1="192.225" y1="22.675" x2="192.575" y2="22.725" layer="94"/>
+<rectangle x1="192.975" y1="22.675" x2="193.275" y2="22.725" layer="94"/>
+<rectangle x1="193.925" y1="22.675" x2="194.225" y2="22.725" layer="94"/>
+<rectangle x1="195.375" y1="22.675" x2="195.675" y2="22.725" layer="94"/>
+<rectangle x1="195.825" y1="22.675" x2="196.075" y2="22.725" layer="94"/>
+<rectangle x1="196.775" y1="22.675" x2="196.975" y2="22.725" layer="94"/>
+<rectangle x1="197.175" y1="22.675" x2="197.425" y2="22.725" layer="94"/>
+<rectangle x1="197.875" y1="22.675" x2="198.125" y2="22.725" layer="94"/>
+<rectangle x1="198.575" y1="22.675" x2="198.925" y2="22.725" layer="94"/>
+<rectangle x1="199.325" y1="22.675" x2="199.775" y2="22.725" layer="94"/>
+<rectangle x1="200.175" y1="22.675" x2="200.675" y2="22.725" layer="94"/>
+<rectangle x1="201.075" y1="22.675" x2="201.425" y2="22.725" layer="94"/>
+<rectangle x1="201.925" y1="22.675" x2="202.175" y2="22.725" layer="94"/>
+<rectangle x1="202.625" y1="22.675" x2="202.925" y2="22.725" layer="94"/>
+<rectangle x1="203.625" y1="22.675" x2="203.875" y2="22.725" layer="94"/>
+<rectangle x1="205.075" y1="22.675" x2="205.375" y2="22.725" layer="94"/>
+<rectangle x1="207.125" y1="22.675" x2="207.725" y2="22.725" layer="94"/>
+<rectangle x1="209.075" y1="22.675" x2="209.325" y2="22.725" layer="94"/>
+<rectangle x1="210.325" y1="22.675" x2="210.675" y2="22.725" layer="94"/>
+<rectangle x1="211.775" y1="22.675" x2="212.125" y2="22.725" layer="94"/>
+<rectangle x1="213.625" y1="22.675" x2="213.975" y2="22.725" layer="94"/>
+<rectangle x1="215.225" y1="22.675" x2="215.525" y2="22.725" layer="94"/>
+<rectangle x1="216.675" y1="22.675" x2="216.975" y2="22.725" layer="94"/>
+<rectangle x1="217.425" y1="22.675" x2="217.775" y2="22.725" layer="94"/>
+<rectangle x1="218.225" y1="22.675" x2="218.575" y2="22.725" layer="94"/>
+<rectangle x1="218.975" y1="22.675" x2="219.225" y2="22.725" layer="94"/>
+<rectangle x1="219.925" y1="22.675" x2="220.225" y2="22.725" layer="94"/>
+<rectangle x1="220.575" y1="22.675" x2="220.975" y2="22.725" layer="94"/>
+<rectangle x1="221.425" y1="22.675" x2="221.725" y2="22.725" layer="94"/>
+<rectangle x1="222.225" y1="22.675" x2="222.475" y2="22.725" layer="94"/>
+<rectangle x1="222.925" y1="22.675" x2="223.275" y2="22.725" layer="94"/>
+<rectangle x1="223.725" y1="22.675" x2="224.075" y2="22.725" layer="94"/>
+<rectangle x1="224.525" y1="22.675" x2="225.025" y2="22.725" layer="94"/>
+<rectangle x1="225.425" y1="22.675" x2="225.775" y2="22.725" layer="94"/>
+<rectangle x1="226.225" y1="22.675" x2="226.675" y2="22.725" layer="94"/>
+<rectangle x1="227.025" y1="22.675" x2="227.575" y2="22.725" layer="94"/>
+<rectangle x1="227.925" y1="22.675" x2="228.275" y2="22.725" layer="94"/>
+<rectangle x1="228.775" y1="22.675" x2="229.125" y2="22.725" layer="94"/>
+<rectangle x1="229.575" y1="22.675" x2="229.925" y2="22.725" layer="94"/>
+<rectangle x1="230.375" y1="22.675" x2="230.825" y2="22.725" layer="94"/>
+<rectangle x1="231.275" y1="22.675" x2="231.575" y2="22.725" layer="94"/>
+<rectangle x1="232.075" y1="22.675" x2="232.375" y2="22.725" layer="94"/>
+<rectangle x1="233.725" y1="22.675" x2="234.025" y2="22.725" layer="94"/>
+<rectangle x1="234.825" y1="22.675" x2="235.125" y2="22.725" layer="94"/>
+<rectangle x1="235.775" y1="22.675" x2="236.125" y2="22.725" layer="94"/>
+<rectangle x1="236.575" y1="22.675" x2="236.925" y2="22.725" layer="94"/>
+<rectangle x1="237.425" y1="22.675" x2="237.725" y2="22.725" layer="94"/>
+<rectangle x1="238.275" y1="22.675" x2="238.625" y2="22.725" layer="94"/>
+<rectangle x1="239.025" y1="22.675" x2="239.525" y2="22.725" layer="94"/>
+<rectangle x1="239.725" y1="22.675" x2="239.825" y2="22.725" layer="94"/>
+<rectangle x1="240.075" y1="22.675" x2="240.425" y2="22.725" layer="94"/>
+<rectangle x1="240.825" y1="22.675" x2="241.325" y2="22.725" layer="94"/>
+<rectangle x1="186.675" y1="22.725" x2="186.925" y2="22.775" layer="94"/>
+<rectangle x1="187.325" y1="22.725" x2="187.625" y2="22.775" layer="94"/>
+<rectangle x1="189.575" y1="22.725" x2="189.825" y2="22.775" layer="94"/>
+<rectangle x1="190.675" y1="22.725" x2="190.975" y2="22.775" layer="94"/>
+<rectangle x1="191.375" y1="22.725" x2="191.975" y2="22.775" layer="94"/>
+<rectangle x1="192.125" y1="22.725" x2="192.525" y2="22.775" layer="94"/>
+<rectangle x1="192.975" y1="22.725" x2="193.225" y2="22.775" layer="94"/>
+<rectangle x1="193.975" y1="22.725" x2="194.225" y2="22.775" layer="94"/>
+<rectangle x1="195.375" y1="22.725" x2="195.675" y2="22.775" layer="94"/>
+<rectangle x1="195.825" y1="22.725" x2="196.075" y2="22.775" layer="94"/>
+<rectangle x1="196.775" y1="22.725" x2="197.025" y2="22.775" layer="94"/>
+<rectangle x1="197.175" y1="22.725" x2="197.425" y2="22.775" layer="94"/>
+<rectangle x1="197.875" y1="22.725" x2="198.125" y2="22.775" layer="94"/>
+<rectangle x1="198.575" y1="22.725" x2="199.025" y2="22.775" layer="94"/>
+<rectangle x1="199.225" y1="22.725" x2="199.775" y2="22.775" layer="94"/>
+<rectangle x1="200.175" y1="22.725" x2="200.775" y2="22.775" layer="94"/>
+<rectangle x1="200.925" y1="22.725" x2="201.375" y2="22.775" layer="94"/>
+<rectangle x1="201.725" y1="22.725" x2="202.425" y2="22.775" layer="94"/>
+<rectangle x1="202.625" y1="22.725" x2="202.925" y2="22.775" layer="94"/>
+<rectangle x1="203.625" y1="22.725" x2="203.875" y2="22.775" layer="94"/>
+<rectangle x1="205.075" y1="22.725" x2="205.375" y2="22.775" layer="94"/>
+<rectangle x1="207.125" y1="22.725" x2="207.525" y2="22.775" layer="94"/>
+<rectangle x1="209.075" y1="22.725" x2="209.325" y2="22.775" layer="94"/>
+<rectangle x1="210.375" y1="22.725" x2="210.675" y2="22.775" layer="94"/>
+<rectangle x1="211.875" y1="22.725" x2="212.175" y2="22.775" layer="94"/>
+<rectangle x1="213.675" y1="22.725" x2="213.975" y2="22.775" layer="94"/>
+<rectangle x1="215.225" y1="22.725" x2="215.525" y2="22.775" layer="94"/>
+<rectangle x1="216.675" y1="22.725" x2="216.975" y2="22.775" layer="94"/>
+<rectangle x1="217.475" y1="22.725" x2="217.875" y2="22.775" layer="94"/>
+<rectangle x1="218.125" y1="22.725" x2="218.525" y2="22.775" layer="94"/>
+<rectangle x1="218.975" y1="22.725" x2="219.225" y2="22.775" layer="94"/>
+<rectangle x1="219.975" y1="22.725" x2="220.225" y2="22.775" layer="94"/>
+<rectangle x1="220.625" y1="22.725" x2="221.075" y2="22.775" layer="94"/>
+<rectangle x1="221.275" y1="22.725" x2="221.725" y2="22.775" layer="94"/>
+<rectangle x1="222.225" y1="22.725" x2="222.475" y2="22.775" layer="94"/>
+<rectangle x1="222.975" y1="22.725" x2="223.425" y2="22.775" layer="94"/>
+<rectangle x1="223.575" y1="22.725" x2="224.025" y2="22.775" layer="94"/>
+<rectangle x1="224.525" y1="22.725" x2="225.075" y2="22.775" layer="94"/>
+<rectangle x1="225.325" y1="22.725" x2="225.725" y2="22.775" layer="94"/>
+<rectangle x1="226.225" y1="22.725" x2="226.775" y2="22.775" layer="94"/>
+<rectangle x1="226.925" y1="22.725" x2="227.325" y2="22.775" layer="94"/>
+<rectangle x1="227.375" y1="22.725" x2="227.725" y2="22.775" layer="94"/>
+<rectangle x1="227.825" y1="22.725" x2="228.275" y2="22.775" layer="94"/>
+<rectangle x1="228.825" y1="22.725" x2="229.225" y2="22.775" layer="94"/>
+<rectangle x1="229.425" y1="22.725" x2="229.875" y2="22.775" layer="94"/>
+<rectangle x1="230.375" y1="22.725" x2="231.025" y2="22.775" layer="94"/>
+<rectangle x1="231.125" y1="22.725" x2="231.575" y2="22.775" layer="94"/>
+<rectangle x1="231.925" y1="22.725" x2="232.625" y2="22.775" layer="94"/>
+<rectangle x1="233.725" y1="22.725" x2="234.025" y2="22.775" layer="94"/>
+<rectangle x1="234.875" y1="22.725" x2="235.175" y2="22.775" layer="94"/>
+<rectangle x1="235.775" y1="22.725" x2="236.275" y2="22.775" layer="94"/>
+<rectangle x1="236.425" y1="22.725" x2="236.875" y2="22.775" layer="94"/>
+<rectangle x1="237.425" y1="22.725" x2="237.825" y2="22.775" layer="94"/>
+<rectangle x1="238.175" y1="22.725" x2="238.575" y2="22.775" layer="94"/>
+<rectangle x1="239.025" y1="22.725" x2="239.825" y2="22.775" layer="94"/>
+<rectangle x1="240.125" y1="22.725" x2="240.575" y2="22.775" layer="94"/>
+<rectangle x1="240.725" y1="22.725" x2="241.325" y2="22.775" layer="94"/>
+<rectangle x1="186.675" y1="22.775" x2="186.975" y2="22.825" layer="94"/>
+<rectangle x1="187.325" y1="22.775" x2="187.575" y2="22.825" layer="94"/>
+<rectangle x1="189.575" y1="22.775" x2="189.825" y2="22.825" layer="94"/>
+<rectangle x1="190.675" y1="22.775" x2="190.975" y2="22.825" layer="94"/>
+<rectangle x1="191.375" y1="22.775" x2="191.575" y2="22.825" layer="94"/>
+<rectangle x1="191.675" y1="22.775" x2="192.525" y2="22.825" layer="94"/>
+<rectangle x1="192.925" y1="22.775" x2="193.225" y2="22.825" layer="94"/>
+<rectangle x1="193.975" y1="22.775" x2="194.225" y2="22.825" layer="94"/>
+<rectangle x1="195.375" y1="22.775" x2="195.675" y2="22.825" layer="94"/>
+<rectangle x1="195.825" y1="22.775" x2="196.075" y2="22.825" layer="94"/>
+<rectangle x1="196.775" y1="22.775" x2="197.025" y2="22.825" layer="94"/>
+<rectangle x1="197.175" y1="22.775" x2="197.425" y2="22.825" layer="94"/>
+<rectangle x1="197.875" y1="22.775" x2="198.125" y2="22.825" layer="94"/>
+<rectangle x1="198.625" y1="22.775" x2="199.775" y2="22.825" layer="94"/>
+<rectangle x1="200.175" y1="22.775" x2="201.375" y2="22.825" layer="94"/>
+<rectangle x1="201.725" y1="22.775" x2="202.425" y2="22.825" layer="94"/>
+<rectangle x1="202.625" y1="22.775" x2="202.875" y2="22.825" layer="94"/>
+<rectangle x1="203.675" y1="22.775" x2="203.925" y2="22.825" layer="94"/>
+<rectangle x1="205.075" y1="22.775" x2="205.375" y2="22.825" layer="94"/>
+<rectangle x1="207.075" y1="22.775" x2="207.425" y2="22.825" layer="94"/>
+<rectangle x1="209.075" y1="22.775" x2="209.325" y2="22.825" layer="94"/>
+<rectangle x1="210.375" y1="22.775" x2="210.675" y2="22.825" layer="94"/>
+<rectangle x1="211.925" y1="22.775" x2="212.225" y2="22.825" layer="94"/>
+<rectangle x1="213.725" y1="22.775" x2="213.975" y2="22.825" layer="94"/>
+<rectangle x1="215.225" y1="22.775" x2="215.525" y2="22.825" layer="94"/>
+<rectangle x1="216.675" y1="22.775" x2="216.975" y2="22.825" layer="94"/>
+<rectangle x1="217.525" y1="22.775" x2="218.475" y2="22.825" layer="94"/>
+<rectangle x1="218.925" y1="22.775" x2="219.225" y2="22.825" layer="94"/>
+<rectangle x1="219.975" y1="22.775" x2="220.225" y2="22.825" layer="94"/>
+<rectangle x1="220.675" y1="22.775" x2="221.675" y2="22.825" layer="94"/>
+<rectangle x1="222.225" y1="22.775" x2="222.475" y2="22.825" layer="94"/>
+<rectangle x1="223.025" y1="22.775" x2="224.025" y2="22.825" layer="94"/>
+<rectangle x1="224.525" y1="22.775" x2="224.775" y2="22.825" layer="94"/>
+<rectangle x1="224.825" y1="22.775" x2="225.675" y2="22.825" layer="94"/>
+<rectangle x1="226.225" y1="22.775" x2="226.425" y2="22.825" layer="94"/>
+<rectangle x1="226.475" y1="22.775" x2="227.325" y2="22.825" layer="94"/>
+<rectangle x1="227.425" y1="22.775" x2="228.225" y2="22.825" layer="94"/>
+<rectangle x1="228.875" y1="22.775" x2="229.825" y2="22.825" layer="94"/>
+<rectangle x1="230.375" y1="22.775" x2="230.625" y2="22.825" layer="94"/>
+<rectangle x1="230.675" y1="22.775" x2="231.525" y2="22.825" layer="94"/>
+<rectangle x1="231.925" y1="22.775" x2="232.625" y2="22.825" layer="94"/>
+<rectangle x1="233.725" y1="22.775" x2="234.025" y2="22.825" layer="94"/>
+<rectangle x1="234.925" y1="22.775" x2="235.225" y2="22.825" layer="94"/>
+<rectangle x1="235.825" y1="22.775" x2="236.825" y2="22.825" layer="94"/>
+<rectangle x1="237.475" y1="22.775" x2="238.575" y2="22.825" layer="94"/>
+<rectangle x1="239.025" y1="22.775" x2="239.275" y2="22.825" layer="94"/>
+<rectangle x1="239.325" y1="22.775" x2="239.875" y2="22.825" layer="94"/>
+<rectangle x1="240.175" y1="22.775" x2="241.325" y2="22.825" layer="94"/>
+<rectangle x1="186.725" y1="22.825" x2="186.975" y2="22.875" layer="94"/>
+<rectangle x1="187.275" y1="22.825" x2="187.575" y2="22.875" layer="94"/>
+<rectangle x1="189.575" y1="22.825" x2="189.825" y2="22.875" layer="94"/>
+<rectangle x1="190.675" y1="22.825" x2="190.975" y2="22.875" layer="94"/>
+<rectangle x1="191.375" y1="22.825" x2="191.575" y2="22.875" layer="94"/>
+<rectangle x1="191.725" y1="22.825" x2="192.475" y2="22.875" layer="94"/>
+<rectangle x1="192.925" y1="22.825" x2="193.175" y2="22.875" layer="94"/>
+<rectangle x1="194.025" y1="22.825" x2="194.275" y2="22.875" layer="94"/>
+<rectangle x1="195.375" y1="22.825" x2="195.675" y2="22.875" layer="94"/>
+<rectangle x1="195.775" y1="22.825" x2="196.025" y2="22.875" layer="94"/>
+<rectangle x1="196.825" y1="22.825" x2="197.025" y2="22.875" layer="94"/>
+<rectangle x1="197.175" y1="22.825" x2="197.425" y2="22.875" layer="94"/>
+<rectangle x1="197.875" y1="22.825" x2="198.125" y2="22.875" layer="94"/>
+<rectangle x1="198.725" y1="22.825" x2="199.475" y2="22.875" layer="94"/>
+<rectangle x1="199.575" y1="22.825" x2="199.775" y2="22.875" layer="94"/>
+<rectangle x1="200.175" y1="22.825" x2="200.475" y2="22.875" layer="94"/>
+<rectangle x1="200.525" y1="22.825" x2="201.325" y2="22.875" layer="94"/>
+<rectangle x1="201.725" y1="22.825" x2="202.425" y2="22.875" layer="94"/>
+<rectangle x1="202.575" y1="22.825" x2="202.875" y2="22.875" layer="94"/>
+<rectangle x1="203.675" y1="22.825" x2="203.925" y2="22.875" layer="94"/>
+<rectangle x1="205.075" y1="22.825" x2="205.375" y2="22.875" layer="94"/>
+<rectangle x1="207.075" y1="22.825" x2="207.375" y2="22.875" layer="94"/>
+<rectangle x1="209.075" y1="22.825" x2="209.325" y2="22.875" layer="94"/>
+<rectangle x1="210.375" y1="22.825" x2="210.675" y2="22.875" layer="94"/>
+<rectangle x1="211.975" y1="22.825" x2="212.225" y2="22.875" layer="94"/>
+<rectangle x1="213.725" y1="22.825" x2="213.975" y2="22.875" layer="94"/>
+<rectangle x1="215.225" y1="22.825" x2="215.525" y2="22.875" layer="94"/>
+<rectangle x1="216.675" y1="22.825" x2="216.975" y2="22.875" layer="94"/>
+<rectangle x1="217.575" y1="22.825" x2="218.425" y2="22.875" layer="94"/>
+<rectangle x1="218.925" y1="22.825" x2="219.175" y2="22.875" layer="94"/>
+<rectangle x1="219.975" y1="22.825" x2="220.275" y2="22.875" layer="94"/>
+<rectangle x1="220.725" y1="22.825" x2="221.625" y2="22.875" layer="94"/>
+<rectangle x1="222.225" y1="22.825" x2="222.475" y2="22.875" layer="94"/>
+<rectangle x1="223.075" y1="22.825" x2="223.925" y2="22.875" layer="94"/>
+<rectangle x1="224.525" y1="22.825" x2="224.775" y2="22.875" layer="94"/>
+<rectangle x1="224.875" y1="22.825" x2="225.625" y2="22.875" layer="94"/>
+<rectangle x1="226.225" y1="22.825" x2="226.425" y2="22.875" layer="94"/>
+<rectangle x1="226.525" y1="22.825" x2="227.275" y2="22.875" layer="94"/>
+<rectangle x1="227.475" y1="22.825" x2="228.175" y2="22.875" layer="94"/>
+<rectangle x1="228.925" y1="22.825" x2="229.775" y2="22.875" layer="94"/>
+<rectangle x1="230.375" y1="22.825" x2="230.625" y2="22.875" layer="94"/>
+<rectangle x1="230.725" y1="22.825" x2="231.475" y2="22.875" layer="94"/>
+<rectangle x1="231.925" y1="22.825" x2="232.625" y2="22.875" layer="94"/>
+<rectangle x1="233.725" y1="22.825" x2="234.025" y2="22.875" layer="94"/>
+<rectangle x1="234.975" y1="22.825" x2="235.225" y2="22.875" layer="94"/>
+<rectangle x1="235.925" y1="22.825" x2="236.775" y2="22.875" layer="94"/>
+<rectangle x1="237.525" y1="22.825" x2="238.525" y2="22.875" layer="94"/>
+<rectangle x1="239.025" y1="22.825" x2="239.275" y2="22.875" layer="94"/>
+<rectangle x1="239.375" y1="22.825" x2="239.875" y2="22.875" layer="94"/>
+<rectangle x1="240.225" y1="22.825" x2="240.975" y2="22.875" layer="94"/>
+<rectangle x1="241.025" y1="22.825" x2="241.325" y2="22.875" layer="94"/>
+<rectangle x1="186.725" y1="22.875" x2="187.025" y2="22.925" layer="94"/>
+<rectangle x1="187.275" y1="22.875" x2="187.525" y2="22.925" layer="94"/>
+<rectangle x1="189.575" y1="22.875" x2="189.825" y2="22.925" layer="94"/>
+<rectangle x1="190.675" y1="22.875" x2="190.975" y2="22.925" layer="94"/>
+<rectangle x1="191.375" y1="22.875" x2="191.575" y2="22.925" layer="94"/>
+<rectangle x1="191.775" y1="22.875" x2="192.425" y2="22.925" layer="94"/>
+<rectangle x1="192.875" y1="22.875" x2="193.175" y2="22.925" layer="94"/>
+<rectangle x1="194.025" y1="22.875" x2="194.275" y2="22.925" layer="94"/>
+<rectangle x1="195.375" y1="22.875" x2="195.675" y2="22.925" layer="94"/>
+<rectangle x1="195.775" y1="22.875" x2="196.025" y2="22.925" layer="94"/>
+<rectangle x1="196.825" y1="22.875" x2="197.075" y2="22.925" layer="94"/>
+<rectangle x1="197.175" y1="22.875" x2="197.425" y2="22.925" layer="94"/>
+<rectangle x1="197.875" y1="22.875" x2="198.125" y2="22.925" layer="94"/>
+<rectangle x1="198.775" y1="22.875" x2="199.375" y2="22.925" layer="94"/>
+<rectangle x1="199.575" y1="22.875" x2="199.775" y2="22.925" layer="94"/>
+<rectangle x1="200.175" y1="22.875" x2="200.475" y2="22.925" layer="94"/>
+<rectangle x1="200.625" y1="22.875" x2="201.275" y2="22.925" layer="94"/>
+<rectangle x1="201.725" y1="22.875" x2="202.425" y2="22.925" layer="94"/>
+<rectangle x1="202.575" y1="22.875" x2="202.825" y2="22.925" layer="94"/>
+<rectangle x1="203.675" y1="22.875" x2="203.975" y2="22.925" layer="94"/>
+<rectangle x1="205.075" y1="22.875" x2="205.375" y2="22.925" layer="94"/>
+<rectangle x1="207.075" y1="22.875" x2="207.325" y2="22.925" layer="94"/>
+<rectangle x1="209.075" y1="22.875" x2="209.325" y2="22.925" layer="94"/>
+<rectangle x1="210.425" y1="22.875" x2="210.725" y2="22.925" layer="94"/>
+<rectangle x1="211.975" y1="22.875" x2="212.225" y2="22.925" layer="94"/>
+<rectangle x1="213.725" y1="22.875" x2="214.025" y2="22.925" layer="94"/>
+<rectangle x1="215.225" y1="22.875" x2="215.525" y2="22.925" layer="94"/>
+<rectangle x1="216.625" y1="22.875" x2="216.975" y2="22.925" layer="94"/>
+<rectangle x1="217.675" y1="22.875" x2="218.375" y2="22.925" layer="94"/>
+<rectangle x1="218.875" y1="22.875" x2="219.175" y2="22.925" layer="94"/>
+<rectangle x1="220.025" y1="22.875" x2="220.275" y2="22.925" layer="94"/>
+<rectangle x1="220.825" y1="22.875" x2="221.525" y2="22.925" layer="94"/>
+<rectangle x1="222.225" y1="22.875" x2="222.475" y2="22.925" layer="94"/>
+<rectangle x1="223.175" y1="22.875" x2="223.875" y2="22.925" layer="94"/>
+<rectangle x1="224.525" y1="22.875" x2="224.775" y2="22.925" layer="94"/>
+<rectangle x1="224.925" y1="22.875" x2="225.575" y2="22.925" layer="94"/>
+<rectangle x1="226.225" y1="22.875" x2="226.425" y2="22.925" layer="94"/>
+<rectangle x1="226.625" y1="22.875" x2="227.225" y2="22.925" layer="94"/>
+<rectangle x1="227.525" y1="22.875" x2="228.125" y2="22.925" layer="94"/>
+<rectangle x1="228.975" y1="22.875" x2="229.675" y2="22.925" layer="94"/>
+<rectangle x1="230.375" y1="22.875" x2="230.625" y2="22.925" layer="94"/>
+<rectangle x1="230.775" y1="22.875" x2="231.425" y2="22.925" layer="94"/>
+<rectangle x1="231.925" y1="22.875" x2="232.625" y2="22.925" layer="94"/>
+<rectangle x1="233.725" y1="22.875" x2="234.025" y2="22.925" layer="94"/>
+<rectangle x1="234.975" y1="22.875" x2="235.225" y2="22.925" layer="94"/>
+<rectangle x1="236.025" y1="22.875" x2="236.725" y2="22.925" layer="94"/>
+<rectangle x1="237.625" y1="22.875" x2="238.425" y2="22.925" layer="94"/>
+<rectangle x1="239.025" y1="22.875" x2="239.275" y2="22.925" layer="94"/>
+<rectangle x1="239.425" y1="22.875" x2="239.875" y2="22.925" layer="94"/>
+<rectangle x1="240.275" y1="22.875" x2="240.925" y2="22.925" layer="94"/>
+<rectangle x1="241.025" y1="22.875" x2="241.325" y2="22.925" layer="94"/>
+<rectangle x1="186.775" y1="22.925" x2="187.025" y2="22.975" layer="94"/>
+<rectangle x1="187.275" y1="22.925" x2="187.525" y2="22.975" layer="94"/>
+<rectangle x1="189.575" y1="22.925" x2="189.825" y2="22.975" layer="94"/>
+<rectangle x1="190.725" y1="22.925" x2="190.925" y2="22.975" layer="94"/>
+<rectangle x1="191.375" y1="22.925" x2="191.575" y2="22.975" layer="94"/>
+<rectangle x1="191.875" y1="22.925" x2="192.325" y2="22.975" layer="94"/>
+<rectangle x1="192.925" y1="22.925" x2="193.125" y2="22.975" layer="94"/>
+<rectangle x1="194.075" y1="22.925" x2="194.275" y2="22.975" layer="94"/>
+<rectangle x1="195.375" y1="22.925" x2="195.675" y2="22.975" layer="94"/>
+<rectangle x1="195.775" y1="22.925" x2="196.025" y2="22.975" layer="94"/>
+<rectangle x1="196.825" y1="22.925" x2="197.075" y2="22.975" layer="94"/>
+<rectangle x1="197.175" y1="22.925" x2="197.425" y2="22.975" layer="94"/>
+<rectangle x1="197.875" y1="22.925" x2="198.125" y2="22.975" layer="94"/>
+<rectangle x1="198.875" y1="22.925" x2="199.275" y2="22.975" layer="94"/>
+<rectangle x1="199.575" y1="22.925" x2="199.775" y2="22.975" layer="94"/>
+<rectangle x1="200.175" y1="22.925" x2="200.475" y2="22.975" layer="94"/>
+<rectangle x1="200.725" y1="22.925" x2="201.125" y2="22.975" layer="94"/>
+<rectangle x1="201.725" y1="22.925" x2="202.425" y2="22.975" layer="94"/>
+<rectangle x1="202.575" y1="22.925" x2="202.825" y2="22.975" layer="94"/>
+<rectangle x1="203.725" y1="22.925" x2="203.925" y2="22.975" layer="94"/>
+<rectangle x1="205.075" y1="22.925" x2="205.375" y2="22.975" layer="94"/>
+<rectangle x1="207.075" y1="22.925" x2="207.325" y2="22.975" layer="94"/>
+<rectangle x1="208.325" y1="22.925" x2="208.625" y2="22.975" layer="94"/>
+<rectangle x1="209.075" y1="22.925" x2="209.325" y2="22.975" layer="94"/>
+<rectangle x1="210.425" y1="22.925" x2="210.725" y2="22.975" layer="94"/>
+<rectangle x1="211.975" y1="22.925" x2="212.275" y2="22.975" layer="94"/>
+<rectangle x1="212.675" y1="22.925" x2="212.925" y2="22.975" layer="94"/>
+<rectangle x1="213.725" y1="22.925" x2="214.025" y2="22.975" layer="94"/>
+<rectangle x1="215.225" y1="22.925" x2="215.525" y2="22.975" layer="94"/>
+<rectangle x1="216.625" y1="22.925" x2="216.925" y2="22.975" layer="94"/>
+<rectangle x1="217.775" y1="22.925" x2="218.225" y2="22.975" layer="94"/>
+<rectangle x1="218.925" y1="22.925" x2="219.125" y2="22.975" layer="94"/>
+<rectangle x1="220.025" y1="22.925" x2="220.275" y2="22.975" layer="94"/>
+<rectangle x1="220.925" y1="22.925" x2="221.425" y2="22.975" layer="94"/>
+<rectangle x1="222.225" y1="22.925" x2="222.475" y2="22.975" layer="94"/>
+<rectangle x1="223.275" y1="22.925" x2="223.725" y2="22.975" layer="94"/>
+<rectangle x1="224.575" y1="22.925" x2="224.775" y2="22.975" layer="94"/>
+<rectangle x1="225.025" y1="22.925" x2="225.425" y2="22.975" layer="94"/>
+<rectangle x1="226.225" y1="22.925" x2="226.425" y2="22.975" layer="94"/>
+<rectangle x1="226.725" y1="22.925" x2="227.125" y2="22.975" layer="94"/>
+<rectangle x1="227.625" y1="22.925" x2="228.025" y2="22.975" layer="94"/>
+<rectangle x1="229.125" y1="22.925" x2="229.575" y2="22.975" layer="94"/>
+<rectangle x1="230.375" y1="22.925" x2="230.575" y2="22.975" layer="94"/>
+<rectangle x1="230.875" y1="22.925" x2="231.325" y2="22.975" layer="94"/>
+<rectangle x1="231.925" y1="22.925" x2="232.625" y2="22.975" layer="94"/>
+<rectangle x1="233.725" y1="22.925" x2="234.025" y2="22.975" layer="94"/>
+<rectangle x1="234.975" y1="22.925" x2="235.225" y2="22.975" layer="94"/>
+<rectangle x1="236.125" y1="22.925" x2="236.575" y2="22.975" layer="94"/>
+<rectangle x1="237.775" y1="22.925" x2="238.325" y2="22.975" layer="94"/>
+<rectangle x1="239.075" y1="22.925" x2="239.275" y2="22.975" layer="94"/>
+<rectangle x1="239.475" y1="22.925" x2="239.775" y2="22.975" layer="94"/>
+<rectangle x1="240.425" y1="22.925" x2="240.825" y2="22.975" layer="94"/>
+<rectangle x1="241.025" y1="22.925" x2="241.325" y2="22.975" layer="94"/>
+<rectangle x1="186.775" y1="22.975" x2="187.025" y2="23.025" layer="94"/>
+<rectangle x1="187.225" y1="22.975" x2="187.525" y2="23.025" layer="94"/>
+<rectangle x1="189.575" y1="22.975" x2="189.825" y2="23.025" layer="94"/>
+<rectangle x1="195.375" y1="22.975" x2="195.675" y2="23.025" layer="94"/>
+<rectangle x1="195.725" y1="22.975" x2="195.975" y2="23.025" layer="94"/>
+<rectangle x1="196.875" y1="22.975" x2="197.075" y2="23.025" layer="94"/>
+<rectangle x1="197.175" y1="22.975" x2="197.425" y2="23.025" layer="94"/>
+<rectangle x1="200.175" y1="22.975" x2="200.475" y2="23.025" layer="94"/>
+<rectangle x1="201.925" y1="22.975" x2="202.175" y2="23.025" layer="94"/>
+<rectangle x1="205.075" y1="22.975" x2="205.375" y2="23.025" layer="94"/>
+<rectangle x1="207.075" y1="22.975" x2="207.325" y2="23.025" layer="94"/>
+<rectangle x1="208.325" y1="22.975" x2="208.625" y2="23.025" layer="94"/>
+<rectangle x1="209.075" y1="22.975" x2="209.325" y2="23.025" layer="94"/>
+<rectangle x1="210.375" y1="22.975" x2="210.675" y2="23.025" layer="94"/>
+<rectangle x1="211.025" y1="22.975" x2="211.275" y2="23.025" layer="94"/>
+<rectangle x1="211.975" y1="22.975" x2="212.275" y2="23.025" layer="94"/>
+<rectangle x1="212.675" y1="22.975" x2="212.925" y2="23.025" layer="94"/>
+<rectangle x1="213.725" y1="22.975" x2="214.025" y2="23.025" layer="94"/>
+<rectangle x1="215.225" y1="22.975" x2="215.525" y2="23.025" layer="94"/>
+<rectangle x1="216.625" y1="22.975" x2="216.925" y2="23.025" layer="94"/>
+<rectangle x1="222.225" y1="22.975" x2="222.475" y2="23.025" layer="94"/>
+<rectangle x1="232.075" y1="22.975" x2="232.375" y2="23.025" layer="94"/>
+<rectangle x1="233.725" y1="22.975" x2="234.025" y2="23.025" layer="94"/>
+<rectangle x1="234.975" y1="22.975" x2="235.275" y2="23.025" layer="94"/>
+<rectangle x1="241.025" y1="22.975" x2="241.325" y2="23.025" layer="94"/>
+<rectangle x1="186.775" y1="23.025" x2="187.025" y2="23.075" layer="94"/>
+<rectangle x1="187.225" y1="23.025" x2="187.475" y2="23.075" layer="94"/>
+<rectangle x1="189.575" y1="23.025" x2="189.825" y2="23.075" layer="94"/>
+<rectangle x1="195.375" y1="23.025" x2="195.675" y2="23.075" layer="94"/>
+<rectangle x1="195.725" y1="23.025" x2="195.975" y2="23.075" layer="94"/>
+<rectangle x1="196.875" y1="23.025" x2="197.125" y2="23.075" layer="94"/>
+<rectangle x1="197.175" y1="23.025" x2="197.425" y2="23.075" layer="94"/>
+<rectangle x1="200.175" y1="23.025" x2="200.475" y2="23.075" layer="94"/>
+<rectangle x1="201.925" y1="23.025" x2="202.175" y2="23.075" layer="94"/>
+<rectangle x1="205.075" y1="23.025" x2="205.375" y2="23.075" layer="94"/>
+<rectangle x1="207.075" y1="23.025" x2="207.325" y2="23.075" layer="94"/>
+<rectangle x1="208.325" y1="23.025" x2="208.575" y2="23.075" layer="94"/>
+<rectangle x1="209.075" y1="23.025" x2="209.325" y2="23.075" layer="94"/>
+<rectangle x1="210.375" y1="23.025" x2="210.675" y2="23.075" layer="94"/>
+<rectangle x1="211.025" y1="23.025" x2="211.275" y2="23.075" layer="94"/>
+<rectangle x1="211.975" y1="23.025" x2="212.275" y2="23.075" layer="94"/>
+<rectangle x1="212.675" y1="23.025" x2="212.925" y2="23.075" layer="94"/>
+<rectangle x1="213.725" y1="23.025" x2="213.975" y2="23.075" layer="94"/>
+<rectangle x1="215.225" y1="23.025" x2="215.525" y2="23.075" layer="94"/>
+<rectangle x1="216.575" y1="23.025" x2="216.875" y2="23.075" layer="94"/>
+<rectangle x1="222.225" y1="23.025" x2="222.475" y2="23.075" layer="94"/>
+<rectangle x1="232.075" y1="23.025" x2="232.375" y2="23.075" layer="94"/>
+<rectangle x1="233.725" y1="23.025" x2="234.025" y2="23.075" layer="94"/>
+<rectangle x1="234.975" y1="23.025" x2="235.225" y2="23.075" layer="94"/>
+<rectangle x1="241.025" y1="23.025" x2="241.325" y2="23.075" layer="94"/>
+<rectangle x1="186.825" y1="23.075" x2="187.075" y2="23.125" layer="94"/>
+<rectangle x1="187.175" y1="23.075" x2="187.475" y2="23.125" layer="94"/>
+<rectangle x1="189.575" y1="23.075" x2="189.825" y2="23.125" layer="94"/>
+<rectangle x1="195.375" y1="23.075" x2="195.675" y2="23.125" layer="94"/>
+<rectangle x1="195.725" y1="23.075" x2="195.975" y2="23.125" layer="94"/>
+<rectangle x1="196.875" y1="23.075" x2="197.125" y2="23.125" layer="94"/>
+<rectangle x1="197.175" y1="23.075" x2="197.425" y2="23.125" layer="94"/>
+<rectangle x1="200.175" y1="23.075" x2="200.475" y2="23.125" layer="94"/>
+<rectangle x1="201.925" y1="23.075" x2="202.175" y2="23.125" layer="94"/>
+<rectangle x1="205.075" y1="23.075" x2="205.375" y2="23.125" layer="94"/>
+<rectangle x1="207.075" y1="23.075" x2="207.325" y2="23.125" layer="94"/>
+<rectangle x1="208.275" y1="23.075" x2="208.575" y2="23.125" layer="94"/>
+<rectangle x1="209.075" y1="23.075" x2="209.325" y2="23.125" layer="94"/>
+<rectangle x1="210.375" y1="23.075" x2="210.675" y2="23.125" layer="94"/>
+<rectangle x1="211.025" y1="23.075" x2="211.275" y2="23.125" layer="94"/>
+<rectangle x1="211.975" y1="23.075" x2="212.225" y2="23.125" layer="94"/>
+<rectangle x1="212.675" y1="23.075" x2="212.975" y2="23.125" layer="94"/>
+<rectangle x1="213.725" y1="23.075" x2="213.975" y2="23.125" layer="94"/>
+<rectangle x1="215.225" y1="23.075" x2="215.525" y2="23.125" layer="94"/>
+<rectangle x1="216.525" y1="23.075" x2="216.875" y2="23.125" layer="94"/>
+<rectangle x1="222.225" y1="23.075" x2="222.475" y2="23.125" layer="94"/>
+<rectangle x1="232.075" y1="23.075" x2="232.375" y2="23.125" layer="94"/>
+<rectangle x1="233.725" y1="23.075" x2="234.025" y2="23.125" layer="94"/>
+<rectangle x1="234.925" y1="23.075" x2="235.225" y2="23.125" layer="94"/>
+<rectangle x1="241.025" y1="23.075" x2="241.325" y2="23.125" layer="94"/>
+<rectangle x1="186.825" y1="23.125" x2="187.075" y2="23.175" layer="94"/>
+<rectangle x1="187.175" y1="23.125" x2="187.425" y2="23.175" layer="94"/>
+<rectangle x1="189.575" y1="23.125" x2="189.825" y2="23.175" layer="94"/>
+<rectangle x1="195.375" y1="23.125" x2="195.925" y2="23.175" layer="94"/>
+<rectangle x1="196.925" y1="23.125" x2="197.425" y2="23.175" layer="94"/>
+<rectangle x1="200.175" y1="23.125" x2="200.475" y2="23.175" layer="94"/>
+<rectangle x1="201.925" y1="23.125" x2="202.175" y2="23.175" layer="94"/>
+<rectangle x1="205.075" y1="23.125" x2="205.375" y2="23.175" layer="94"/>
+<rectangle x1="207.075" y1="23.125" x2="207.375" y2="23.175" layer="94"/>
+<rectangle x1="208.275" y1="23.125" x2="208.575" y2="23.175" layer="94"/>
+<rectangle x1="209.075" y1="23.125" x2="209.325" y2="23.175" layer="94"/>
+<rectangle x1="210.325" y1="23.125" x2="210.675" y2="23.175" layer="94"/>
+<rectangle x1="211.025" y1="23.125" x2="211.325" y2="23.175" layer="94"/>
+<rectangle x1="211.975" y1="23.125" x2="212.225" y2="23.175" layer="94"/>
+<rectangle x1="212.675" y1="23.125" x2="212.975" y2="23.175" layer="94"/>
+<rectangle x1="213.675" y1="23.125" x2="213.975" y2="23.175" layer="94"/>
+<rectangle x1="215.225" y1="23.125" x2="215.525" y2="23.175" layer="94"/>
+<rectangle x1="216.475" y1="23.125" x2="216.825" y2="23.175" layer="94"/>
+<rectangle x1="222.225" y1="23.125" x2="222.475" y2="23.175" layer="94"/>
+<rectangle x1="232.075" y1="23.125" x2="232.375" y2="23.175" layer="94"/>
+<rectangle x1="233.725" y1="23.125" x2="234.025" y2="23.175" layer="94"/>
+<rectangle x1="234.925" y1="23.125" x2="235.225" y2="23.175" layer="94"/>
+<rectangle x1="241.025" y1="23.125" x2="241.325" y2="23.175" layer="94"/>
+<rectangle x1="186.825" y1="23.175" x2="187.075" y2="23.225" layer="94"/>
+<rectangle x1="187.175" y1="23.175" x2="187.425" y2="23.225" layer="94"/>
+<rectangle x1="189.575" y1="23.175" x2="189.825" y2="23.225" layer="94"/>
+<rectangle x1="195.375" y1="23.175" x2="195.925" y2="23.225" layer="94"/>
+<rectangle x1="196.925" y1="23.175" x2="197.425" y2="23.225" layer="94"/>
+<rectangle x1="200.175" y1="23.175" x2="200.475" y2="23.225" layer="94"/>
+<rectangle x1="201.925" y1="23.175" x2="202.175" y2="23.225" layer="94"/>
+<rectangle x1="205.075" y1="23.175" x2="205.375" y2="23.225" layer="94"/>
+<rectangle x1="207.075" y1="23.175" x2="207.425" y2="23.225" layer="94"/>
+<rectangle x1="208.225" y1="23.175" x2="208.525" y2="23.225" layer="94"/>
+<rectangle x1="209.075" y1="23.175" x2="209.325" y2="23.225" layer="94"/>
+<rectangle x1="210.275" y1="23.175" x2="210.625" y2="23.225" layer="94"/>
+<rectangle x1="211.075" y1="23.175" x2="211.375" y2="23.225" layer="94"/>
+<rectangle x1="211.925" y1="23.175" x2="212.225" y2="23.225" layer="94"/>
+<rectangle x1="212.725" y1="23.175" x2="213.025" y2="23.225" layer="94"/>
+<rectangle x1="213.625" y1="23.175" x2="213.975" y2="23.225" layer="94"/>
+<rectangle x1="215.225" y1="23.175" x2="215.525" y2="23.225" layer="94"/>
+<rectangle x1="216.425" y1="23.175" x2="216.825" y2="23.225" layer="94"/>
+<rectangle x1="222.225" y1="23.175" x2="222.475" y2="23.225" layer="94"/>
+<rectangle x1="232.075" y1="23.175" x2="232.375" y2="23.225" layer="94"/>
+<rectangle x1="233.725" y1="23.175" x2="234.025" y2="23.225" layer="94"/>
+<rectangle x1="234.875" y1="23.175" x2="235.225" y2="23.225" layer="94"/>
+<rectangle x1="241.025" y1="23.175" x2="241.325" y2="23.225" layer="94"/>
+<rectangle x1="186.875" y1="23.225" x2="187.425" y2="23.275" layer="94"/>
+<rectangle x1="189.575" y1="23.225" x2="189.825" y2="23.275" layer="94"/>
+<rectangle x1="190.725" y1="23.225" x2="190.925" y2="23.275" layer="94"/>
+<rectangle x1="195.375" y1="23.225" x2="195.925" y2="23.275" layer="94"/>
+<rectangle x1="196.975" y1="23.225" x2="197.425" y2="23.275" layer="94"/>
+<rectangle x1="197.875" y1="23.225" x2="198.125" y2="23.275" layer="94"/>
+<rectangle x1="200.175" y1="23.225" x2="200.475" y2="23.275" layer="94"/>
+<rectangle x1="201.925" y1="23.225" x2="202.175" y2="23.275" layer="94"/>
+<rectangle x1="205.075" y1="23.225" x2="205.375" y2="23.275" layer="94"/>
+<rectangle x1="207.125" y1="23.225" x2="207.475" y2="23.275" layer="94"/>
+<rectangle x1="208.125" y1="23.225" x2="208.525" y2="23.275" layer="94"/>
+<rectangle x1="209.075" y1="23.225" x2="209.325" y2="23.275" layer="94"/>
+<rectangle x1="210.225" y1="23.225" x2="210.625" y2="23.275" layer="94"/>
+<rectangle x1="211.075" y1="23.225" x2="211.425" y2="23.275" layer="94"/>
+<rectangle x1="211.875" y1="23.225" x2="212.175" y2="23.275" layer="94"/>
+<rectangle x1="212.725" y1="23.225" x2="213.075" y2="23.275" layer="94"/>
+<rectangle x1="213.575" y1="23.225" x2="213.925" y2="23.275" layer="94"/>
+<rectangle x1="215.225" y1="23.225" x2="215.525" y2="23.275" layer="94"/>
+<rectangle x1="216.325" y1="23.225" x2="216.775" y2="23.275" layer="94"/>
+<rectangle x1="222.225" y1="23.225" x2="222.475" y2="23.275" layer="94"/>
+<rectangle x1="232.075" y1="23.225" x2="232.375" y2="23.275" layer="94"/>
+<rectangle x1="233.725" y1="23.225" x2="234.025" y2="23.275" layer="94"/>
+<rectangle x1="234.775" y1="23.225" x2="235.175" y2="23.275" layer="94"/>
+<rectangle x1="241.025" y1="23.225" x2="241.325" y2="23.275" layer="94"/>
+<rectangle x1="186.875" y1="23.275" x2="187.375" y2="23.325" layer="94"/>
+<rectangle x1="188.875" y1="23.275" x2="190.525" y2="23.325" layer="94"/>
+<rectangle x1="190.675" y1="23.275" x2="190.975" y2="23.325" layer="94"/>
+<rectangle x1="195.375" y1="23.275" x2="195.875" y2="23.325" layer="94"/>
+<rectangle x1="196.975" y1="23.275" x2="197.425" y2="23.325" layer="94"/>
+<rectangle x1="197.875" y1="23.275" x2="198.125" y2="23.325" layer="94"/>
+<rectangle x1="200.175" y1="23.275" x2="200.475" y2="23.325" layer="94"/>
+<rectangle x1="201.925" y1="23.275" x2="202.175" y2="23.325" layer="94"/>
+<rectangle x1="205.075" y1="23.275" x2="206.625" y2="23.325" layer="94"/>
+<rectangle x1="207.125" y1="23.275" x2="207.575" y2="23.325" layer="94"/>
+<rectangle x1="208.025" y1="23.275" x2="208.475" y2="23.325" layer="94"/>
+<rectangle x1="209.075" y1="23.275" x2="210.575" y2="23.325" layer="94"/>
+<rectangle x1="211.125" y1="23.275" x2="211.475" y2="23.325" layer="94"/>
+<rectangle x1="211.775" y1="23.275" x2="212.175" y2="23.325" layer="94"/>
+<rectangle x1="212.775" y1="23.275" x2="213.175" y2="23.325" layer="94"/>
+<rectangle x1="213.525" y1="23.275" x2="213.875" y2="23.325" layer="94"/>
+<rectangle x1="215.225" y1="23.275" x2="216.725" y2="23.325" layer="94"/>
+<rectangle x1="222.225" y1="23.275" x2="222.475" y2="23.325" layer="94"/>
+<rectangle x1="232.075" y1="23.275" x2="232.375" y2="23.325" layer="94"/>
+<rectangle x1="233.725" y1="23.275" x2="235.125" y2="23.325" layer="94"/>
+<rectangle x1="241.025" y1="23.275" x2="241.325" y2="23.325" layer="94"/>
+<rectangle x1="186.925" y1="23.325" x2="187.375" y2="23.375" layer="94"/>
+<rectangle x1="188.825" y1="23.325" x2="190.525" y2="23.375" layer="94"/>
+<rectangle x1="190.675" y1="23.325" x2="190.975" y2="23.375" layer="94"/>
+<rectangle x1="195.375" y1="23.325" x2="195.875" y2="23.375" layer="94"/>
+<rectangle x1="196.975" y1="23.325" x2="197.425" y2="23.375" layer="94"/>
+<rectangle x1="197.875" y1="23.325" x2="198.125" y2="23.375" layer="94"/>
+<rectangle x1="200.175" y1="23.325" x2="200.475" y2="23.375" layer="94"/>
+<rectangle x1="201.925" y1="23.325" x2="202.175" y2="23.375" layer="94"/>
+<rectangle x1="205.075" y1="23.325" x2="206.625" y2="23.375" layer="94"/>
+<rectangle x1="207.175" y1="23.325" x2="208.425" y2="23.375" layer="94"/>
+<rectangle x1="209.075" y1="23.325" x2="210.525" y2="23.375" layer="94"/>
+<rectangle x1="211.175" y1="23.325" x2="212.125" y2="23.375" layer="94"/>
+<rectangle x1="212.825" y1="23.325" x2="213.875" y2="23.375" layer="94"/>
+<rectangle x1="215.225" y1="23.325" x2="216.675" y2="23.375" layer="94"/>
+<rectangle x1="222.225" y1="23.325" x2="222.475" y2="23.375" layer="94"/>
+<rectangle x1="232.125" y1="23.325" x2="232.375" y2="23.375" layer="94"/>
+<rectangle x1="233.725" y1="23.325" x2="235.125" y2="23.375" layer="94"/>
+<rectangle x1="241.025" y1="23.325" x2="241.325" y2="23.375" layer="94"/>
+<rectangle x1="186.925" y1="23.375" x2="187.325" y2="23.425" layer="94"/>
+<rectangle x1="188.825" y1="23.375" x2="190.525" y2="23.425" layer="94"/>
+<rectangle x1="190.675" y1="23.375" x2="190.975" y2="23.425" layer="94"/>
+<rectangle x1="195.375" y1="23.375" x2="195.875" y2="23.425" layer="94"/>
+<rectangle x1="197.025" y1="23.375" x2="197.425" y2="23.425" layer="94"/>
+<rectangle x1="197.875" y1="23.375" x2="198.125" y2="23.425" layer="94"/>
+<rectangle x1="200.175" y1="23.375" x2="200.475" y2="23.425" layer="94"/>
+<rectangle x1="202.025" y1="23.375" x2="202.175" y2="23.425" layer="94"/>
+<rectangle x1="205.075" y1="23.375" x2="206.625" y2="23.425" layer="94"/>
+<rectangle x1="207.225" y1="23.375" x2="208.375" y2="23.425" layer="94"/>
+<rectangle x1="209.075" y1="23.375" x2="210.475" y2="23.425" layer="94"/>
+<rectangle x1="211.225" y1="23.375" x2="212.075" y2="23.425" layer="94"/>
+<rectangle x1="212.875" y1="23.375" x2="213.825" y2="23.425" layer="94"/>
+<rectangle x1="215.225" y1="23.375" x2="216.625" y2="23.425" layer="94"/>
+<rectangle x1="222.225" y1="23.375" x2="222.475" y2="23.425" layer="94"/>
+<rectangle x1="232.175" y1="23.375" x2="232.375" y2="23.425" layer="94"/>
+<rectangle x1="233.725" y1="23.375" x2="235.075" y2="23.425" layer="94"/>
+<rectangle x1="241.025" y1="23.375" x2="241.325" y2="23.425" layer="94"/>
+<rectangle x1="186.925" y1="23.425" x2="187.325" y2="23.475" layer="94"/>
+<rectangle x1="188.825" y1="23.425" x2="190.525" y2="23.475" layer="94"/>
+<rectangle x1="190.675" y1="23.425" x2="190.975" y2="23.475" layer="94"/>
+<rectangle x1="195.375" y1="23.425" x2="195.825" y2="23.475" layer="94"/>
+<rectangle x1="197.025" y1="23.425" x2="197.425" y2="23.475" layer="94"/>
+<rectangle x1="197.875" y1="23.425" x2="198.125" y2="23.475" layer="94"/>
+<rectangle x1="200.175" y1="23.425" x2="200.475" y2="23.475" layer="94"/>
+<rectangle x1="202.075" y1="23.425" x2="202.175" y2="23.475" layer="94"/>
+<rectangle x1="205.075" y1="23.425" x2="206.625" y2="23.475" layer="94"/>
+<rectangle x1="207.325" y1="23.425" x2="208.325" y2="23.475" layer="94"/>
+<rectangle x1="209.075" y1="23.425" x2="210.425" y2="23.475" layer="94"/>
+<rectangle x1="211.275" y1="23.425" x2="211.975" y2="23.475" layer="94"/>
+<rectangle x1="212.975" y1="23.425" x2="213.725" y2="23.475" layer="94"/>
+<rectangle x1="215.225" y1="23.425" x2="216.525" y2="23.475" layer="94"/>
+<rectangle x1="222.225" y1="23.425" x2="222.475" y2="23.475" layer="94"/>
+<rectangle x1="232.275" y1="23.425" x2="232.375" y2="23.475" layer="94"/>
+<rectangle x1="233.725" y1="23.425" x2="234.975" y2="23.475" layer="94"/>
+<rectangle x1="241.025" y1="23.425" x2="241.325" y2="23.475" layer="94"/>
+<rectangle x1="186.975" y1="23.475" x2="187.325" y2="23.525" layer="94"/>
+<rectangle x1="188.825" y1="23.475" x2="190.525" y2="23.525" layer="94"/>
+<rectangle x1="190.675" y1="23.475" x2="190.975" y2="23.525" layer="94"/>
+<rectangle x1="195.375" y1="23.475" x2="195.825" y2="23.525" layer="94"/>
+<rectangle x1="197.025" y1="23.475" x2="197.425" y2="23.525" layer="94"/>
+<rectangle x1="197.875" y1="23.475" x2="198.125" y2="23.525" layer="94"/>
+<rectangle x1="200.175" y1="23.475" x2="200.475" y2="23.525" layer="94"/>
+<rectangle x1="205.075" y1="23.475" x2="206.625" y2="23.525" layer="94"/>
+<rectangle x1="207.375" y1="23.475" x2="208.225" y2="23.525" layer="94"/>
+<rectangle x1="209.075" y1="23.475" x2="210.275" y2="23.525" layer="94"/>
+<rectangle x1="211.375" y1="23.475" x2="211.875" y2="23.525" layer="94"/>
+<rectangle x1="213.025" y1="23.475" x2="213.625" y2="23.525" layer="94"/>
+<rectangle x1="215.225" y1="23.475" x2="216.375" y2="23.525" layer="94"/>
+<rectangle x1="222.225" y1="23.475" x2="222.475" y2="23.525" layer="94"/>
+<rectangle x1="233.725" y1="23.475" x2="234.875" y2="23.525" layer="94"/>
+<rectangle x1="241.025" y1="23.475" x2="241.325" y2="23.525" layer="94"/>
+<rectangle x1="207.575" y1="23.525" x2="208.075" y2="23.575" layer="94"/>
+<rectangle x1="211.625" y1="23.525" x2="211.675" y2="23.575" layer="94"/>
+<rectangle x1="213.325" y1="23.525" x2="213.375" y2="23.575" layer="94"/>
+<rectangle x1="186.925" y1="24.625" x2="205.075" y2="24.675" layer="94"/>
+<rectangle x1="208.525" y1="24.625" x2="240.575" y2="24.675" layer="94"/>
+<rectangle x1="186.625" y1="24.675" x2="206.325" y2="24.725" layer="94"/>
+<rectangle x1="208.525" y1="24.675" x2="240.875" y2="24.725" layer="94"/>
+<rectangle x1="186.425" y1="24.725" x2="206.475" y2="24.775" layer="94"/>
+<rectangle x1="208.575" y1="24.725" x2="241.075" y2="24.775" layer="94"/>
+<rectangle x1="186.275" y1="24.775" x2="206.625" y2="24.825" layer="94"/>
+<rectangle x1="208.625" y1="24.775" x2="241.225" y2="24.825" layer="94"/>
+<rectangle x1="186.125" y1="24.825" x2="206.675" y2="24.875" layer="94"/>
+<rectangle x1="208.625" y1="24.825" x2="241.375" y2="24.875" layer="94"/>
+<rectangle x1="186.025" y1="24.875" x2="206.775" y2="24.925" layer="94"/>
+<rectangle x1="208.675" y1="24.875" x2="241.475" y2="24.925" layer="94"/>
+<rectangle x1="185.925" y1="24.925" x2="206.825" y2="24.975" layer="94"/>
+<rectangle x1="208.675" y1="24.925" x2="241.575" y2="24.975" layer="94"/>
+<rectangle x1="185.825" y1="24.975" x2="206.875" y2="25.025" layer="94"/>
+<rectangle x1="208.725" y1="24.975" x2="241.675" y2="25.025" layer="94"/>
+<rectangle x1="185.725" y1="25.025" x2="206.925" y2="25.075" layer="94"/>
+<rectangle x1="208.725" y1="25.025" x2="241.775" y2="25.075" layer="94"/>
+<rectangle x1="185.625" y1="25.075" x2="206.975" y2="25.125" layer="94"/>
+<rectangle x1="208.775" y1="25.075" x2="241.875" y2="25.125" layer="94"/>
+<rectangle x1="185.575" y1="25.125" x2="207.025" y2="25.175" layer="94"/>
+<rectangle x1="208.775" y1="25.125" x2="241.975" y2="25.175" layer="94"/>
+<rectangle x1="185.475" y1="25.175" x2="207.075" y2="25.225" layer="94"/>
+<rectangle x1="208.825" y1="25.175" x2="242.025" y2="25.225" layer="94"/>
+<rectangle x1="185.425" y1="25.225" x2="207.125" y2="25.275" layer="94"/>
+<rectangle x1="208.825" y1="25.225" x2="242.075" y2="25.275" layer="94"/>
+<rectangle x1="185.325" y1="25.275" x2="207.125" y2="25.325" layer="94"/>
+<rectangle x1="208.825" y1="25.275" x2="242.175" y2="25.325" layer="94"/>
+<rectangle x1="185.275" y1="25.325" x2="207.175" y2="25.375" layer="94"/>
+<rectangle x1="208.875" y1="25.325" x2="242.225" y2="25.375" layer="94"/>
+<rectangle x1="185.225" y1="25.375" x2="207.175" y2="25.425" layer="94"/>
+<rectangle x1="208.875" y1="25.375" x2="242.275" y2="25.425" layer="94"/>
+<rectangle x1="185.175" y1="25.425" x2="207.225" y2="25.475" layer="94"/>
+<rectangle x1="208.925" y1="25.425" x2="242.325" y2="25.475" layer="94"/>
+<rectangle x1="185.125" y1="25.475" x2="207.225" y2="25.525" layer="94"/>
+<rectangle x1="208.925" y1="25.475" x2="242.375" y2="25.525" layer="94"/>
+<rectangle x1="185.075" y1="25.525" x2="207.275" y2="25.575" layer="94"/>
+<rectangle x1="208.975" y1="25.525" x2="242.425" y2="25.575" layer="94"/>
+<rectangle x1="185.025" y1="25.575" x2="207.275" y2="25.625" layer="94"/>
+<rectangle x1="208.975" y1="25.575" x2="242.475" y2="25.625" layer="94"/>
+<rectangle x1="184.975" y1="25.625" x2="207.325" y2="25.675" layer="94"/>
+<rectangle x1="208.975" y1="25.625" x2="242.525" y2="25.675" layer="94"/>
+<rectangle x1="184.925" y1="25.675" x2="207.325" y2="25.725" layer="94"/>
+<rectangle x1="209.025" y1="25.675" x2="242.575" y2="25.725" layer="94"/>
+<rectangle x1="184.875" y1="25.725" x2="207.375" y2="25.775" layer="94"/>
+<rectangle x1="209.025" y1="25.725" x2="242.625" y2="25.775" layer="94"/>
+<rectangle x1="184.825" y1="25.775" x2="207.375" y2="25.825" layer="94"/>
+<rectangle x1="209.075" y1="25.775" x2="242.675" y2="25.825" layer="94"/>
+<rectangle x1="184.775" y1="25.825" x2="207.375" y2="25.875" layer="94"/>
+<rectangle x1="209.075" y1="25.825" x2="242.725" y2="25.875" layer="94"/>
+<rectangle x1="184.775" y1="25.875" x2="207.425" y2="25.925" layer="94"/>
+<rectangle x1="209.075" y1="25.875" x2="242.725" y2="25.925" layer="94"/>
+<rectangle x1="184.725" y1="25.925" x2="207.425" y2="25.975" layer="94"/>
+<rectangle x1="209.125" y1="25.925" x2="242.775" y2="25.975" layer="94"/>
+<rectangle x1="184.675" y1="25.975" x2="207.425" y2="26.025" layer="94"/>
+<rectangle x1="209.125" y1="25.975" x2="242.825" y2="26.025" layer="94"/>
+<rectangle x1="184.625" y1="26.025" x2="207.475" y2="26.075" layer="94"/>
+<rectangle x1="209.125" y1="26.025" x2="242.875" y2="26.075" layer="94"/>
+<rectangle x1="184.625" y1="26.075" x2="207.475" y2="26.125" layer="94"/>
+<rectangle x1="209.175" y1="26.075" x2="242.875" y2="26.125" layer="94"/>
+<rectangle x1="184.575" y1="26.125" x2="207.475" y2="26.175" layer="94"/>
+<rectangle x1="209.175" y1="26.125" x2="242.925" y2="26.175" layer="94"/>
+<rectangle x1="184.575" y1="26.175" x2="207.525" y2="26.225" layer="94"/>
+<rectangle x1="209.225" y1="26.175" x2="228.275" y2="26.225" layer="94"/>
+<rectangle x1="229.625" y1="26.175" x2="236.675" y2="26.225" layer="94"/>
+<rectangle x1="238.025" y1="26.175" x2="242.925" y2="26.225" layer="94"/>
+<rectangle x1="184.525" y1="26.225" x2="207.525" y2="26.275" layer="94"/>
+<rectangle x1="209.225" y1="26.225" x2="227.925" y2="26.275" layer="94"/>
+<rectangle x1="229.975" y1="26.225" x2="236.325" y2="26.275" layer="94"/>
+<rectangle x1="238.375" y1="26.225" x2="242.975" y2="26.275" layer="94"/>
+<rectangle x1="184.475" y1="26.275" x2="188.775" y2="26.325" layer="94"/>
+<rectangle x1="190.475" y1="26.275" x2="194.225" y2="26.325" layer="94"/>
+<rectangle x1="195.875" y1="26.275" x2="197.675" y2="26.325" layer="94"/>
+<rectangle x1="199.275" y1="26.275" x2="202.375" y2="26.325" layer="94"/>
+<rectangle x1="204.025" y1="26.275" x2="207.525" y2="26.325" layer="94"/>
+<rectangle x1="209.225" y1="26.275" x2="212.925" y2="26.325" layer="94"/>
+<rectangle x1="214.625" y1="26.275" x2="221.025" y2="26.325" layer="94"/>
+<rectangle x1="222.725" y1="26.275" x2="227.675" y2="26.325" layer="94"/>
+<rectangle x1="230.275" y1="26.275" x2="236.075" y2="26.325" layer="94"/>
+<rectangle x1="238.625" y1="26.275" x2="243.025" y2="26.325" layer="94"/>
+<rectangle x1="184.475" y1="26.325" x2="188.775" y2="26.375" layer="94"/>
+<rectangle x1="190.475" y1="26.325" x2="194.225" y2="26.375" layer="94"/>
+<rectangle x1="195.875" y1="26.325" x2="197.625" y2="26.375" layer="94"/>
+<rectangle x1="199.325" y1="26.325" x2="202.325" y2="26.375" layer="94"/>
+<rectangle x1="204.025" y1="26.325" x2="207.575" y2="26.375" layer="94"/>
+<rectangle x1="209.275" y1="26.325" x2="212.925" y2="26.375" layer="94"/>
+<rectangle x1="214.625" y1="26.325" x2="220.975" y2="26.375" layer="94"/>
+<rectangle x1="222.725" y1="26.325" x2="227.475" y2="26.375" layer="94"/>
+<rectangle x1="230.475" y1="26.325" x2="235.875" y2="26.375" layer="94"/>
+<rectangle x1="238.825" y1="26.325" x2="243.025" y2="26.375" layer="94"/>
+<rectangle x1="184.425" y1="26.375" x2="188.775" y2="26.425" layer="94"/>
+<rectangle x1="190.475" y1="26.375" x2="194.225" y2="26.425" layer="94"/>
+<rectangle x1="195.875" y1="26.375" x2="197.625" y2="26.425" layer="94"/>
+<rectangle x1="199.325" y1="26.375" x2="202.325" y2="26.425" layer="94"/>
+<rectangle x1="204.025" y1="26.375" x2="207.575" y2="26.425" layer="94"/>
+<rectangle x1="209.275" y1="26.375" x2="212.925" y2="26.425" layer="94"/>
+<rectangle x1="214.625" y1="26.375" x2="220.975" y2="26.425" layer="94"/>
+<rectangle x1="222.725" y1="26.375" x2="227.325" y2="26.425" layer="94"/>
+<rectangle x1="230.625" y1="26.375" x2="235.725" y2="26.425" layer="94"/>
+<rectangle x1="238.975" y1="26.375" x2="243.075" y2="26.425" layer="94"/>
+<rectangle x1="184.425" y1="26.425" x2="188.775" y2="26.475" layer="94"/>
+<rectangle x1="190.475" y1="26.425" x2="194.225" y2="26.475" layer="94"/>
+<rectangle x1="195.875" y1="26.425" x2="197.625" y2="26.475" layer="94"/>
+<rectangle x1="199.325" y1="26.425" x2="202.325" y2="26.475" layer="94"/>
+<rectangle x1="204.025" y1="26.425" x2="207.575" y2="26.475" layer="94"/>
+<rectangle x1="209.275" y1="26.425" x2="212.925" y2="26.475" layer="94"/>
+<rectangle x1="214.625" y1="26.425" x2="220.975" y2="26.475" layer="94"/>
+<rectangle x1="222.725" y1="26.425" x2="227.175" y2="26.475" layer="94"/>
+<rectangle x1="230.825" y1="26.425" x2="235.575" y2="26.475" layer="94"/>
+<rectangle x1="239.125" y1="26.425" x2="243.075" y2="26.475" layer="94"/>
+<rectangle x1="184.425" y1="26.475" x2="188.775" y2="26.525" layer="94"/>
+<rectangle x1="190.475" y1="26.475" x2="194.225" y2="26.525" layer="94"/>
+<rectangle x1="195.875" y1="26.475" x2="197.625" y2="26.525" layer="94"/>
+<rectangle x1="199.325" y1="26.475" x2="202.325" y2="26.525" layer="94"/>
+<rectangle x1="204.025" y1="26.475" x2="207.575" y2="26.525" layer="94"/>
+<rectangle x1="209.325" y1="26.475" x2="212.925" y2="26.525" layer="94"/>
+<rectangle x1="214.625" y1="26.475" x2="220.975" y2="26.525" layer="94"/>
+<rectangle x1="222.725" y1="26.475" x2="227.025" y2="26.525" layer="94"/>
+<rectangle x1="230.975" y1="26.475" x2="235.425" y2="26.525" layer="94"/>
+<rectangle x1="239.275" y1="26.475" x2="243.125" y2="26.525" layer="94"/>
+<rectangle x1="184.375" y1="26.525" x2="188.775" y2="26.575" layer="94"/>
+<rectangle x1="190.475" y1="26.525" x2="194.225" y2="26.575" layer="94"/>
+<rectangle x1="195.875" y1="26.525" x2="197.625" y2="26.575" layer="94"/>
+<rectangle x1="199.325" y1="26.525" x2="202.325" y2="26.575" layer="94"/>
+<rectangle x1="204.025" y1="26.525" x2="207.525" y2="26.575" layer="94"/>
+<rectangle x1="209.325" y1="26.525" x2="212.925" y2="26.575" layer="94"/>
+<rectangle x1="214.625" y1="26.525" x2="220.975" y2="26.575" layer="94"/>
+<rectangle x1="222.725" y1="26.525" x2="226.925" y2="26.575" layer="94"/>
+<rectangle x1="231.075" y1="26.525" x2="235.325" y2="26.575" layer="94"/>
+<rectangle x1="239.425" y1="26.525" x2="243.125" y2="26.575" layer="94"/>
+<rectangle x1="184.375" y1="26.575" x2="188.775" y2="26.625" layer="94"/>
+<rectangle x1="190.475" y1="26.575" x2="194.225" y2="26.625" layer="94"/>
+<rectangle x1="195.875" y1="26.575" x2="197.625" y2="26.625" layer="94"/>
+<rectangle x1="199.325" y1="26.575" x2="202.325" y2="26.625" layer="94"/>
+<rectangle x1="204.025" y1="26.575" x2="207.525" y2="26.625" layer="94"/>
+<rectangle x1="209.375" y1="26.575" x2="212.925" y2="26.625" layer="94"/>
+<rectangle x1="214.625" y1="26.575" x2="220.975" y2="26.625" layer="94"/>
+<rectangle x1="222.725" y1="26.575" x2="226.825" y2="26.625" layer="94"/>
+<rectangle x1="231.225" y1="26.575" x2="235.175" y2="26.625" layer="94"/>
+<rectangle x1="239.525" y1="26.575" x2="243.125" y2="26.625" layer="94"/>
+<rectangle x1="184.325" y1="26.625" x2="188.775" y2="26.675" layer="94"/>
+<rectangle x1="190.475" y1="26.625" x2="194.225" y2="26.675" layer="94"/>
+<rectangle x1="195.875" y1="26.625" x2="197.625" y2="26.675" layer="94"/>
+<rectangle x1="199.325" y1="26.625" x2="202.325" y2="26.675" layer="94"/>
+<rectangle x1="204.025" y1="26.625" x2="207.475" y2="26.675" layer="94"/>
+<rectangle x1="209.375" y1="26.625" x2="212.925" y2="26.675" layer="94"/>
+<rectangle x1="214.625" y1="26.625" x2="220.975" y2="26.675" layer="94"/>
+<rectangle x1="222.725" y1="26.625" x2="226.725" y2="26.675" layer="94"/>
+<rectangle x1="231.325" y1="26.625" x2="235.075" y2="26.675" layer="94"/>
+<rectangle x1="239.625" y1="26.625" x2="243.175" y2="26.675" layer="94"/>
+<rectangle x1="184.325" y1="26.675" x2="188.775" y2="26.725" layer="94"/>
+<rectangle x1="190.475" y1="26.675" x2="194.225" y2="26.725" layer="94"/>
+<rectangle x1="195.875" y1="26.675" x2="197.625" y2="26.725" layer="94"/>
+<rectangle x1="199.325" y1="26.675" x2="202.325" y2="26.725" layer="94"/>
+<rectangle x1="204.025" y1="26.675" x2="207.475" y2="26.725" layer="94"/>
+<rectangle x1="209.375" y1="26.675" x2="212.925" y2="26.725" layer="94"/>
+<rectangle x1="214.625" y1="26.675" x2="220.975" y2="26.725" layer="94"/>
+<rectangle x1="222.725" y1="26.675" x2="226.625" y2="26.725" layer="94"/>
+<rectangle x1="231.425" y1="26.675" x2="234.975" y2="26.725" layer="94"/>
+<rectangle x1="239.725" y1="26.675" x2="243.175" y2="26.725" layer="94"/>
+<rectangle x1="184.325" y1="26.725" x2="188.775" y2="26.775" layer="94"/>
+<rectangle x1="190.475" y1="26.725" x2="194.225" y2="26.775" layer="94"/>
+<rectangle x1="195.875" y1="26.725" x2="197.625" y2="26.775" layer="94"/>
+<rectangle x1="199.325" y1="26.725" x2="202.325" y2="26.775" layer="94"/>
+<rectangle x1="204.025" y1="26.725" x2="207.475" y2="26.775" layer="94"/>
+<rectangle x1="209.425" y1="26.725" x2="212.925" y2="26.775" layer="94"/>
+<rectangle x1="214.625" y1="26.725" x2="220.975" y2="26.775" layer="94"/>
+<rectangle x1="222.725" y1="26.725" x2="226.525" y2="26.775" layer="94"/>
+<rectangle x1="231.525" y1="26.725" x2="234.925" y2="26.775" layer="94"/>
+<rectangle x1="239.825" y1="26.725" x2="243.225" y2="26.775" layer="94"/>
+<rectangle x1="184.275" y1="26.775" x2="188.775" y2="26.825" layer="94"/>
+<rectangle x1="190.475" y1="26.775" x2="194.225" y2="26.825" layer="94"/>
+<rectangle x1="195.875" y1="26.775" x2="197.625" y2="26.825" layer="94"/>
+<rectangle x1="199.325" y1="26.775" x2="202.325" y2="26.825" layer="94"/>
+<rectangle x1="204.025" y1="26.775" x2="207.425" y2="26.825" layer="94"/>
+<rectangle x1="209.425" y1="26.775" x2="212.925" y2="26.825" layer="94"/>
+<rectangle x1="214.625" y1="26.775" x2="220.975" y2="26.825" layer="94"/>
+<rectangle x1="222.725" y1="26.775" x2="226.475" y2="26.825" layer="94"/>
+<rectangle x1="231.575" y1="26.775" x2="234.825" y2="26.825" layer="94"/>
+<rectangle x1="239.875" y1="26.775" x2="243.225" y2="26.825" layer="94"/>
+<rectangle x1="184.275" y1="26.825" x2="188.775" y2="26.875" layer="94"/>
+<rectangle x1="190.475" y1="26.825" x2="194.225" y2="26.875" layer="94"/>
+<rectangle x1="195.875" y1="26.825" x2="197.625" y2="26.875" layer="94"/>
+<rectangle x1="199.325" y1="26.825" x2="202.325" y2="26.875" layer="94"/>
+<rectangle x1="204.025" y1="26.825" x2="207.425" y2="26.875" layer="94"/>
+<rectangle x1="209.425" y1="26.825" x2="212.925" y2="26.875" layer="94"/>
+<rectangle x1="214.625" y1="26.825" x2="220.975" y2="26.875" layer="94"/>
+<rectangle x1="222.725" y1="26.825" x2="226.375" y2="26.875" layer="94"/>
+<rectangle x1="231.625" y1="26.825" x2="234.725" y2="26.875" layer="94"/>
+<rectangle x1="239.975" y1="26.825" x2="243.225" y2="26.875" layer="94"/>
+<rectangle x1="184.275" y1="26.875" x2="188.775" y2="26.925" layer="94"/>
+<rectangle x1="190.475" y1="26.875" x2="194.225" y2="26.925" layer="94"/>
+<rectangle x1="195.875" y1="26.875" x2="197.625" y2="26.925" layer="94"/>
+<rectangle x1="199.325" y1="26.875" x2="202.325" y2="26.925" layer="94"/>
+<rectangle x1="204.025" y1="26.875" x2="207.375" y2="26.925" layer="94"/>
+<rectangle x1="209.475" y1="26.875" x2="212.925" y2="26.925" layer="94"/>
+<rectangle x1="214.625" y1="26.875" x2="220.975" y2="26.925" layer="94"/>
+<rectangle x1="222.725" y1="26.875" x2="226.275" y2="26.925" layer="94"/>
+<rectangle x1="231.575" y1="26.875" x2="234.675" y2="26.925" layer="94"/>
+<rectangle x1="240.075" y1="26.875" x2="243.275" y2="26.925" layer="94"/>
+<rectangle x1="184.225" y1="26.925" x2="188.775" y2="26.975" layer="94"/>
+<rectangle x1="190.475" y1="26.925" x2="194.225" y2="26.975" layer="94"/>
+<rectangle x1="195.875" y1="26.925" x2="197.625" y2="26.975" layer="94"/>
+<rectangle x1="199.325" y1="26.925" x2="202.325" y2="26.975" layer="94"/>
+<rectangle x1="204.025" y1="26.925" x2="207.375" y2="26.975" layer="94"/>
+<rectangle x1="209.475" y1="26.925" x2="212.925" y2="26.975" layer="94"/>
+<rectangle x1="214.625" y1="26.925" x2="220.975" y2="26.975" layer="94"/>
+<rectangle x1="222.725" y1="26.925" x2="226.225" y2="26.975" layer="94"/>
+<rectangle x1="231.575" y1="26.925" x2="234.575" y2="26.975" layer="94"/>
+<rectangle x1="240.125" y1="26.925" x2="243.275" y2="26.975" layer="94"/>
+<rectangle x1="184.225" y1="26.975" x2="188.775" y2="27.025" layer="94"/>
+<rectangle x1="190.475" y1="26.975" x2="194.225" y2="27.025" layer="94"/>
+<rectangle x1="195.875" y1="26.975" x2="197.625" y2="27.025" layer="94"/>
+<rectangle x1="199.325" y1="26.975" x2="202.325" y2="27.025" layer="94"/>
+<rectangle x1="204.025" y1="26.975" x2="207.375" y2="27.025" layer="94"/>
+<rectangle x1="209.525" y1="26.975" x2="212.925" y2="27.025" layer="94"/>
+<rectangle x1="214.625" y1="26.975" x2="220.975" y2="27.025" layer="94"/>
+<rectangle x1="222.725" y1="26.975" x2="226.175" y2="27.025" layer="94"/>
+<rectangle x1="231.575" y1="26.975" x2="234.525" y2="27.025" layer="94"/>
+<rectangle x1="240.175" y1="26.975" x2="243.275" y2="27.025" layer="94"/>
+<rectangle x1="184.225" y1="27.025" x2="188.775" y2="27.075" layer="94"/>
+<rectangle x1="190.475" y1="27.025" x2="194.225" y2="27.075" layer="94"/>
+<rectangle x1="195.875" y1="27.025" x2="197.625" y2="27.075" layer="94"/>
+<rectangle x1="199.325" y1="27.025" x2="202.325" y2="27.075" layer="94"/>
+<rectangle x1="204.025" y1="27.025" x2="207.325" y2="27.075" layer="94"/>
+<rectangle x1="209.525" y1="27.025" x2="212.925" y2="27.075" layer="94"/>
+<rectangle x1="214.625" y1="27.025" x2="220.975" y2="27.075" layer="94"/>
+<rectangle x1="222.725" y1="27.025" x2="226.075" y2="27.075" layer="94"/>
+<rectangle x1="231.575" y1="27.025" x2="234.475" y2="27.075" layer="94"/>
+<rectangle x1="240.275" y1="27.025" x2="243.275" y2="27.075" layer="94"/>
+<rectangle x1="184.225" y1="27.075" x2="188.775" y2="27.125" layer="94"/>
+<rectangle x1="190.475" y1="27.075" x2="194.225" y2="27.125" layer="94"/>
+<rectangle x1="195.875" y1="27.075" x2="197.625" y2="27.125" layer="94"/>
+<rectangle x1="199.325" y1="27.075" x2="202.325" y2="27.125" layer="94"/>
+<rectangle x1="204.025" y1="27.075" x2="207.325" y2="27.125" layer="94"/>
+<rectangle x1="209.525" y1="27.075" x2="212.925" y2="27.125" layer="94"/>
+<rectangle x1="214.625" y1="27.075" x2="220.975" y2="27.125" layer="94"/>
+<rectangle x1="222.725" y1="27.075" x2="226.025" y2="27.125" layer="94"/>
+<rectangle x1="231.575" y1="27.075" x2="234.375" y2="27.125" layer="94"/>
+<rectangle x1="240.325" y1="27.075" x2="243.325" y2="27.125" layer="94"/>
+<rectangle x1="184.175" y1="27.125" x2="188.775" y2="27.175" layer="94"/>
+<rectangle x1="190.475" y1="27.125" x2="194.225" y2="27.175" layer="94"/>
+<rectangle x1="195.875" y1="27.125" x2="197.625" y2="27.175" layer="94"/>
+<rectangle x1="199.325" y1="27.125" x2="202.325" y2="27.175" layer="94"/>
+<rectangle x1="204.025" y1="27.125" x2="207.275" y2="27.175" layer="94"/>
+<rectangle x1="209.575" y1="27.125" x2="212.925" y2="27.175" layer="94"/>
+<rectangle x1="214.625" y1="27.125" x2="220.975" y2="27.175" layer="94"/>
+<rectangle x1="222.725" y1="27.125" x2="225.975" y2="27.175" layer="94"/>
+<rectangle x1="231.575" y1="27.125" x2="234.325" y2="27.175" layer="94"/>
+<rectangle x1="240.375" y1="27.125" x2="243.325" y2="27.175" layer="94"/>
+<rectangle x1="184.175" y1="27.175" x2="188.775" y2="27.225" layer="94"/>
+<rectangle x1="190.475" y1="27.175" x2="194.225" y2="27.225" layer="94"/>
+<rectangle x1="195.875" y1="27.175" x2="197.625" y2="27.225" layer="94"/>
+<rectangle x1="199.325" y1="27.175" x2="202.325" y2="27.225" layer="94"/>
+<rectangle x1="204.025" y1="27.175" x2="207.275" y2="27.225" layer="94"/>
+<rectangle x1="209.575" y1="27.175" x2="212.925" y2="27.225" layer="94"/>
+<rectangle x1="214.625" y1="27.175" x2="220.975" y2="27.225" layer="94"/>
+<rectangle x1="222.725" y1="27.175" x2="225.925" y2="27.225" layer="94"/>
+<rectangle x1="231.525" y1="27.175" x2="234.275" y2="27.225" layer="94"/>
+<rectangle x1="240.425" y1="27.175" x2="243.325" y2="27.225" layer="94"/>
+<rectangle x1="184.175" y1="27.225" x2="188.775" y2="27.275" layer="94"/>
+<rectangle x1="190.475" y1="27.225" x2="194.225" y2="27.275" layer="94"/>
+<rectangle x1="195.875" y1="27.225" x2="197.625" y2="27.275" layer="94"/>
+<rectangle x1="199.325" y1="27.225" x2="202.325" y2="27.275" layer="94"/>
+<rectangle x1="204.025" y1="27.225" x2="207.275" y2="27.275" layer="94"/>
+<rectangle x1="209.625" y1="27.225" x2="212.925" y2="27.275" layer="94"/>
+<rectangle x1="214.625" y1="27.225" x2="220.975" y2="27.275" layer="94"/>
+<rectangle x1="222.725" y1="27.225" x2="225.875" y2="27.275" layer="94"/>
+<rectangle x1="231.525" y1="27.225" x2="234.225" y2="27.275" layer="94"/>
+<rectangle x1="240.475" y1="27.225" x2="243.325" y2="27.275" layer="94"/>
+<rectangle x1="184.175" y1="27.275" x2="188.775" y2="27.325" layer="94"/>
+<rectangle x1="190.475" y1="27.275" x2="194.225" y2="27.325" layer="94"/>
+<rectangle x1="195.875" y1="27.275" x2="197.625" y2="27.325" layer="94"/>
+<rectangle x1="199.325" y1="27.275" x2="202.325" y2="27.325" layer="94"/>
+<rectangle x1="204.025" y1="27.275" x2="207.225" y2="27.325" layer="94"/>
+<rectangle x1="209.625" y1="27.275" x2="212.925" y2="27.325" layer="94"/>
+<rectangle x1="214.625" y1="27.275" x2="220.975" y2="27.325" layer="94"/>
+<rectangle x1="222.725" y1="27.275" x2="225.825" y2="27.325" layer="94"/>
+<rectangle x1="231.525" y1="27.275" x2="234.175" y2="27.325" layer="94"/>
+<rectangle x1="240.525" y1="27.275" x2="243.325" y2="27.325" layer="94"/>
+<rectangle x1="184.175" y1="27.325" x2="188.775" y2="27.375" layer="94"/>
+<rectangle x1="190.475" y1="27.325" x2="194.225" y2="27.375" layer="94"/>
+<rectangle x1="195.875" y1="27.325" x2="197.625" y2="27.375" layer="94"/>
+<rectangle x1="199.325" y1="27.325" x2="202.325" y2="27.375" layer="94"/>
+<rectangle x1="204.025" y1="27.325" x2="207.225" y2="27.375" layer="94"/>
+<rectangle x1="209.625" y1="27.325" x2="212.925" y2="27.375" layer="94"/>
+<rectangle x1="214.625" y1="27.325" x2="220.975" y2="27.375" layer="94"/>
+<rectangle x1="222.725" y1="27.325" x2="225.775" y2="27.375" layer="94"/>
+<rectangle x1="231.525" y1="27.325" x2="234.125" y2="27.375" layer="94"/>
+<rectangle x1="240.575" y1="27.325" x2="243.325" y2="27.375" layer="94"/>
+<rectangle x1="184.175" y1="27.375" x2="188.775" y2="27.425" layer="94"/>
+<rectangle x1="190.475" y1="27.375" x2="194.225" y2="27.425" layer="94"/>
+<rectangle x1="195.875" y1="27.375" x2="197.625" y2="27.425" layer="94"/>
+<rectangle x1="199.325" y1="27.375" x2="202.325" y2="27.425" layer="94"/>
+<rectangle x1="204.025" y1="27.375" x2="207.175" y2="27.425" layer="94"/>
+<rectangle x1="209.675" y1="27.375" x2="212.925" y2="27.425" layer="94"/>
+<rectangle x1="214.625" y1="27.375" x2="220.975" y2="27.425" layer="94"/>
+<rectangle x1="222.725" y1="27.375" x2="225.725" y2="27.425" layer="94"/>
+<rectangle x1="231.525" y1="27.375" x2="234.075" y2="27.425" layer="94"/>
+<rectangle x1="240.675" y1="27.375" x2="243.375" y2="27.425" layer="94"/>
+<rectangle x1="184.125" y1="27.425" x2="188.775" y2="27.475" layer="94"/>
+<rectangle x1="190.475" y1="27.425" x2="194.225" y2="27.475" layer="94"/>
+<rectangle x1="195.875" y1="27.425" x2="197.625" y2="27.475" layer="94"/>
+<rectangle x1="199.325" y1="27.425" x2="202.325" y2="27.475" layer="94"/>
+<rectangle x1="204.025" y1="27.425" x2="207.175" y2="27.475" layer="94"/>
+<rectangle x1="209.675" y1="27.425" x2="212.925" y2="27.475" layer="94"/>
+<rectangle x1="214.625" y1="27.425" x2="220.975" y2="27.475" layer="94"/>
+<rectangle x1="222.725" y1="27.425" x2="225.675" y2="27.475" layer="94"/>
+<rectangle x1="231.525" y1="27.425" x2="234.025" y2="27.475" layer="94"/>
+<rectangle x1="240.725" y1="27.425" x2="243.375" y2="27.475" layer="94"/>
+<rectangle x1="184.125" y1="27.475" x2="188.775" y2="27.525" layer="94"/>
+<rectangle x1="190.475" y1="27.475" x2="194.225" y2="27.525" layer="94"/>
+<rectangle x1="195.875" y1="27.475" x2="197.625" y2="27.525" layer="94"/>
+<rectangle x1="199.325" y1="27.475" x2="202.325" y2="27.525" layer="94"/>
+<rectangle x1="204.025" y1="27.475" x2="207.175" y2="27.525" layer="94"/>
+<rectangle x1="209.675" y1="27.475" x2="212.925" y2="27.525" layer="94"/>
+<rectangle x1="214.625" y1="27.475" x2="220.975" y2="27.525" layer="94"/>
+<rectangle x1="222.725" y1="27.475" x2="225.625" y2="27.525" layer="94"/>
+<rectangle x1="231.475" y1="27.475" x2="233.975" y2="27.525" layer="94"/>
+<rectangle x1="240.725" y1="27.475" x2="243.375" y2="27.525" layer="94"/>
+<rectangle x1="184.125" y1="27.525" x2="188.775" y2="27.575" layer="94"/>
+<rectangle x1="190.475" y1="27.525" x2="194.225" y2="27.575" layer="94"/>
+<rectangle x1="195.875" y1="27.525" x2="197.625" y2="27.575" layer="94"/>
+<rectangle x1="199.325" y1="27.525" x2="202.325" y2="27.575" layer="94"/>
+<rectangle x1="204.025" y1="27.525" x2="207.125" y2="27.575" layer="94"/>
+<rectangle x1="209.725" y1="27.525" x2="212.925" y2="27.575" layer="94"/>
+<rectangle x1="214.625" y1="27.525" x2="220.975" y2="27.575" layer="94"/>
+<rectangle x1="222.725" y1="27.525" x2="225.575" y2="27.575" layer="94"/>
+<rectangle x1="231.475" y1="27.525" x2="233.925" y2="27.575" layer="94"/>
+<rectangle x1="240.775" y1="27.525" x2="243.375" y2="27.575" layer="94"/>
+<rectangle x1="184.125" y1="27.575" x2="188.775" y2="27.625" layer="94"/>
+<rectangle x1="190.475" y1="27.575" x2="194.225" y2="27.625" layer="94"/>
+<rectangle x1="195.875" y1="27.575" x2="197.625" y2="27.625" layer="94"/>
+<rectangle x1="199.325" y1="27.575" x2="202.325" y2="27.625" layer="94"/>
+<rectangle x1="204.025" y1="27.575" x2="207.125" y2="27.625" layer="94"/>
+<rectangle x1="209.725" y1="27.575" x2="212.925" y2="27.625" layer="94"/>
+<rectangle x1="214.625" y1="27.575" x2="220.975" y2="27.625" layer="94"/>
+<rectangle x1="222.725" y1="27.575" x2="225.525" y2="27.625" layer="94"/>
+<rectangle x1="228.625" y1="27.575" x2="229.475" y2="27.625" layer="94"/>
+<rectangle x1="231.475" y1="27.575" x2="233.875" y2="27.625" layer="94"/>
+<rectangle x1="236.975" y1="27.575" x2="237.725" y2="27.625" layer="94"/>
+<rectangle x1="240.825" y1="27.575" x2="243.375" y2="27.625" layer="94"/>
+<rectangle x1="184.125" y1="27.625" x2="188.775" y2="27.675" layer="94"/>
+<rectangle x1="190.475" y1="27.625" x2="194.225" y2="27.675" layer="94"/>
+<rectangle x1="195.875" y1="27.625" x2="197.625" y2="27.675" layer="94"/>
+<rectangle x1="199.325" y1="27.625" x2="202.325" y2="27.675" layer="94"/>
+<rectangle x1="204.025" y1="27.625" x2="207.075" y2="27.675" layer="94"/>
+<rectangle x1="209.775" y1="27.625" x2="212.925" y2="27.675" layer="94"/>
+<rectangle x1="214.625" y1="27.625" x2="220.975" y2="27.675" layer="94"/>
+<rectangle x1="222.725" y1="27.625" x2="225.475" y2="27.675" layer="94"/>
+<rectangle x1="228.325" y1="27.625" x2="229.825" y2="27.675" layer="94"/>
+<rectangle x1="231.475" y1="27.625" x2="233.825" y2="27.675" layer="94"/>
+<rectangle x1="236.675" y1="27.625" x2="238.075" y2="27.675" layer="94"/>
+<rectangle x1="240.875" y1="27.625" x2="243.375" y2="27.675" layer="94"/>
+<rectangle x1="184.125" y1="27.675" x2="188.775" y2="27.725" layer="94"/>
+<rectangle x1="190.475" y1="27.675" x2="194.225" y2="27.725" layer="94"/>
+<rectangle x1="195.875" y1="27.675" x2="197.625" y2="27.725" layer="94"/>
+<rectangle x1="199.325" y1="27.675" x2="202.325" y2="27.725" layer="94"/>
+<rectangle x1="204.025" y1="27.675" x2="207.075" y2="27.725" layer="94"/>
+<rectangle x1="209.775" y1="27.675" x2="212.925" y2="27.725" layer="94"/>
+<rectangle x1="214.625" y1="27.675" x2="220.975" y2="27.725" layer="94"/>
+<rectangle x1="222.725" y1="27.675" x2="225.425" y2="27.725" layer="94"/>
+<rectangle x1="228.125" y1="27.675" x2="230.125" y2="27.725" layer="94"/>
+<rectangle x1="231.475" y1="27.675" x2="233.775" y2="27.725" layer="94"/>
+<rectangle x1="236.475" y1="27.675" x2="238.275" y2="27.725" layer="94"/>
+<rectangle x1="240.925" y1="27.675" x2="243.375" y2="27.725" layer="94"/>
+<rectangle x1="184.125" y1="27.725" x2="188.775" y2="27.775" layer="94"/>
+<rectangle x1="190.475" y1="27.725" x2="194.225" y2="27.775" layer="94"/>
+<rectangle x1="195.875" y1="27.725" x2="197.625" y2="27.775" layer="94"/>
+<rectangle x1="199.325" y1="27.725" x2="202.325" y2="27.775" layer="94"/>
+<rectangle x1="204.025" y1="27.725" x2="207.025" y2="27.775" layer="94"/>
+<rectangle x1="209.775" y1="27.725" x2="212.925" y2="27.775" layer="94"/>
+<rectangle x1="214.625" y1="27.725" x2="220.975" y2="27.775" layer="94"/>
+<rectangle x1="222.725" y1="27.725" x2="225.425" y2="27.775" layer="94"/>
+<rectangle x1="227.975" y1="27.725" x2="230.325" y2="27.775" layer="94"/>
+<rectangle x1="231.475" y1="27.725" x2="233.725" y2="27.775" layer="94"/>
+<rectangle x1="236.325" y1="27.725" x2="238.425" y2="27.775" layer="94"/>
+<rectangle x1="240.975" y1="27.725" x2="243.375" y2="27.775" layer="94"/>
+<rectangle x1="184.125" y1="27.775" x2="188.775" y2="27.825" layer="94"/>
+<rectangle x1="190.475" y1="27.775" x2="194.225" y2="27.825" layer="94"/>
+<rectangle x1="195.875" y1="27.775" x2="197.625" y2="27.825" layer="94"/>
+<rectangle x1="199.325" y1="27.775" x2="202.325" y2="27.825" layer="94"/>
+<rectangle x1="204.025" y1="27.775" x2="207.025" y2="27.825" layer="94"/>
+<rectangle x1="209.825" y1="27.775" x2="212.925" y2="27.825" layer="94"/>
+<rectangle x1="214.625" y1="27.775" x2="220.975" y2="27.825" layer="94"/>
+<rectangle x1="222.725" y1="27.775" x2="225.375" y2="27.825" layer="94"/>
+<rectangle x1="227.825" y1="27.775" x2="230.475" y2="27.825" layer="94"/>
+<rectangle x1="231.425" y1="27.775" x2="233.725" y2="27.825" layer="94"/>
+<rectangle x1="236.175" y1="27.775" x2="238.575" y2="27.825" layer="94"/>
+<rectangle x1="241.025" y1="27.775" x2="243.375" y2="27.825" layer="94"/>
+<rectangle x1="184.125" y1="27.825" x2="188.775" y2="27.875" layer="94"/>
+<rectangle x1="190.475" y1="27.825" x2="194.225" y2="27.875" layer="94"/>
+<rectangle x1="195.875" y1="27.825" x2="197.625" y2="27.875" layer="94"/>
+<rectangle x1="199.325" y1="27.825" x2="202.325" y2="27.875" layer="94"/>
+<rectangle x1="204.025" y1="27.825" x2="207.025" y2="27.875" layer="94"/>
+<rectangle x1="209.825" y1="27.825" x2="212.925" y2="27.875" layer="94"/>
+<rectangle x1="214.625" y1="27.825" x2="220.975" y2="27.875" layer="94"/>
+<rectangle x1="222.725" y1="27.825" x2="225.325" y2="27.875" layer="94"/>
+<rectangle x1="227.725" y1="27.825" x2="230.625" y2="27.875" layer="94"/>
+<rectangle x1="231.425" y1="27.825" x2="233.675" y2="27.875" layer="94"/>
+<rectangle x1="236.075" y1="27.825" x2="238.675" y2="27.875" layer="94"/>
+<rectangle x1="241.025" y1="27.825" x2="243.375" y2="27.875" layer="94"/>
+<rectangle x1="184.125" y1="27.875" x2="188.775" y2="27.925" layer="94"/>
+<rectangle x1="190.475" y1="27.875" x2="194.225" y2="27.925" layer="94"/>
+<rectangle x1="195.875" y1="27.875" x2="197.625" y2="27.925" layer="94"/>
+<rectangle x1="199.325" y1="27.875" x2="202.325" y2="27.925" layer="94"/>
+<rectangle x1="204.025" y1="27.875" x2="206.975" y2="27.925" layer="94"/>
+<rectangle x1="209.825" y1="27.875" x2="212.925" y2="27.925" layer="94"/>
+<rectangle x1="214.625" y1="27.875" x2="220.975" y2="27.925" layer="94"/>
+<rectangle x1="222.725" y1="27.875" x2="225.275" y2="27.925" layer="94"/>
+<rectangle x1="227.625" y1="27.875" x2="230.775" y2="27.925" layer="94"/>
+<rectangle x1="231.425" y1="27.875" x2="233.625" y2="27.925" layer="94"/>
+<rectangle x1="235.975" y1="27.875" x2="238.775" y2="27.925" layer="94"/>
+<rectangle x1="241.075" y1="27.875" x2="243.375" y2="27.925" layer="94"/>
+<rectangle x1="184.125" y1="27.925" x2="188.775" y2="27.975" layer="94"/>
+<rectangle x1="190.475" y1="27.925" x2="194.225" y2="27.975" layer="94"/>
+<rectangle x1="195.875" y1="27.925" x2="197.625" y2="27.975" layer="94"/>
+<rectangle x1="199.325" y1="27.925" x2="202.325" y2="27.975" layer="94"/>
+<rectangle x1="204.025" y1="27.925" x2="206.975" y2="27.975" layer="94"/>
+<rectangle x1="209.875" y1="27.925" x2="212.925" y2="27.975" layer="94"/>
+<rectangle x1="214.625" y1="27.925" x2="220.975" y2="27.975" layer="94"/>
+<rectangle x1="222.725" y1="27.925" x2="225.275" y2="27.975" layer="94"/>
+<rectangle x1="227.575" y1="27.925" x2="230.875" y2="27.975" layer="94"/>
+<rectangle x1="231.425" y1="27.925" x2="233.625" y2="27.975" layer="94"/>
+<rectangle x1="235.875" y1="27.925" x2="238.825" y2="27.975" layer="94"/>
+<rectangle x1="241.125" y1="27.925" x2="243.375" y2="27.975" layer="94"/>
+<rectangle x1="184.125" y1="27.975" x2="188.775" y2="28.025" layer="94"/>
+<rectangle x1="190.475" y1="27.975" x2="194.225" y2="28.025" layer="94"/>
+<rectangle x1="195.875" y1="27.975" x2="197.625" y2="28.025" layer="94"/>
+<rectangle x1="199.325" y1="27.975" x2="202.325" y2="28.025" layer="94"/>
+<rectangle x1="204.025" y1="27.975" x2="206.925" y2="28.025" layer="94"/>
+<rectangle x1="209.875" y1="27.975" x2="212.925" y2="28.025" layer="94"/>
+<rectangle x1="214.625" y1="27.975" x2="220.975" y2="28.025" layer="94"/>
+<rectangle x1="222.725" y1="27.975" x2="225.225" y2="28.025" layer="94"/>
+<rectangle x1="227.475" y1="27.975" x2="231.025" y2="28.025" layer="94"/>
+<rectangle x1="231.425" y1="27.975" x2="233.575" y2="28.025" layer="94"/>
+<rectangle x1="235.825" y1="27.975" x2="238.925" y2="28.025" layer="94"/>
+<rectangle x1="241.125" y1="27.975" x2="243.375" y2="28.025" layer="94"/>
+<rectangle x1="184.125" y1="28.025" x2="188.775" y2="28.075" layer="94"/>
+<rectangle x1="190.475" y1="28.025" x2="194.225" y2="28.075" layer="94"/>
+<rectangle x1="195.875" y1="28.025" x2="197.625" y2="28.075" layer="94"/>
+<rectangle x1="199.325" y1="28.025" x2="202.325" y2="28.075" layer="94"/>
+<rectangle x1="204.025" y1="28.025" x2="206.925" y2="28.075" layer="94"/>
+<rectangle x1="209.925" y1="28.025" x2="212.925" y2="28.075" layer="94"/>
+<rectangle x1="214.625" y1="28.025" x2="220.975" y2="28.075" layer="94"/>
+<rectangle x1="222.725" y1="28.025" x2="225.175" y2="28.075" layer="94"/>
+<rectangle x1="227.425" y1="28.025" x2="231.125" y2="28.075" layer="94"/>
+<rectangle x1="231.425" y1="28.025" x2="233.525" y2="28.075" layer="94"/>
+<rectangle x1="235.725" y1="28.025" x2="238.975" y2="28.075" layer="94"/>
+<rectangle x1="241.175" y1="28.025" x2="243.375" y2="28.075" layer="94"/>
+<rectangle x1="184.125" y1="28.075" x2="188.775" y2="28.125" layer="94"/>
+<rectangle x1="190.475" y1="28.075" x2="194.225" y2="28.125" layer="94"/>
+<rectangle x1="195.875" y1="28.075" x2="197.625" y2="28.125" layer="94"/>
+<rectangle x1="199.325" y1="28.075" x2="202.325" y2="28.125" layer="94"/>
+<rectangle x1="204.025" y1="28.075" x2="206.925" y2="28.125" layer="94"/>
+<rectangle x1="209.925" y1="28.075" x2="212.925" y2="28.125" layer="94"/>
+<rectangle x1="214.625" y1="28.075" x2="220.975" y2="28.125" layer="94"/>
+<rectangle x1="222.725" y1="28.075" x2="225.175" y2="28.125" layer="94"/>
+<rectangle x1="227.325" y1="28.075" x2="231.225" y2="28.125" layer="94"/>
+<rectangle x1="231.375" y1="28.075" x2="233.525" y2="28.125" layer="94"/>
+<rectangle x1="235.675" y1="28.075" x2="239.075" y2="28.125" layer="94"/>
+<rectangle x1="241.225" y1="28.075" x2="243.375" y2="28.125" layer="94"/>
+<rectangle x1="184.125" y1="28.125" x2="188.775" y2="28.175" layer="94"/>
+<rectangle x1="190.475" y1="28.125" x2="194.225" y2="28.175" layer="94"/>
+<rectangle x1="195.875" y1="28.125" x2="197.625" y2="28.175" layer="94"/>
+<rectangle x1="199.325" y1="28.125" x2="202.325" y2="28.175" layer="94"/>
+<rectangle x1="204.025" y1="28.125" x2="206.875" y2="28.175" layer="94"/>
+<rectangle x1="209.925" y1="28.125" x2="212.925" y2="28.175" layer="94"/>
+<rectangle x1="214.625" y1="28.125" x2="220.975" y2="28.175" layer="94"/>
+<rectangle x1="222.725" y1="28.125" x2="225.125" y2="28.175" layer="94"/>
+<rectangle x1="227.275" y1="28.125" x2="233.475" y2="28.175" layer="94"/>
+<rectangle x1="235.625" y1="28.125" x2="239.125" y2="28.175" layer="94"/>
+<rectangle x1="241.225" y1="28.125" x2="243.375" y2="28.175" layer="94"/>
+<rectangle x1="184.125" y1="28.175" x2="188.775" y2="28.225" layer="94"/>
+<rectangle x1="190.475" y1="28.175" x2="194.225" y2="28.225" layer="94"/>
+<rectangle x1="195.875" y1="28.175" x2="197.625" y2="28.225" layer="94"/>
+<rectangle x1="199.325" y1="28.175" x2="202.325" y2="28.225" layer="94"/>
+<rectangle x1="204.025" y1="28.175" x2="206.875" y2="28.225" layer="94"/>
+<rectangle x1="209.975" y1="28.175" x2="212.925" y2="28.225" layer="94"/>
+<rectangle x1="214.625" y1="28.175" x2="220.975" y2="28.225" layer="94"/>
+<rectangle x1="222.725" y1="28.175" x2="225.125" y2="28.225" layer="94"/>
+<rectangle x1="227.225" y1="28.175" x2="233.425" y2="28.225" layer="94"/>
+<rectangle x1="235.575" y1="28.175" x2="239.175" y2="28.225" layer="94"/>
+<rectangle x1="241.275" y1="28.175" x2="243.375" y2="28.225" layer="94"/>
+<rectangle x1="184.125" y1="28.225" x2="188.775" y2="28.275" layer="94"/>
+<rectangle x1="190.475" y1="28.225" x2="194.225" y2="28.275" layer="94"/>
+<rectangle x1="195.875" y1="28.225" x2="197.625" y2="28.275" layer="94"/>
+<rectangle x1="199.325" y1="28.225" x2="202.325" y2="28.275" layer="94"/>
+<rectangle x1="204.025" y1="28.225" x2="206.825" y2="28.275" layer="94"/>
+<rectangle x1="209.975" y1="28.225" x2="212.925" y2="28.275" layer="94"/>
+<rectangle x1="214.625" y1="28.225" x2="220.975" y2="28.275" layer="94"/>
+<rectangle x1="222.725" y1="28.225" x2="225.075" y2="28.275" layer="94"/>
+<rectangle x1="227.175" y1="28.225" x2="233.425" y2="28.275" layer="94"/>
+<rectangle x1="235.525" y1="28.225" x2="239.225" y2="28.275" layer="94"/>
+<rectangle x1="241.275" y1="28.225" x2="243.375" y2="28.275" layer="94"/>
+<rectangle x1="184.125" y1="28.275" x2="188.775" y2="28.325" layer="94"/>
+<rectangle x1="190.475" y1="28.275" x2="194.225" y2="28.325" layer="94"/>
+<rectangle x1="195.875" y1="28.275" x2="197.625" y2="28.325" layer="94"/>
+<rectangle x1="199.325" y1="28.275" x2="202.325" y2="28.325" layer="94"/>
+<rectangle x1="204.025" y1="28.275" x2="206.825" y2="28.325" layer="94"/>
+<rectangle x1="208.375" y1="28.275" x2="208.425" y2="28.325" layer="94"/>
+<rectangle x1="209.975" y1="28.275" x2="212.925" y2="28.325" layer="94"/>
+<rectangle x1="214.625" y1="28.275" x2="220.975" y2="28.325" layer="94"/>
+<rectangle x1="222.725" y1="28.275" x2="225.075" y2="28.325" layer="94"/>
+<rectangle x1="227.125" y1="28.275" x2="233.375" y2="28.325" layer="94"/>
+<rectangle x1="235.475" y1="28.275" x2="239.275" y2="28.325" layer="94"/>
+<rectangle x1="241.325" y1="28.275" x2="243.375" y2="28.325" layer="94"/>
+<rectangle x1="184.125" y1="28.325" x2="188.775" y2="28.375" layer="94"/>
+<rectangle x1="190.475" y1="28.325" x2="194.225" y2="28.375" layer="94"/>
+<rectangle x1="195.875" y1="28.325" x2="197.625" y2="28.375" layer="94"/>
+<rectangle x1="199.325" y1="28.325" x2="202.325" y2="28.375" layer="94"/>
+<rectangle x1="204.025" y1="28.325" x2="206.825" y2="28.375" layer="94"/>
+<rectangle x1="208.375" y1="28.325" x2="208.425" y2="28.375" layer="94"/>
+<rectangle x1="210.025" y1="28.325" x2="212.925" y2="28.375" layer="94"/>
+<rectangle x1="214.625" y1="28.325" x2="220.975" y2="28.375" layer="94"/>
+<rectangle x1="222.725" y1="28.325" x2="225.025" y2="28.375" layer="94"/>
+<rectangle x1="227.075" y1="28.325" x2="233.375" y2="28.375" layer="94"/>
+<rectangle x1="235.425" y1="28.325" x2="239.325" y2="28.375" layer="94"/>
+<rectangle x1="241.325" y1="28.325" x2="243.375" y2="28.375" layer="94"/>
+<rectangle x1="184.125" y1="28.375" x2="188.775" y2="28.425" layer="94"/>
+<rectangle x1="190.475" y1="28.375" x2="194.225" y2="28.425" layer="94"/>
+<rectangle x1="195.875" y1="28.375" x2="197.625" y2="28.425" layer="94"/>
+<rectangle x1="199.325" y1="28.375" x2="202.325" y2="28.425" layer="94"/>
+<rectangle x1="204.025" y1="28.375" x2="206.775" y2="28.425" layer="94"/>
+<rectangle x1="208.325" y1="28.375" x2="208.475" y2="28.425" layer="94"/>
+<rectangle x1="210.025" y1="28.375" x2="212.925" y2="28.425" layer="94"/>
+<rectangle x1="214.625" y1="28.375" x2="220.975" y2="28.425" layer="94"/>
+<rectangle x1="222.725" y1="28.375" x2="224.975" y2="28.425" layer="94"/>
+<rectangle x1="227.025" y1="28.375" x2="233.325" y2="28.425" layer="94"/>
+<rectangle x1="235.375" y1="28.375" x2="239.375" y2="28.425" layer="94"/>
+<rectangle x1="241.375" y1="28.375" x2="243.375" y2="28.425" layer="94"/>
+<rectangle x1="184.125" y1="28.425" x2="188.775" y2="28.475" layer="94"/>
+<rectangle x1="190.475" y1="28.425" x2="194.225" y2="28.475" layer="94"/>
+<rectangle x1="195.875" y1="28.425" x2="197.625" y2="28.475" layer="94"/>
+<rectangle x1="199.325" y1="28.425" x2="202.325" y2="28.475" layer="94"/>
+<rectangle x1="204.025" y1="28.425" x2="206.775" y2="28.475" layer="94"/>
+<rectangle x1="208.325" y1="28.425" x2="208.475" y2="28.475" layer="94"/>
+<rectangle x1="210.075" y1="28.425" x2="212.925" y2="28.475" layer="94"/>
+<rectangle x1="214.625" y1="28.425" x2="220.975" y2="28.475" layer="94"/>
+<rectangle x1="222.725" y1="28.425" x2="224.975" y2="28.475" layer="94"/>
+<rectangle x1="226.975" y1="28.425" x2="233.325" y2="28.475" layer="94"/>
+<rectangle x1="235.325" y1="28.425" x2="239.425" y2="28.475" layer="94"/>
+<rectangle x1="241.425" y1="28.425" x2="243.375" y2="28.475" layer="94"/>
+<rectangle x1="184.125" y1="28.475" x2="188.775" y2="28.525" layer="94"/>
+<rectangle x1="190.475" y1="28.475" x2="194.225" y2="28.525" layer="94"/>
+<rectangle x1="195.875" y1="28.475" x2="197.625" y2="28.525" layer="94"/>
+<rectangle x1="199.325" y1="28.475" x2="202.325" y2="28.525" layer="94"/>
+<rectangle x1="204.025" y1="28.475" x2="206.725" y2="28.525" layer="94"/>
+<rectangle x1="208.325" y1="28.475" x2="208.475" y2="28.525" layer="94"/>
+<rectangle x1="210.075" y1="28.475" x2="212.925" y2="28.525" layer="94"/>
+<rectangle x1="214.625" y1="28.475" x2="220.975" y2="28.525" layer="94"/>
+<rectangle x1="222.725" y1="28.475" x2="224.925" y2="28.525" layer="94"/>
+<rectangle x1="226.925" y1="28.475" x2="233.275" y2="28.525" layer="94"/>
+<rectangle x1="235.275" y1="28.475" x2="239.425" y2="28.525" layer="94"/>
+<rectangle x1="241.425" y1="28.475" x2="243.375" y2="28.525" layer="94"/>
+<rectangle x1="184.125" y1="28.525" x2="188.775" y2="28.575" layer="94"/>
+<rectangle x1="190.475" y1="28.525" x2="194.225" y2="28.575" layer="94"/>
+<rectangle x1="195.875" y1="28.525" x2="197.625" y2="28.575" layer="94"/>
+<rectangle x1="199.325" y1="28.525" x2="202.325" y2="28.575" layer="94"/>
+<rectangle x1="204.025" y1="28.525" x2="206.725" y2="28.575" layer="94"/>
+<rectangle x1="208.275" y1="28.525" x2="208.525" y2="28.575" layer="94"/>
+<rectangle x1="210.075" y1="28.525" x2="212.925" y2="28.575" layer="94"/>
+<rectangle x1="214.625" y1="28.525" x2="220.975" y2="28.575" layer="94"/>
+<rectangle x1="222.725" y1="28.525" x2="224.925" y2="28.575" layer="94"/>
+<rectangle x1="226.925" y1="28.525" x2="233.275" y2="28.575" layer="94"/>
+<rectangle x1="235.225" y1="28.525" x2="239.475" y2="28.575" layer="94"/>
+<rectangle x1="241.475" y1="28.525" x2="243.375" y2="28.575" layer="94"/>
+<rectangle x1="184.125" y1="28.575" x2="188.775" y2="28.625" layer="94"/>
+<rectangle x1="190.475" y1="28.575" x2="194.225" y2="28.625" layer="94"/>
+<rectangle x1="195.875" y1="28.575" x2="197.625" y2="28.625" layer="94"/>
+<rectangle x1="199.325" y1="28.575" x2="202.325" y2="28.625" layer="94"/>
+<rectangle x1="204.025" y1="28.575" x2="206.675" y2="28.625" layer="94"/>
+<rectangle x1="208.275" y1="28.575" x2="208.525" y2="28.625" layer="94"/>
+<rectangle x1="210.125" y1="28.575" x2="212.925" y2="28.625" layer="94"/>
+<rectangle x1="214.625" y1="28.575" x2="220.975" y2="28.625" layer="94"/>
+<rectangle x1="222.725" y1="28.575" x2="224.875" y2="28.625" layer="94"/>
+<rectangle x1="226.875" y1="28.575" x2="233.225" y2="28.625" layer="94"/>
+<rectangle x1="235.225" y1="28.575" x2="239.525" y2="28.625" layer="94"/>
+<rectangle x1="241.475" y1="28.575" x2="243.375" y2="28.625" layer="94"/>
+<rectangle x1="184.125" y1="28.625" x2="188.775" y2="28.675" layer="94"/>
+<rectangle x1="190.475" y1="28.625" x2="194.225" y2="28.675" layer="94"/>
+<rectangle x1="195.875" y1="28.625" x2="197.625" y2="28.675" layer="94"/>
+<rectangle x1="199.325" y1="28.625" x2="202.325" y2="28.675" layer="94"/>
+<rectangle x1="204.025" y1="28.625" x2="206.675" y2="28.675" layer="94"/>
+<rectangle x1="208.275" y1="28.625" x2="208.525" y2="28.675" layer="94"/>
+<rectangle x1="210.125" y1="28.625" x2="212.925" y2="28.675" layer="94"/>
+<rectangle x1="214.625" y1="28.625" x2="220.975" y2="28.675" layer="94"/>
+<rectangle x1="222.725" y1="28.625" x2="224.875" y2="28.675" layer="94"/>
+<rectangle x1="226.825" y1="28.625" x2="233.225" y2="28.675" layer="94"/>
+<rectangle x1="235.175" y1="28.625" x2="239.575" y2="28.675" layer="94"/>
+<rectangle x1="241.475" y1="28.625" x2="243.375" y2="28.675" layer="94"/>
+<rectangle x1="184.125" y1="28.675" x2="188.775" y2="28.725" layer="94"/>
+<rectangle x1="190.475" y1="28.675" x2="194.225" y2="28.725" layer="94"/>
+<rectangle x1="195.875" y1="28.675" x2="197.625" y2="28.725" layer="94"/>
+<rectangle x1="199.325" y1="28.675" x2="202.325" y2="28.725" layer="94"/>
+<rectangle x1="204.025" y1="28.675" x2="206.675" y2="28.725" layer="94"/>
+<rectangle x1="208.225" y1="28.675" x2="208.525" y2="28.725" layer="94"/>
+<rectangle x1="210.125" y1="28.675" x2="212.925" y2="28.725" layer="94"/>
+<rectangle x1="214.625" y1="28.675" x2="220.975" y2="28.725" layer="94"/>
+<rectangle x1="222.725" y1="28.675" x2="224.875" y2="28.725" layer="94"/>
+<rectangle x1="226.775" y1="28.675" x2="233.175" y2="28.725" layer="94"/>
+<rectangle x1="235.125" y1="28.675" x2="239.575" y2="28.725" layer="94"/>
+<rectangle x1="241.525" y1="28.675" x2="243.375" y2="28.725" layer="94"/>
+<rectangle x1="184.125" y1="28.725" x2="188.775" y2="28.775" layer="94"/>
+<rectangle x1="190.475" y1="28.725" x2="194.225" y2="28.775" layer="94"/>
+<rectangle x1="195.875" y1="28.725" x2="197.625" y2="28.775" layer="94"/>
+<rectangle x1="199.325" y1="28.725" x2="202.325" y2="28.775" layer="94"/>
+<rectangle x1="204.025" y1="28.725" x2="206.625" y2="28.775" layer="94"/>
+<rectangle x1="208.225" y1="28.725" x2="208.575" y2="28.775" layer="94"/>
+<rectangle x1="210.175" y1="28.725" x2="212.925" y2="28.775" layer="94"/>
+<rectangle x1="214.625" y1="28.725" x2="220.975" y2="28.775" layer="94"/>
+<rectangle x1="222.725" y1="28.725" x2="224.825" y2="28.775" layer="94"/>
+<rectangle x1="226.775" y1="28.725" x2="233.175" y2="28.775" layer="94"/>
+<rectangle x1="235.125" y1="28.725" x2="239.625" y2="28.775" layer="94"/>
+<rectangle x1="241.525" y1="28.725" x2="243.375" y2="28.775" layer="94"/>
+<rectangle x1="184.125" y1="28.775" x2="188.775" y2="28.825" layer="94"/>
+<rectangle x1="190.475" y1="28.775" x2="194.225" y2="28.825" layer="94"/>
+<rectangle x1="195.875" y1="28.775" x2="197.625" y2="28.825" layer="94"/>
+<rectangle x1="199.325" y1="28.775" x2="202.325" y2="28.825" layer="94"/>
+<rectangle x1="204.025" y1="28.775" x2="206.625" y2="28.825" layer="94"/>
+<rectangle x1="208.225" y1="28.775" x2="208.575" y2="28.825" layer="94"/>
+<rectangle x1="210.175" y1="28.775" x2="212.925" y2="28.825" layer="94"/>
+<rectangle x1="214.625" y1="28.775" x2="220.975" y2="28.825" layer="94"/>
+<rectangle x1="222.725" y1="28.775" x2="224.825" y2="28.825" layer="94"/>
+<rectangle x1="226.725" y1="28.775" x2="233.175" y2="28.825" layer="94"/>
+<rectangle x1="235.075" y1="28.775" x2="239.625" y2="28.825" layer="94"/>
+<rectangle x1="241.575" y1="28.775" x2="243.375" y2="28.825" layer="94"/>
+<rectangle x1="184.125" y1="28.825" x2="188.775" y2="28.875" layer="94"/>
+<rectangle x1="190.475" y1="28.825" x2="194.225" y2="28.875" layer="94"/>
+<rectangle x1="195.875" y1="28.825" x2="197.625" y2="28.875" layer="94"/>
+<rectangle x1="199.325" y1="28.825" x2="202.325" y2="28.875" layer="94"/>
+<rectangle x1="204.025" y1="28.825" x2="206.575" y2="28.875" layer="94"/>
+<rectangle x1="208.175" y1="28.825" x2="208.575" y2="28.875" layer="94"/>
+<rectangle x1="210.225" y1="28.825" x2="212.925" y2="28.875" layer="94"/>
+<rectangle x1="214.625" y1="28.825" x2="220.975" y2="28.875" layer="94"/>
+<rectangle x1="222.725" y1="28.825" x2="224.825" y2="28.875" layer="94"/>
+<rectangle x1="226.725" y1="28.825" x2="233.125" y2="28.875" layer="94"/>
+<rectangle x1="235.075" y1="28.825" x2="239.675" y2="28.875" layer="94"/>
+<rectangle x1="241.575" y1="28.825" x2="243.375" y2="28.875" layer="94"/>
+<rectangle x1="184.125" y1="28.875" x2="188.775" y2="28.925" layer="94"/>
+<rectangle x1="190.475" y1="28.875" x2="194.225" y2="28.925" layer="94"/>
+<rectangle x1="195.875" y1="28.875" x2="197.625" y2="28.925" layer="94"/>
+<rectangle x1="199.325" y1="28.875" x2="202.325" y2="28.925" layer="94"/>
+<rectangle x1="204.025" y1="28.875" x2="206.575" y2="28.925" layer="94"/>
+<rectangle x1="208.175" y1="28.875" x2="208.625" y2="28.925" layer="94"/>
+<rectangle x1="210.225" y1="28.875" x2="212.925" y2="28.925" layer="94"/>
+<rectangle x1="214.625" y1="28.875" x2="220.975" y2="28.925" layer="94"/>
+<rectangle x1="222.725" y1="28.875" x2="224.775" y2="28.925" layer="94"/>
+<rectangle x1="226.675" y1="28.875" x2="233.125" y2="28.925" layer="94"/>
+<rectangle x1="235.025" y1="28.875" x2="239.675" y2="28.925" layer="94"/>
+<rectangle x1="241.575" y1="28.875" x2="243.375" y2="28.925" layer="94"/>
+<rectangle x1="184.125" y1="28.925" x2="188.775" y2="28.975" layer="94"/>
+<rectangle x1="190.475" y1="28.925" x2="194.225" y2="28.975" layer="94"/>
+<rectangle x1="195.875" y1="28.925" x2="197.625" y2="28.975" layer="94"/>
+<rectangle x1="199.325" y1="28.925" x2="202.325" y2="28.975" layer="94"/>
+<rectangle x1="204.025" y1="28.925" x2="206.575" y2="28.975" layer="94"/>
+<rectangle x1="208.125" y1="28.925" x2="208.625" y2="28.975" layer="94"/>
+<rectangle x1="210.225" y1="28.925" x2="212.925" y2="28.975" layer="94"/>
+<rectangle x1="214.625" y1="28.925" x2="220.975" y2="28.975" layer="94"/>
+<rectangle x1="222.725" y1="28.925" x2="224.775" y2="28.975" layer="94"/>
+<rectangle x1="226.675" y1="28.925" x2="233.075" y2="28.975" layer="94"/>
+<rectangle x1="235.025" y1="28.925" x2="239.725" y2="28.975" layer="94"/>
+<rectangle x1="241.625" y1="28.925" x2="243.375" y2="28.975" layer="94"/>
+<rectangle x1="184.125" y1="28.975" x2="188.775" y2="29.025" layer="94"/>
+<rectangle x1="190.475" y1="28.975" x2="194.225" y2="29.025" layer="94"/>
+<rectangle x1="195.875" y1="28.975" x2="197.625" y2="29.025" layer="94"/>
+<rectangle x1="199.325" y1="28.975" x2="202.325" y2="29.025" layer="94"/>
+<rectangle x1="204.025" y1="28.975" x2="206.525" y2="29.025" layer="94"/>
+<rectangle x1="208.125" y1="28.975" x2="208.625" y2="29.025" layer="94"/>
+<rectangle x1="210.275" y1="28.975" x2="212.925" y2="29.025" layer="94"/>
+<rectangle x1="214.625" y1="28.975" x2="220.975" y2="29.025" layer="94"/>
+<rectangle x1="222.725" y1="28.975" x2="224.725" y2="29.025" layer="94"/>
+<rectangle x1="226.625" y1="28.975" x2="233.075" y2="29.025" layer="94"/>
+<rectangle x1="234.975" y1="28.975" x2="239.725" y2="29.025" layer="94"/>
+<rectangle x1="241.625" y1="28.975" x2="243.375" y2="29.025" layer="94"/>
+<rectangle x1="184.125" y1="29.025" x2="188.775" y2="29.075" layer="94"/>
+<rectangle x1="190.475" y1="29.025" x2="194.225" y2="29.075" layer="94"/>
+<rectangle x1="195.875" y1="29.025" x2="197.625" y2="29.075" layer="94"/>
+<rectangle x1="199.325" y1="29.025" x2="202.325" y2="29.075" layer="94"/>
+<rectangle x1="204.025" y1="29.025" x2="206.525" y2="29.075" layer="94"/>
+<rectangle x1="208.125" y1="29.025" x2="208.675" y2="29.075" layer="94"/>
+<rectangle x1="210.275" y1="29.025" x2="212.925" y2="29.075" layer="94"/>
+<rectangle x1="214.625" y1="29.025" x2="220.975" y2="29.075" layer="94"/>
+<rectangle x1="222.725" y1="29.025" x2="224.725" y2="29.075" layer="94"/>
+<rectangle x1="226.625" y1="29.025" x2="233.075" y2="29.075" layer="94"/>
+<rectangle x1="234.975" y1="29.025" x2="239.775" y2="29.075" layer="94"/>
+<rectangle x1="241.675" y1="29.025" x2="243.375" y2="29.075" layer="94"/>
+<rectangle x1="184.125" y1="29.075" x2="188.775" y2="29.125" layer="94"/>
+<rectangle x1="190.475" y1="29.075" x2="194.225" y2="29.125" layer="94"/>
+<rectangle x1="195.875" y1="29.075" x2="197.625" y2="29.125" layer="94"/>
+<rectangle x1="199.325" y1="29.075" x2="202.325" y2="29.125" layer="94"/>
+<rectangle x1="204.025" y1="29.075" x2="206.475" y2="29.125" layer="94"/>
+<rectangle x1="208.075" y1="29.075" x2="208.675" y2="29.125" layer="94"/>
+<rectangle x1="210.325" y1="29.075" x2="212.925" y2="29.125" layer="94"/>
+<rectangle x1="214.625" y1="29.075" x2="220.975" y2="29.125" layer="94"/>
+<rectangle x1="222.725" y1="29.075" x2="224.725" y2="29.125" layer="94"/>
+<rectangle x1="226.575" y1="29.075" x2="233.075" y2="29.125" layer="94"/>
+<rectangle x1="234.925" y1="29.075" x2="239.775" y2="29.125" layer="94"/>
+<rectangle x1="241.675" y1="29.075" x2="243.375" y2="29.125" layer="94"/>
+<rectangle x1="184.125" y1="29.125" x2="188.775" y2="29.175" layer="94"/>
+<rectangle x1="190.475" y1="29.125" x2="194.225" y2="29.175" layer="94"/>
+<rectangle x1="195.875" y1="29.125" x2="197.625" y2="29.175" layer="94"/>
+<rectangle x1="199.325" y1="29.125" x2="202.325" y2="29.175" layer="94"/>
+<rectangle x1="204.025" y1="29.125" x2="206.475" y2="29.175" layer="94"/>
+<rectangle x1="208.075" y1="29.125" x2="208.675" y2="29.175" layer="94"/>
+<rectangle x1="210.325" y1="29.125" x2="212.925" y2="29.175" layer="94"/>
+<rectangle x1="214.625" y1="29.125" x2="220.975" y2="29.175" layer="94"/>
+<rectangle x1="222.725" y1="29.125" x2="224.675" y2="29.175" layer="94"/>
+<rectangle x1="226.575" y1="29.125" x2="233.025" y2="29.175" layer="94"/>
+<rectangle x1="234.925" y1="29.125" x2="239.825" y2="29.175" layer="94"/>
+<rectangle x1="241.675" y1="29.125" x2="243.375" y2="29.175" layer="94"/>
+<rectangle x1="184.125" y1="29.175" x2="188.775" y2="29.225" layer="94"/>
+<rectangle x1="190.475" y1="29.175" x2="194.225" y2="29.225" layer="94"/>
+<rectangle x1="195.875" y1="29.175" x2="197.625" y2="29.225" layer="94"/>
+<rectangle x1="199.325" y1="29.175" x2="202.325" y2="29.225" layer="94"/>
+<rectangle x1="204.025" y1="29.175" x2="206.475" y2="29.225" layer="94"/>
+<rectangle x1="208.075" y1="29.175" x2="208.725" y2="29.225" layer="94"/>
+<rectangle x1="210.325" y1="29.175" x2="212.925" y2="29.225" layer="94"/>
+<rectangle x1="214.625" y1="29.175" x2="220.975" y2="29.225" layer="94"/>
+<rectangle x1="222.725" y1="29.175" x2="224.675" y2="29.225" layer="94"/>
+<rectangle x1="226.525" y1="29.175" x2="233.025" y2="29.225" layer="94"/>
+<rectangle x1="234.875" y1="29.175" x2="239.825" y2="29.225" layer="94"/>
+<rectangle x1="241.675" y1="29.175" x2="243.375" y2="29.225" layer="94"/>
+<rectangle x1="184.125" y1="29.225" x2="188.775" y2="29.275" layer="94"/>
+<rectangle x1="190.475" y1="29.225" x2="194.225" y2="29.275" layer="94"/>
+<rectangle x1="195.875" y1="29.225" x2="197.625" y2="29.275" layer="94"/>
+<rectangle x1="199.325" y1="29.225" x2="202.325" y2="29.275" layer="94"/>
+<rectangle x1="204.025" y1="29.225" x2="206.425" y2="29.275" layer="94"/>
+<rectangle x1="208.025" y1="29.225" x2="208.725" y2="29.275" layer="94"/>
+<rectangle x1="210.375" y1="29.225" x2="212.925" y2="29.275" layer="94"/>
+<rectangle x1="214.625" y1="29.225" x2="220.975" y2="29.275" layer="94"/>
+<rectangle x1="222.725" y1="29.225" x2="224.675" y2="29.275" layer="94"/>
+<rectangle x1="226.525" y1="29.225" x2="233.025" y2="29.275" layer="94"/>
+<rectangle x1="234.875" y1="29.225" x2="239.875" y2="29.275" layer="94"/>
+<rectangle x1="241.725" y1="29.225" x2="243.375" y2="29.275" layer="94"/>
+<rectangle x1="184.125" y1="29.275" x2="188.775" y2="29.325" layer="94"/>
+<rectangle x1="190.475" y1="29.275" x2="194.225" y2="29.325" layer="94"/>
+<rectangle x1="195.875" y1="29.275" x2="197.625" y2="29.325" layer="94"/>
+<rectangle x1="199.325" y1="29.275" x2="202.325" y2="29.325" layer="94"/>
+<rectangle x1="204.025" y1="29.275" x2="206.425" y2="29.325" layer="94"/>
+<rectangle x1="208.025" y1="29.275" x2="208.725" y2="29.325" layer="94"/>
+<rectangle x1="210.375" y1="29.275" x2="212.925" y2="29.325" layer="94"/>
+<rectangle x1="214.625" y1="29.275" x2="220.975" y2="29.325" layer="94"/>
+<rectangle x1="222.725" y1="29.275" x2="224.675" y2="29.325" layer="94"/>
+<rectangle x1="226.525" y1="29.275" x2="232.975" y2="29.325" layer="94"/>
+<rectangle x1="234.875" y1="29.275" x2="239.875" y2="29.325" layer="94"/>
+<rectangle x1="241.725" y1="29.275" x2="243.375" y2="29.325" layer="94"/>
+<rectangle x1="184.125" y1="29.325" x2="188.775" y2="29.375" layer="94"/>
+<rectangle x1="190.475" y1="29.325" x2="194.225" y2="29.375" layer="94"/>
+<rectangle x1="195.875" y1="29.325" x2="197.625" y2="29.375" layer="94"/>
+<rectangle x1="199.325" y1="29.325" x2="202.325" y2="29.375" layer="94"/>
+<rectangle x1="204.025" y1="29.325" x2="206.375" y2="29.375" layer="94"/>
+<rectangle x1="208.025" y1="29.325" x2="208.725" y2="29.375" layer="94"/>
+<rectangle x1="210.375" y1="29.325" x2="212.925" y2="29.375" layer="94"/>
+<rectangle x1="214.625" y1="29.325" x2="220.975" y2="29.375" layer="94"/>
+<rectangle x1="222.725" y1="29.325" x2="224.625" y2="29.375" layer="94"/>
+<rectangle x1="226.475" y1="29.325" x2="232.975" y2="29.375" layer="94"/>
+<rectangle x1="234.825" y1="29.325" x2="239.875" y2="29.375" layer="94"/>
+<rectangle x1="241.725" y1="29.325" x2="243.375" y2="29.375" layer="94"/>
+<rectangle x1="184.125" y1="29.375" x2="188.775" y2="29.425" layer="94"/>
+<rectangle x1="190.475" y1="29.375" x2="194.225" y2="29.425" layer="94"/>
+<rectangle x1="195.875" y1="29.375" x2="197.625" y2="29.425" layer="94"/>
+<rectangle x1="199.325" y1="29.375" x2="202.325" y2="29.425" layer="94"/>
+<rectangle x1="204.025" y1="29.375" x2="206.375" y2="29.425" layer="94"/>
+<rectangle x1="207.975" y1="29.375" x2="208.775" y2="29.425" layer="94"/>
+<rectangle x1="210.425" y1="29.375" x2="212.925" y2="29.425" layer="94"/>
+<rectangle x1="214.625" y1="29.375" x2="220.975" y2="29.425" layer="94"/>
+<rectangle x1="222.725" y1="29.375" x2="224.625" y2="29.425" layer="94"/>
+<rectangle x1="226.475" y1="29.375" x2="232.975" y2="29.425" layer="94"/>
+<rectangle x1="234.825" y1="29.375" x2="239.925" y2="29.425" layer="94"/>
+<rectangle x1="241.775" y1="29.375" x2="243.375" y2="29.425" layer="94"/>
+<rectangle x1="184.125" y1="29.425" x2="188.775" y2="29.475" layer="94"/>
+<rectangle x1="190.475" y1="29.425" x2="194.225" y2="29.475" layer="94"/>
+<rectangle x1="195.875" y1="29.425" x2="197.625" y2="29.475" layer="94"/>
+<rectangle x1="199.325" y1="29.425" x2="202.325" y2="29.475" layer="94"/>
+<rectangle x1="204.025" y1="29.425" x2="206.375" y2="29.475" layer="94"/>
+<rectangle x1="207.975" y1="29.425" x2="208.775" y2="29.475" layer="94"/>
+<rectangle x1="210.425" y1="29.425" x2="212.925" y2="29.475" layer="94"/>
+<rectangle x1="214.625" y1="29.425" x2="220.975" y2="29.475" layer="94"/>
+<rectangle x1="222.725" y1="29.425" x2="224.625" y2="29.475" layer="94"/>
+<rectangle x1="226.425" y1="29.425" x2="232.925" y2="29.475" layer="94"/>
+<rectangle x1="234.825" y1="29.425" x2="239.925" y2="29.475" layer="94"/>
+<rectangle x1="241.775" y1="29.425" x2="243.375" y2="29.475" layer="94"/>
+<rectangle x1="184.125" y1="29.475" x2="188.775" y2="29.525" layer="94"/>
+<rectangle x1="190.475" y1="29.475" x2="194.225" y2="29.525" layer="94"/>
+<rectangle x1="195.875" y1="29.475" x2="197.625" y2="29.525" layer="94"/>
+<rectangle x1="199.325" y1="29.475" x2="202.325" y2="29.525" layer="94"/>
+<rectangle x1="204.025" y1="29.475" x2="206.325" y2="29.525" layer="94"/>
+<rectangle x1="207.925" y1="29.475" x2="208.775" y2="29.525" layer="94"/>
+<rectangle x1="210.475" y1="29.475" x2="212.925" y2="29.525" layer="94"/>
+<rectangle x1="214.625" y1="29.475" x2="220.975" y2="29.525" layer="94"/>
+<rectangle x1="222.725" y1="29.475" x2="224.625" y2="29.525" layer="94"/>
+<rectangle x1="226.425" y1="29.475" x2="232.925" y2="29.525" layer="94"/>
+<rectangle x1="234.775" y1="29.475" x2="239.925" y2="29.525" layer="94"/>
+<rectangle x1="241.775" y1="29.475" x2="243.375" y2="29.525" layer="94"/>
+<rectangle x1="184.125" y1="29.525" x2="188.775" y2="29.575" layer="94"/>
+<rectangle x1="190.475" y1="29.525" x2="194.225" y2="29.575" layer="94"/>
+<rectangle x1="195.875" y1="29.525" x2="197.625" y2="29.575" layer="94"/>
+<rectangle x1="199.325" y1="29.525" x2="202.325" y2="29.575" layer="94"/>
+<rectangle x1="204.025" y1="29.525" x2="206.325" y2="29.575" layer="94"/>
+<rectangle x1="207.925" y1="29.525" x2="208.825" y2="29.575" layer="94"/>
+<rectangle x1="210.475" y1="29.525" x2="212.925" y2="29.575" layer="94"/>
+<rectangle x1="214.625" y1="29.525" x2="220.975" y2="29.575" layer="94"/>
+<rectangle x1="222.725" y1="29.525" x2="224.575" y2="29.575" layer="94"/>
+<rectangle x1="226.425" y1="29.525" x2="232.925" y2="29.575" layer="94"/>
+<rectangle x1="234.775" y1="29.525" x2="239.975" y2="29.575" layer="94"/>
+<rectangle x1="241.775" y1="29.525" x2="243.375" y2="29.575" layer="94"/>
+<rectangle x1="184.125" y1="29.575" x2="188.775" y2="29.625" layer="94"/>
+<rectangle x1="190.475" y1="29.575" x2="194.225" y2="29.625" layer="94"/>
+<rectangle x1="195.875" y1="29.575" x2="197.625" y2="29.625" layer="94"/>
+<rectangle x1="199.325" y1="29.575" x2="202.325" y2="29.625" layer="94"/>
+<rectangle x1="204.025" y1="29.575" x2="206.275" y2="29.625" layer="94"/>
+<rectangle x1="207.925" y1="29.575" x2="208.825" y2="29.625" layer="94"/>
+<rectangle x1="210.475" y1="29.575" x2="212.925" y2="29.625" layer="94"/>
+<rectangle x1="214.625" y1="29.575" x2="220.975" y2="29.625" layer="94"/>
+<rectangle x1="222.725" y1="29.575" x2="224.575" y2="29.625" layer="94"/>
+<rectangle x1="226.425" y1="29.575" x2="232.925" y2="29.625" layer="94"/>
+<rectangle x1="234.775" y1="29.575" x2="239.975" y2="29.625" layer="94"/>
+<rectangle x1="241.775" y1="29.575" x2="243.375" y2="29.625" layer="94"/>
+<rectangle x1="184.125" y1="29.625" x2="188.775" y2="29.675" layer="94"/>
+<rectangle x1="190.475" y1="29.625" x2="194.225" y2="29.675" layer="94"/>
+<rectangle x1="195.875" y1="29.625" x2="197.625" y2="29.675" layer="94"/>
+<rectangle x1="199.325" y1="29.625" x2="202.325" y2="29.675" layer="94"/>
+<rectangle x1="204.025" y1="29.625" x2="206.275" y2="29.675" layer="94"/>
+<rectangle x1="207.875" y1="29.625" x2="208.825" y2="29.675" layer="94"/>
+<rectangle x1="210.525" y1="29.625" x2="212.925" y2="29.675" layer="94"/>
+<rectangle x1="214.625" y1="29.625" x2="220.975" y2="29.675" layer="94"/>
+<rectangle x1="222.725" y1="29.625" x2="224.575" y2="29.675" layer="94"/>
+<rectangle x1="226.375" y1="29.625" x2="232.925" y2="29.675" layer="94"/>
+<rectangle x1="234.775" y1="29.625" x2="239.975" y2="29.675" layer="94"/>
+<rectangle x1="241.825" y1="29.625" x2="243.375" y2="29.675" layer="94"/>
+<rectangle x1="184.125" y1="29.675" x2="188.775" y2="29.725" layer="94"/>
+<rectangle x1="190.475" y1="29.675" x2="194.225" y2="29.725" layer="94"/>
+<rectangle x1="195.875" y1="29.675" x2="197.625" y2="29.725" layer="94"/>
+<rectangle x1="199.325" y1="29.675" x2="202.325" y2="29.725" layer="94"/>
+<rectangle x1="204.025" y1="29.675" x2="206.225" y2="29.725" layer="94"/>
+<rectangle x1="207.875" y1="29.675" x2="208.875" y2="29.725" layer="94"/>
+<rectangle x1="210.525" y1="29.675" x2="212.925" y2="29.725" layer="94"/>
+<rectangle x1="214.625" y1="29.675" x2="220.975" y2="29.725" layer="94"/>
+<rectangle x1="222.725" y1="29.675" x2="224.575" y2="29.725" layer="94"/>
+<rectangle x1="226.375" y1="29.675" x2="232.925" y2="29.725" layer="94"/>
+<rectangle x1="234.725" y1="29.675" x2="239.975" y2="29.725" layer="94"/>
+<rectangle x1="241.825" y1="29.675" x2="243.375" y2="29.725" layer="94"/>
+<rectangle x1="184.125" y1="29.725" x2="188.775" y2="29.775" layer="94"/>
+<rectangle x1="190.475" y1="29.725" x2="194.225" y2="29.775" layer="94"/>
+<rectangle x1="195.875" y1="29.725" x2="197.625" y2="29.775" layer="94"/>
+<rectangle x1="199.325" y1="29.725" x2="202.325" y2="29.775" layer="94"/>
+<rectangle x1="204.025" y1="29.725" x2="206.225" y2="29.775" layer="94"/>
+<rectangle x1="207.875" y1="29.725" x2="208.875" y2="29.775" layer="94"/>
+<rectangle x1="210.525" y1="29.725" x2="212.925" y2="29.775" layer="94"/>
+<rectangle x1="214.625" y1="29.725" x2="220.975" y2="29.775" layer="94"/>
+<rectangle x1="222.725" y1="29.725" x2="224.575" y2="29.775" layer="94"/>
+<rectangle x1="226.375" y1="29.725" x2="232.875" y2="29.775" layer="94"/>
+<rectangle x1="234.725" y1="29.725" x2="239.975" y2="29.775" layer="94"/>
+<rectangle x1="241.825" y1="29.725" x2="243.375" y2="29.775" layer="94"/>
+<rectangle x1="184.125" y1="29.775" x2="188.775" y2="29.825" layer="94"/>
+<rectangle x1="190.475" y1="29.775" x2="194.225" y2="29.825" layer="94"/>
+<rectangle x1="195.875" y1="29.775" x2="197.625" y2="29.825" layer="94"/>
+<rectangle x1="199.325" y1="29.775" x2="202.325" y2="29.825" layer="94"/>
+<rectangle x1="204.025" y1="29.775" x2="206.225" y2="29.825" layer="94"/>
+<rectangle x1="207.825" y1="29.775" x2="208.875" y2="29.825" layer="94"/>
+<rectangle x1="210.575" y1="29.775" x2="212.925" y2="29.825" layer="94"/>
+<rectangle x1="214.625" y1="29.775" x2="220.975" y2="29.825" layer="94"/>
+<rectangle x1="222.725" y1="29.775" x2="224.525" y2="29.825" layer="94"/>
+<rectangle x1="226.375" y1="29.775" x2="232.875" y2="29.825" layer="94"/>
+<rectangle x1="234.725" y1="29.775" x2="240.025" y2="29.825" layer="94"/>
+<rectangle x1="241.825" y1="29.775" x2="243.375" y2="29.825" layer="94"/>
+<rectangle x1="184.125" y1="29.825" x2="188.775" y2="29.875" layer="94"/>
+<rectangle x1="190.475" y1="29.825" x2="194.225" y2="29.875" layer="94"/>
+<rectangle x1="195.875" y1="29.825" x2="197.625" y2="29.875" layer="94"/>
+<rectangle x1="199.325" y1="29.825" x2="202.325" y2="29.875" layer="94"/>
+<rectangle x1="204.025" y1="29.825" x2="206.175" y2="29.875" layer="94"/>
+<rectangle x1="207.825" y1="29.825" x2="208.925" y2="29.875" layer="94"/>
+<rectangle x1="210.575" y1="29.825" x2="212.925" y2="29.875" layer="94"/>
+<rectangle x1="214.625" y1="29.825" x2="220.975" y2="29.875" layer="94"/>
+<rectangle x1="222.725" y1="29.825" x2="224.525" y2="29.875" layer="94"/>
+<rectangle x1="226.325" y1="29.825" x2="232.875" y2="29.875" layer="94"/>
+<rectangle x1="234.725" y1="29.825" x2="240.025" y2="29.875" layer="94"/>
+<rectangle x1="241.825" y1="29.825" x2="243.375" y2="29.875" layer="94"/>
+<rectangle x1="184.125" y1="29.875" x2="188.775" y2="29.925" layer="94"/>
+<rectangle x1="190.475" y1="29.875" x2="194.225" y2="29.925" layer="94"/>
+<rectangle x1="195.875" y1="29.875" x2="197.625" y2="29.925" layer="94"/>
+<rectangle x1="199.325" y1="29.875" x2="202.325" y2="29.925" layer="94"/>
+<rectangle x1="204.025" y1="29.875" x2="206.175" y2="29.925" layer="94"/>
+<rectangle x1="207.825" y1="29.875" x2="208.925" y2="29.925" layer="94"/>
+<rectangle x1="210.625" y1="29.875" x2="212.925" y2="29.925" layer="94"/>
+<rectangle x1="214.625" y1="29.875" x2="214.875" y2="29.925" layer="94"/>
+<rectangle x1="216.775" y1="29.875" x2="220.975" y2="29.925" layer="94"/>
+<rectangle x1="222.725" y1="29.875" x2="224.525" y2="29.925" layer="94"/>
+<rectangle x1="226.325" y1="29.875" x2="232.875" y2="29.925" layer="94"/>
+<rectangle x1="234.675" y1="29.875" x2="240.025" y2="29.925" layer="94"/>
+<rectangle x1="241.875" y1="29.875" x2="243.375" y2="29.925" layer="94"/>
+<rectangle x1="184.125" y1="29.925" x2="188.775" y2="29.975" layer="94"/>
+<rectangle x1="190.475" y1="29.925" x2="194.225" y2="29.975" layer="94"/>
+<rectangle x1="195.875" y1="29.925" x2="197.625" y2="29.975" layer="94"/>
+<rectangle x1="199.325" y1="29.925" x2="202.325" y2="29.975" layer="94"/>
+<rectangle x1="204.025" y1="29.925" x2="206.125" y2="29.975" layer="94"/>
+<rectangle x1="207.775" y1="29.925" x2="208.925" y2="29.975" layer="94"/>
+<rectangle x1="210.625" y1="29.925" x2="212.925" y2="29.975" layer="94"/>
+<rectangle x1="217.175" y1="29.925" x2="220.975" y2="29.975" layer="94"/>
+<rectangle x1="222.725" y1="29.925" x2="224.525" y2="29.975" layer="94"/>
+<rectangle x1="226.325" y1="29.925" x2="232.875" y2="29.975" layer="94"/>
+<rectangle x1="234.675" y1="29.925" x2="240.025" y2="29.975" layer="94"/>
+<rectangle x1="241.875" y1="29.925" x2="243.375" y2="29.975" layer="94"/>
+<rectangle x1="184.125" y1="29.975" x2="188.775" y2="30.025" layer="94"/>
+<rectangle x1="190.475" y1="29.975" x2="194.225" y2="30.025" layer="94"/>
+<rectangle x1="195.875" y1="29.975" x2="197.625" y2="30.025" layer="94"/>
+<rectangle x1="199.325" y1="29.975" x2="202.325" y2="30.025" layer="94"/>
+<rectangle x1="204.025" y1="29.975" x2="206.125" y2="30.025" layer="94"/>
+<rectangle x1="207.775" y1="29.975" x2="208.975" y2="30.025" layer="94"/>
+<rectangle x1="210.625" y1="29.975" x2="212.925" y2="30.025" layer="94"/>
+<rectangle x1="217.425" y1="29.975" x2="220.975" y2="30.025" layer="94"/>
+<rectangle x1="222.725" y1="29.975" x2="224.525" y2="30.025" layer="94"/>
+<rectangle x1="226.325" y1="29.975" x2="232.825" y2="30.025" layer="94"/>
+<rectangle x1="234.675" y1="29.975" x2="240.025" y2="30.025" layer="94"/>
+<rectangle x1="241.875" y1="29.975" x2="243.375" y2="30.025" layer="94"/>
+<rectangle x1="184.125" y1="30.025" x2="188.775" y2="30.075" layer="94"/>
+<rectangle x1="190.475" y1="30.025" x2="194.225" y2="30.075" layer="94"/>
+<rectangle x1="195.875" y1="30.025" x2="197.625" y2="30.075" layer="94"/>
+<rectangle x1="199.325" y1="30.025" x2="202.325" y2="30.075" layer="94"/>
+<rectangle x1="204.025" y1="30.025" x2="206.125" y2="30.075" layer="94"/>
+<rectangle x1="207.725" y1="30.025" x2="208.975" y2="30.075" layer="94"/>
+<rectangle x1="210.675" y1="30.025" x2="212.925" y2="30.075" layer="94"/>
+<rectangle x1="217.625" y1="30.025" x2="220.975" y2="30.075" layer="94"/>
+<rectangle x1="222.725" y1="30.025" x2="224.525" y2="30.075" layer="94"/>
+<rectangle x1="226.325" y1="30.025" x2="232.825" y2="30.075" layer="94"/>
+<rectangle x1="234.675" y1="30.025" x2="240.075" y2="30.075" layer="94"/>
+<rectangle x1="241.875" y1="30.025" x2="243.375" y2="30.075" layer="94"/>
+<rectangle x1="184.125" y1="30.075" x2="188.775" y2="30.125" layer="94"/>
+<rectangle x1="190.475" y1="30.075" x2="194.225" y2="30.125" layer="94"/>
+<rectangle x1="195.875" y1="30.075" x2="197.625" y2="30.125" layer="94"/>
+<rectangle x1="199.325" y1="30.075" x2="202.325" y2="30.125" layer="94"/>
+<rectangle x1="204.025" y1="30.075" x2="206.075" y2="30.125" layer="94"/>
+<rectangle x1="207.725" y1="30.075" x2="208.975" y2="30.125" layer="94"/>
+<rectangle x1="210.675" y1="30.075" x2="212.925" y2="30.125" layer="94"/>
+<rectangle x1="217.825" y1="30.075" x2="220.975" y2="30.125" layer="94"/>
+<rectangle x1="222.725" y1="30.075" x2="224.525" y2="30.125" layer="94"/>
+<rectangle x1="226.325" y1="30.075" x2="232.825" y2="30.125" layer="94"/>
+<rectangle x1="234.675" y1="30.075" x2="240.075" y2="30.125" layer="94"/>
+<rectangle x1="241.875" y1="30.075" x2="243.375" y2="30.125" layer="94"/>
+<rectangle x1="184.125" y1="30.125" x2="188.775" y2="30.175" layer="94"/>
+<rectangle x1="190.475" y1="30.125" x2="194.225" y2="30.175" layer="94"/>
+<rectangle x1="195.875" y1="30.125" x2="197.625" y2="30.175" layer="94"/>
+<rectangle x1="199.325" y1="30.125" x2="202.325" y2="30.175" layer="94"/>
+<rectangle x1="204.025" y1="30.125" x2="206.075" y2="30.175" layer="94"/>
+<rectangle x1="207.725" y1="30.125" x2="209.025" y2="30.175" layer="94"/>
+<rectangle x1="210.675" y1="30.125" x2="212.925" y2="30.175" layer="94"/>
+<rectangle x1="217.925" y1="30.125" x2="220.975" y2="30.175" layer="94"/>
+<rectangle x1="222.725" y1="30.125" x2="224.475" y2="30.175" layer="94"/>
+<rectangle x1="226.275" y1="30.125" x2="232.825" y2="30.175" layer="94"/>
+<rectangle x1="234.675" y1="30.125" x2="240.075" y2="30.175" layer="94"/>
+<rectangle x1="241.875" y1="30.125" x2="243.375" y2="30.175" layer="94"/>
+<rectangle x1="184.125" y1="30.175" x2="188.775" y2="30.225" layer="94"/>
+<rectangle x1="190.475" y1="30.175" x2="194.225" y2="30.225" layer="94"/>
+<rectangle x1="195.875" y1="30.175" x2="197.625" y2="30.225" layer="94"/>
+<rectangle x1="199.325" y1="30.175" x2="202.325" y2="30.225" layer="94"/>
+<rectangle x1="204.025" y1="30.175" x2="206.025" y2="30.225" layer="94"/>
+<rectangle x1="207.675" y1="30.175" x2="209.025" y2="30.225" layer="94"/>
+<rectangle x1="210.725" y1="30.175" x2="212.925" y2="30.225" layer="94"/>
+<rectangle x1="218.075" y1="30.175" x2="220.975" y2="30.225" layer="94"/>
+<rectangle x1="222.725" y1="30.175" x2="224.475" y2="30.225" layer="94"/>
+<rectangle x1="226.275" y1="30.175" x2="232.825" y2="30.225" layer="94"/>
+<rectangle x1="234.625" y1="30.175" x2="240.075" y2="30.225" layer="94"/>
+<rectangle x1="241.875" y1="30.175" x2="243.375" y2="30.225" layer="94"/>
+<rectangle x1="184.125" y1="30.225" x2="188.775" y2="30.275" layer="94"/>
+<rectangle x1="190.475" y1="30.225" x2="194.225" y2="30.275" layer="94"/>
+<rectangle x1="195.875" y1="30.225" x2="197.625" y2="30.275" layer="94"/>
+<rectangle x1="199.325" y1="30.225" x2="202.325" y2="30.275" layer="94"/>
+<rectangle x1="204.025" y1="30.225" x2="206.025" y2="30.275" layer="94"/>
+<rectangle x1="207.675" y1="30.225" x2="209.025" y2="30.275" layer="94"/>
+<rectangle x1="210.725" y1="30.225" x2="212.925" y2="30.275" layer="94"/>
+<rectangle x1="218.175" y1="30.225" x2="220.975" y2="30.275" layer="94"/>
+<rectangle x1="222.725" y1="30.225" x2="224.475" y2="30.275" layer="94"/>
+<rectangle x1="226.275" y1="30.225" x2="232.825" y2="30.275" layer="94"/>
+<rectangle x1="234.625" y1="30.225" x2="240.075" y2="30.275" layer="94"/>
+<rectangle x1="241.875" y1="30.225" x2="243.375" y2="30.275" layer="94"/>
+<rectangle x1="184.125" y1="30.275" x2="188.775" y2="30.325" layer="94"/>
+<rectangle x1="190.475" y1="30.275" x2="194.225" y2="30.325" layer="94"/>
+<rectangle x1="195.875" y1="30.275" x2="197.625" y2="30.325" layer="94"/>
+<rectangle x1="199.325" y1="30.275" x2="202.325" y2="30.325" layer="94"/>
+<rectangle x1="204.025" y1="30.275" x2="206.025" y2="30.325" layer="94"/>
+<rectangle x1="207.675" y1="30.275" x2="209.075" y2="30.325" layer="94"/>
+<rectangle x1="210.775" y1="30.275" x2="212.925" y2="30.325" layer="94"/>
+<rectangle x1="218.275" y1="30.275" x2="220.975" y2="30.325" layer="94"/>
+<rectangle x1="222.725" y1="30.275" x2="224.475" y2="30.325" layer="94"/>
+<rectangle x1="226.275" y1="30.275" x2="232.825" y2="30.325" layer="94"/>
+<rectangle x1="234.625" y1="30.275" x2="240.075" y2="30.325" layer="94"/>
+<rectangle x1="241.925" y1="30.275" x2="243.375" y2="30.325" layer="94"/>
+<rectangle x1="184.125" y1="30.325" x2="188.775" y2="30.375" layer="94"/>
+<rectangle x1="190.475" y1="30.325" x2="194.225" y2="30.375" layer="94"/>
+<rectangle x1="195.875" y1="30.325" x2="197.625" y2="30.375" layer="94"/>
+<rectangle x1="199.325" y1="30.325" x2="202.325" y2="30.375" layer="94"/>
+<rectangle x1="204.025" y1="30.325" x2="205.975" y2="30.375" layer="94"/>
+<rectangle x1="207.625" y1="30.325" x2="209.075" y2="30.375" layer="94"/>
+<rectangle x1="210.775" y1="30.325" x2="212.925" y2="30.375" layer="94"/>
+<rectangle x1="218.375" y1="30.325" x2="220.975" y2="30.375" layer="94"/>
+<rectangle x1="222.725" y1="30.325" x2="224.475" y2="30.375" layer="94"/>
+<rectangle x1="226.275" y1="30.325" x2="232.825" y2="30.375" layer="94"/>
+<rectangle x1="234.625" y1="30.325" x2="240.075" y2="30.375" layer="94"/>
+<rectangle x1="241.925" y1="30.325" x2="243.375" y2="30.375" layer="94"/>
+<rectangle x1="184.125" y1="30.375" x2="188.775" y2="30.425" layer="94"/>
+<rectangle x1="190.475" y1="30.375" x2="194.225" y2="30.425" layer="94"/>
+<rectangle x1="195.875" y1="30.375" x2="197.625" y2="30.425" layer="94"/>
+<rectangle x1="199.325" y1="30.375" x2="202.325" y2="30.425" layer="94"/>
+<rectangle x1="204.025" y1="30.375" x2="205.975" y2="30.425" layer="94"/>
+<rectangle x1="207.625" y1="30.375" x2="209.125" y2="30.425" layer="94"/>
+<rectangle x1="210.775" y1="30.375" x2="212.925" y2="30.425" layer="94"/>
+<rectangle x1="218.475" y1="30.375" x2="220.975" y2="30.425" layer="94"/>
+<rectangle x1="222.725" y1="30.375" x2="224.475" y2="30.425" layer="94"/>
+<rectangle x1="226.275" y1="30.375" x2="232.825" y2="30.425" layer="94"/>
+<rectangle x1="234.625" y1="30.375" x2="240.075" y2="30.425" layer="94"/>
+<rectangle x1="241.925" y1="30.375" x2="243.375" y2="30.425" layer="94"/>
+<rectangle x1="184.125" y1="30.425" x2="188.775" y2="30.475" layer="94"/>
+<rectangle x1="190.475" y1="30.425" x2="194.225" y2="30.475" layer="94"/>
+<rectangle x1="195.875" y1="30.425" x2="197.625" y2="30.475" layer="94"/>
+<rectangle x1="199.325" y1="30.425" x2="202.325" y2="30.475" layer="94"/>
+<rectangle x1="204.025" y1="30.425" x2="205.925" y2="30.475" layer="94"/>
+<rectangle x1="207.625" y1="30.425" x2="209.125" y2="30.475" layer="94"/>
+<rectangle x1="210.825" y1="30.425" x2="212.925" y2="30.475" layer="94"/>
+<rectangle x1="218.525" y1="30.425" x2="220.975" y2="30.475" layer="94"/>
+<rectangle x1="222.725" y1="30.425" x2="224.475" y2="30.475" layer="94"/>
+<rectangle x1="226.275" y1="30.425" x2="232.775" y2="30.475" layer="94"/>
+<rectangle x1="234.625" y1="30.425" x2="240.075" y2="30.475" layer="94"/>
+<rectangle x1="241.925" y1="30.425" x2="243.375" y2="30.475" layer="94"/>
+<rectangle x1="184.125" y1="30.475" x2="188.775" y2="30.525" layer="94"/>
+<rectangle x1="190.475" y1="30.475" x2="194.225" y2="30.525" layer="94"/>
+<rectangle x1="195.875" y1="30.475" x2="197.625" y2="30.525" layer="94"/>
+<rectangle x1="199.325" y1="30.475" x2="202.325" y2="30.525" layer="94"/>
+<rectangle x1="204.025" y1="30.475" x2="205.925" y2="30.525" layer="94"/>
+<rectangle x1="207.575" y1="30.475" x2="209.125" y2="30.525" layer="94"/>
+<rectangle x1="210.825" y1="30.475" x2="212.925" y2="30.525" layer="94"/>
+<rectangle x1="218.625" y1="30.475" x2="220.975" y2="30.525" layer="94"/>
+<rectangle x1="222.725" y1="30.475" x2="224.475" y2="30.525" layer="94"/>
+<rectangle x1="226.275" y1="30.475" x2="232.775" y2="30.525" layer="94"/>
+<rectangle x1="234.625" y1="30.475" x2="240.075" y2="30.525" layer="94"/>
+<rectangle x1="241.925" y1="30.475" x2="243.375" y2="30.525" layer="94"/>
+<rectangle x1="184.125" y1="30.525" x2="188.775" y2="30.575" layer="94"/>
+<rectangle x1="190.475" y1="30.525" x2="194.225" y2="30.575" layer="94"/>
+<rectangle x1="195.875" y1="30.525" x2="197.625" y2="30.575" layer="94"/>
+<rectangle x1="199.325" y1="30.525" x2="202.325" y2="30.575" layer="94"/>
+<rectangle x1="204.025" y1="30.525" x2="205.925" y2="30.575" layer="94"/>
+<rectangle x1="207.575" y1="30.525" x2="209.175" y2="30.575" layer="94"/>
+<rectangle x1="210.825" y1="30.525" x2="212.925" y2="30.575" layer="94"/>
+<rectangle x1="218.675" y1="30.525" x2="220.975" y2="30.575" layer="94"/>
+<rectangle x1="222.725" y1="30.525" x2="224.475" y2="30.575" layer="94"/>
+<rectangle x1="226.275" y1="30.525" x2="232.775" y2="30.575" layer="94"/>
+<rectangle x1="234.625" y1="30.525" x2="240.075" y2="30.575" layer="94"/>
+<rectangle x1="241.925" y1="30.525" x2="243.375" y2="30.575" layer="94"/>
+<rectangle x1="184.125" y1="30.575" x2="188.775" y2="30.625" layer="94"/>
+<rectangle x1="190.475" y1="30.575" x2="194.225" y2="30.625" layer="94"/>
+<rectangle x1="195.875" y1="30.575" x2="197.625" y2="30.625" layer="94"/>
+<rectangle x1="199.325" y1="30.575" x2="202.325" y2="30.625" layer="94"/>
+<rectangle x1="204.025" y1="30.575" x2="205.875" y2="30.625" layer="94"/>
+<rectangle x1="207.525" y1="30.575" x2="209.175" y2="30.625" layer="94"/>
+<rectangle x1="210.875" y1="30.575" x2="212.925" y2="30.625" layer="94"/>
+<rectangle x1="218.725" y1="30.575" x2="220.975" y2="30.625" layer="94"/>
+<rectangle x1="222.725" y1="30.575" x2="224.475" y2="30.625" layer="94"/>
+<rectangle x1="226.275" y1="30.575" x2="232.775" y2="30.625" layer="94"/>
+<rectangle x1="234.625" y1="30.575" x2="240.125" y2="30.625" layer="94"/>
+<rectangle x1="241.925" y1="30.575" x2="243.375" y2="30.625" layer="94"/>
+<rectangle x1="184.125" y1="30.625" x2="188.775" y2="30.675" layer="94"/>
+<rectangle x1="190.475" y1="30.625" x2="194.225" y2="30.675" layer="94"/>
+<rectangle x1="195.875" y1="30.625" x2="197.625" y2="30.675" layer="94"/>
+<rectangle x1="199.325" y1="30.625" x2="202.325" y2="30.675" layer="94"/>
+<rectangle x1="204.025" y1="30.625" x2="205.875" y2="30.675" layer="94"/>
+<rectangle x1="207.525" y1="30.625" x2="209.175" y2="30.675" layer="94"/>
+<rectangle x1="210.875" y1="30.625" x2="212.925" y2="30.675" layer="94"/>
+<rectangle x1="218.825" y1="30.625" x2="220.975" y2="30.675" layer="94"/>
+<rectangle x1="222.725" y1="30.625" x2="224.475" y2="30.675" layer="94"/>
+<rectangle x1="226.275" y1="30.625" x2="232.775" y2="30.675" layer="94"/>
+<rectangle x1="234.625" y1="30.625" x2="240.125" y2="30.675" layer="94"/>
+<rectangle x1="241.925" y1="30.625" x2="243.375" y2="30.675" layer="94"/>
+<rectangle x1="184.125" y1="30.675" x2="188.775" y2="30.725" layer="94"/>
+<rectangle x1="190.475" y1="30.675" x2="194.225" y2="30.725" layer="94"/>
+<rectangle x1="195.875" y1="30.675" x2="197.625" y2="30.725" layer="94"/>
+<rectangle x1="199.375" y1="30.675" x2="202.325" y2="30.725" layer="94"/>
+<rectangle x1="204.025" y1="30.675" x2="205.825" y2="30.725" layer="94"/>
+<rectangle x1="207.525" y1="30.675" x2="209.225" y2="30.725" layer="94"/>
+<rectangle x1="210.925" y1="30.675" x2="212.925" y2="30.725" layer="94"/>
+<rectangle x1="218.875" y1="30.675" x2="220.975" y2="30.725" layer="94"/>
+<rectangle x1="222.725" y1="30.675" x2="224.475" y2="30.725" layer="94"/>
+<rectangle x1="226.275" y1="30.675" x2="232.775" y2="30.725" layer="94"/>
+<rectangle x1="234.625" y1="30.675" x2="240.125" y2="30.725" layer="94"/>
+<rectangle x1="241.925" y1="30.675" x2="243.375" y2="30.725" layer="94"/>
+<rectangle x1="184.125" y1="30.725" x2="188.775" y2="30.775" layer="94"/>
+<rectangle x1="190.475" y1="30.725" x2="194.225" y2="30.775" layer="94"/>
+<rectangle x1="195.875" y1="30.725" x2="197.625" y2="30.775" layer="94"/>
+<rectangle x1="199.375" y1="30.725" x2="202.325" y2="30.775" layer="94"/>
+<rectangle x1="204.025" y1="30.725" x2="205.825" y2="30.775" layer="94"/>
+<rectangle x1="207.475" y1="30.725" x2="209.225" y2="30.775" layer="94"/>
+<rectangle x1="210.925" y1="30.725" x2="212.925" y2="30.775" layer="94"/>
+<rectangle x1="218.925" y1="30.725" x2="220.975" y2="30.775" layer="94"/>
+<rectangle x1="222.725" y1="30.725" x2="224.475" y2="30.775" layer="94"/>
+<rectangle x1="226.275" y1="30.725" x2="232.775" y2="30.775" layer="94"/>
+<rectangle x1="234.625" y1="30.725" x2="240.125" y2="30.775" layer="94"/>
+<rectangle x1="241.925" y1="30.725" x2="243.375" y2="30.775" layer="94"/>
+<rectangle x1="184.125" y1="30.775" x2="188.775" y2="30.825" layer="94"/>
+<rectangle x1="190.475" y1="30.775" x2="194.225" y2="30.825" layer="94"/>
+<rectangle x1="195.875" y1="30.775" x2="197.625" y2="30.825" layer="94"/>
+<rectangle x1="199.375" y1="30.775" x2="202.325" y2="30.825" layer="94"/>
+<rectangle x1="204.025" y1="30.775" x2="205.775" y2="30.825" layer="94"/>
+<rectangle x1="207.475" y1="30.775" x2="209.225" y2="30.825" layer="94"/>
+<rectangle x1="210.925" y1="30.775" x2="212.925" y2="30.825" layer="94"/>
+<rectangle x1="218.975" y1="30.775" x2="220.975" y2="30.825" layer="94"/>
+<rectangle x1="222.725" y1="30.775" x2="224.425" y2="30.825" layer="94"/>
+<rectangle x1="226.225" y1="30.775" x2="232.775" y2="30.825" layer="94"/>
+<rectangle x1="234.625" y1="30.775" x2="240.125" y2="30.825" layer="94"/>
+<rectangle x1="241.925" y1="30.775" x2="243.375" y2="30.825" layer="94"/>
+<rectangle x1="184.125" y1="30.825" x2="188.775" y2="30.875" layer="94"/>
+<rectangle x1="190.475" y1="30.825" x2="194.225" y2="30.875" layer="94"/>
+<rectangle x1="195.875" y1="30.825" x2="197.625" y2="30.875" layer="94"/>
+<rectangle x1="199.375" y1="30.825" x2="202.325" y2="30.875" layer="94"/>
+<rectangle x1="204.025" y1="30.825" x2="205.775" y2="30.875" layer="94"/>
+<rectangle x1="207.475" y1="30.825" x2="209.275" y2="30.875" layer="94"/>
+<rectangle x1="210.975" y1="30.825" x2="212.925" y2="30.875" layer="94"/>
+<rectangle x1="218.975" y1="30.825" x2="220.975" y2="30.875" layer="94"/>
+<rectangle x1="222.725" y1="30.825" x2="224.425" y2="30.875" layer="94"/>
+<rectangle x1="226.225" y1="30.825" x2="232.775" y2="30.875" layer="94"/>
+<rectangle x1="234.625" y1="30.825" x2="240.125" y2="30.875" layer="94"/>
+<rectangle x1="241.925" y1="30.825" x2="243.375" y2="30.875" layer="94"/>
+<rectangle x1="184.125" y1="30.875" x2="188.775" y2="30.925" layer="94"/>
+<rectangle x1="190.475" y1="30.875" x2="194.225" y2="30.925" layer="94"/>
+<rectangle x1="195.875" y1="30.875" x2="197.625" y2="30.925" layer="94"/>
+<rectangle x1="199.375" y1="30.875" x2="202.325" y2="30.925" layer="94"/>
+<rectangle x1="204.025" y1="30.875" x2="205.775" y2="30.925" layer="94"/>
+<rectangle x1="207.425" y1="30.875" x2="209.275" y2="30.925" layer="94"/>
+<rectangle x1="210.975" y1="30.875" x2="212.925" y2="30.925" layer="94"/>
+<rectangle x1="219.025" y1="30.875" x2="220.975" y2="30.925" layer="94"/>
+<rectangle x1="222.725" y1="30.875" x2="224.425" y2="30.925" layer="94"/>
+<rectangle x1="226.225" y1="30.875" x2="232.775" y2="30.925" layer="94"/>
+<rectangle x1="234.625" y1="30.875" x2="240.125" y2="30.925" layer="94"/>
+<rectangle x1="241.925" y1="30.875" x2="243.375" y2="30.925" layer="94"/>
+<rectangle x1="184.125" y1="30.925" x2="188.775" y2="30.975" layer="94"/>
+<rectangle x1="190.475" y1="30.925" x2="194.225" y2="30.975" layer="94"/>
+<rectangle x1="195.875" y1="30.925" x2="197.625" y2="30.975" layer="94"/>
+<rectangle x1="199.375" y1="30.925" x2="202.325" y2="30.975" layer="94"/>
+<rectangle x1="204.025" y1="30.925" x2="205.725" y2="30.975" layer="94"/>
+<rectangle x1="207.425" y1="30.925" x2="209.275" y2="30.975" layer="94"/>
+<rectangle x1="211.025" y1="30.925" x2="212.925" y2="30.975" layer="94"/>
+<rectangle x1="219.075" y1="30.925" x2="220.975" y2="30.975" layer="94"/>
+<rectangle x1="222.725" y1="30.925" x2="224.425" y2="30.975" layer="94"/>
+<rectangle x1="226.225" y1="30.925" x2="232.775" y2="30.975" layer="94"/>
+<rectangle x1="234.625" y1="30.925" x2="240.125" y2="30.975" layer="94"/>
+<rectangle x1="241.925" y1="30.925" x2="243.375" y2="30.975" layer="94"/>
+<rectangle x1="184.125" y1="30.975" x2="188.775" y2="31.025" layer="94"/>
+<rectangle x1="190.475" y1="30.975" x2="194.225" y2="31.025" layer="94"/>
+<rectangle x1="195.875" y1="30.975" x2="197.625" y2="31.025" layer="94"/>
+<rectangle x1="199.425" y1="30.975" x2="202.325" y2="31.025" layer="94"/>
+<rectangle x1="204.025" y1="30.975" x2="205.725" y2="31.025" layer="94"/>
+<rectangle x1="207.425" y1="30.975" x2="209.325" y2="31.025" layer="94"/>
+<rectangle x1="211.025" y1="30.975" x2="212.925" y2="31.025" layer="94"/>
+<rectangle x1="219.125" y1="30.975" x2="220.975" y2="31.025" layer="94"/>
+<rectangle x1="222.725" y1="30.975" x2="224.425" y2="31.025" layer="94"/>
+<rectangle x1="226.225" y1="30.975" x2="232.775" y2="31.025" layer="94"/>
+<rectangle x1="234.625" y1="30.975" x2="240.125" y2="31.025" layer="94"/>
+<rectangle x1="241.925" y1="30.975" x2="243.375" y2="31.025" layer="94"/>
+<rectangle x1="184.125" y1="31.025" x2="188.775" y2="31.075" layer="94"/>
+<rectangle x1="190.475" y1="31.025" x2="194.225" y2="31.075" layer="94"/>
+<rectangle x1="195.875" y1="31.025" x2="197.625" y2="31.075" layer="94"/>
+<rectangle x1="199.425" y1="31.025" x2="202.325" y2="31.075" layer="94"/>
+<rectangle x1="204.025" y1="31.025" x2="205.675" y2="31.075" layer="94"/>
+<rectangle x1="207.375" y1="31.025" x2="209.325" y2="31.075" layer="94"/>
+<rectangle x1="211.025" y1="31.025" x2="212.925" y2="31.075" layer="94"/>
+<rectangle x1="219.175" y1="31.025" x2="220.975" y2="31.075" layer="94"/>
+<rectangle x1="222.725" y1="31.025" x2="224.425" y2="31.075" layer="94"/>
+<rectangle x1="226.225" y1="31.025" x2="232.775" y2="31.075" layer="94"/>
+<rectangle x1="234.625" y1="31.025" x2="240.125" y2="31.075" layer="94"/>
+<rectangle x1="241.925" y1="31.025" x2="243.375" y2="31.075" layer="94"/>
+<rectangle x1="184.125" y1="31.075" x2="188.775" y2="31.125" layer="94"/>
+<rectangle x1="190.475" y1="31.075" x2="194.225" y2="31.125" layer="94"/>
+<rectangle x1="195.875" y1="31.075" x2="197.625" y2="31.125" layer="94"/>
+<rectangle x1="199.425" y1="31.075" x2="202.275" y2="31.125" layer="94"/>
+<rectangle x1="204.025" y1="31.075" x2="205.675" y2="31.125" layer="94"/>
+<rectangle x1="207.375" y1="31.075" x2="209.325" y2="31.125" layer="94"/>
+<rectangle x1="211.075" y1="31.075" x2="212.925" y2="31.125" layer="94"/>
+<rectangle x1="219.175" y1="31.075" x2="220.975" y2="31.125" layer="94"/>
+<rectangle x1="222.725" y1="31.075" x2="224.425" y2="31.125" layer="94"/>
+<rectangle x1="226.225" y1="31.075" x2="232.775" y2="31.125" layer="94"/>
+<rectangle x1="234.625" y1="31.075" x2="240.125" y2="31.125" layer="94"/>
+<rectangle x1="241.925" y1="31.075" x2="243.375" y2="31.125" layer="94"/>
+<rectangle x1="184.125" y1="31.125" x2="188.775" y2="31.175" layer="94"/>
+<rectangle x1="190.475" y1="31.125" x2="194.225" y2="31.175" layer="94"/>
+<rectangle x1="195.875" y1="31.125" x2="197.625" y2="31.175" layer="94"/>
+<rectangle x1="199.425" y1="31.125" x2="202.275" y2="31.175" layer="94"/>
+<rectangle x1="204.025" y1="31.125" x2="205.675" y2="31.175" layer="94"/>
+<rectangle x1="207.325" y1="31.125" x2="209.375" y2="31.175" layer="94"/>
+<rectangle x1="211.075" y1="31.125" x2="212.925" y2="31.175" layer="94"/>
+<rectangle x1="214.625" y1="31.125" x2="216.375" y2="31.175" layer="94"/>
+<rectangle x1="219.225" y1="31.125" x2="220.975" y2="31.175" layer="94"/>
+<rectangle x1="222.725" y1="31.125" x2="224.425" y2="31.175" layer="94"/>
+<rectangle x1="226.225" y1="31.125" x2="232.775" y2="31.175" layer="94"/>
+<rectangle x1="234.625" y1="31.125" x2="240.125" y2="31.175" layer="94"/>
+<rectangle x1="241.925" y1="31.125" x2="243.375" y2="31.175" layer="94"/>
+<rectangle x1="184.125" y1="31.175" x2="188.775" y2="31.225" layer="94"/>
+<rectangle x1="190.475" y1="31.175" x2="194.225" y2="31.225" layer="94"/>
+<rectangle x1="195.875" y1="31.175" x2="197.625" y2="31.225" layer="94"/>
+<rectangle x1="199.425" y1="31.175" x2="202.275" y2="31.225" layer="94"/>
+<rectangle x1="203.975" y1="31.175" x2="205.625" y2="31.225" layer="94"/>
+<rectangle x1="207.325" y1="31.175" x2="209.375" y2="31.225" layer="94"/>
+<rectangle x1="211.075" y1="31.175" x2="212.925" y2="31.225" layer="94"/>
+<rectangle x1="214.625" y1="31.175" x2="216.675" y2="31.225" layer="94"/>
+<rectangle x1="219.275" y1="31.175" x2="220.975" y2="31.225" layer="94"/>
+<rectangle x1="222.725" y1="31.175" x2="224.425" y2="31.225" layer="94"/>
+<rectangle x1="226.275" y1="31.175" x2="232.775" y2="31.225" layer="94"/>
+<rectangle x1="234.625" y1="31.175" x2="240.125" y2="31.225" layer="94"/>
+<rectangle x1="241.925" y1="31.175" x2="243.375" y2="31.225" layer="94"/>
+<rectangle x1="184.125" y1="31.225" x2="188.775" y2="31.275" layer="94"/>
+<rectangle x1="190.475" y1="31.225" x2="194.225" y2="31.275" layer="94"/>
+<rectangle x1="195.875" y1="31.225" x2="197.625" y2="31.275" layer="94"/>
+<rectangle x1="199.425" y1="31.225" x2="202.275" y2="31.275" layer="94"/>
+<rectangle x1="203.975" y1="31.225" x2="205.625" y2="31.275" layer="94"/>
+<rectangle x1="207.325" y1="31.225" x2="209.375" y2="31.275" layer="94"/>
+<rectangle x1="211.125" y1="31.225" x2="212.925" y2="31.275" layer="94"/>
+<rectangle x1="214.625" y1="31.225" x2="216.875" y2="31.275" layer="94"/>
+<rectangle x1="219.275" y1="31.225" x2="220.975" y2="31.275" layer="94"/>
+<rectangle x1="222.725" y1="31.225" x2="224.425" y2="31.275" layer="94"/>
+<rectangle x1="226.275" y1="31.225" x2="232.775" y2="31.275" layer="94"/>
+<rectangle x1="234.625" y1="31.225" x2="240.125" y2="31.275" layer="94"/>
+<rectangle x1="241.925" y1="31.225" x2="243.375" y2="31.275" layer="94"/>
+<rectangle x1="184.125" y1="31.275" x2="188.775" y2="31.325" layer="94"/>
+<rectangle x1="190.475" y1="31.275" x2="194.225" y2="31.325" layer="94"/>
+<rectangle x1="195.875" y1="31.275" x2="197.625" y2="31.325" layer="94"/>
+<rectangle x1="199.475" y1="31.275" x2="202.275" y2="31.325" layer="94"/>
+<rectangle x1="203.975" y1="31.275" x2="205.575" y2="31.325" layer="94"/>
+<rectangle x1="207.275" y1="31.275" x2="209.425" y2="31.325" layer="94"/>
+<rectangle x1="211.125" y1="31.275" x2="212.925" y2="31.325" layer="94"/>
+<rectangle x1="214.625" y1="31.275" x2="217.025" y2="31.325" layer="94"/>
+<rectangle x1="219.325" y1="31.275" x2="220.975" y2="31.325" layer="94"/>
+<rectangle x1="222.725" y1="31.275" x2="224.475" y2="31.325" layer="94"/>
+<rectangle x1="226.275" y1="31.275" x2="232.775" y2="31.325" layer="94"/>
+<rectangle x1="234.625" y1="31.275" x2="240.125" y2="31.325" layer="94"/>
+<rectangle x1="241.925" y1="31.275" x2="243.375" y2="31.325" layer="94"/>
+<rectangle x1="184.125" y1="31.325" x2="188.775" y2="31.375" layer="94"/>
+<rectangle x1="190.475" y1="31.325" x2="194.225" y2="31.375" layer="94"/>
+<rectangle x1="195.875" y1="31.325" x2="197.625" y2="31.375" layer="94"/>
+<rectangle x1="199.475" y1="31.325" x2="202.225" y2="31.375" layer="94"/>
+<rectangle x1="203.975" y1="31.325" x2="205.575" y2="31.375" layer="94"/>
+<rectangle x1="207.275" y1="31.325" x2="209.425" y2="31.375" layer="94"/>
+<rectangle x1="211.175" y1="31.325" x2="212.925" y2="31.375" layer="94"/>
+<rectangle x1="214.625" y1="31.325" x2="217.175" y2="31.375" layer="94"/>
+<rectangle x1="219.325" y1="31.325" x2="220.975" y2="31.375" layer="94"/>
+<rectangle x1="222.725" y1="31.325" x2="224.475" y2="31.375" layer="94"/>
+<rectangle x1="226.275" y1="31.325" x2="232.775" y2="31.375" layer="94"/>
+<rectangle x1="234.625" y1="31.325" x2="240.125" y2="31.375" layer="94"/>
+<rectangle x1="241.925" y1="31.325" x2="243.375" y2="31.375" layer="94"/>
+<rectangle x1="184.125" y1="31.375" x2="188.775" y2="31.425" layer="94"/>
+<rectangle x1="190.475" y1="31.375" x2="194.225" y2="31.425" layer="94"/>
+<rectangle x1="195.875" y1="31.375" x2="197.625" y2="31.425" layer="94"/>
+<rectangle x1="199.525" y1="31.375" x2="202.225" y2="31.425" layer="94"/>
+<rectangle x1="203.975" y1="31.375" x2="205.575" y2="31.425" layer="94"/>
+<rectangle x1="207.275" y1="31.375" x2="209.425" y2="31.425" layer="94"/>
+<rectangle x1="211.175" y1="31.375" x2="212.925" y2="31.425" layer="94"/>
+<rectangle x1="214.625" y1="31.375" x2="217.275" y2="31.425" layer="94"/>
+<rectangle x1="219.375" y1="31.375" x2="220.975" y2="31.425" layer="94"/>
+<rectangle x1="222.725" y1="31.375" x2="224.475" y2="31.425" layer="94"/>
+<rectangle x1="226.275" y1="31.375" x2="232.775" y2="31.425" layer="94"/>
+<rectangle x1="234.625" y1="31.375" x2="240.075" y2="31.425" layer="94"/>
+<rectangle x1="241.925" y1="31.375" x2="243.375" y2="31.425" layer="94"/>
+<rectangle x1="184.125" y1="31.425" x2="188.775" y2="31.475" layer="94"/>
+<rectangle x1="190.475" y1="31.425" x2="194.225" y2="31.475" layer="94"/>
+<rectangle x1="195.875" y1="31.425" x2="197.625" y2="31.475" layer="94"/>
+<rectangle x1="199.525" y1="31.425" x2="202.225" y2="31.475" layer="94"/>
+<rectangle x1="203.975" y1="31.425" x2="205.525" y2="31.475" layer="94"/>
+<rectangle x1="207.225" y1="31.425" x2="209.475" y2="31.475" layer="94"/>
+<rectangle x1="211.175" y1="31.425" x2="212.925" y2="31.475" layer="94"/>
+<rectangle x1="214.625" y1="31.425" x2="217.325" y2="31.475" layer="94"/>
+<rectangle x1="219.375" y1="31.425" x2="220.975" y2="31.475" layer="94"/>
+<rectangle x1="222.725" y1="31.425" x2="224.475" y2="31.475" layer="94"/>
+<rectangle x1="226.275" y1="31.425" x2="232.775" y2="31.475" layer="94"/>
+<rectangle x1="234.625" y1="31.425" x2="240.075" y2="31.475" layer="94"/>
+<rectangle x1="241.925" y1="31.425" x2="243.375" y2="31.475" layer="94"/>
+<rectangle x1="184.125" y1="31.475" x2="188.775" y2="31.525" layer="94"/>
+<rectangle x1="190.475" y1="31.475" x2="194.225" y2="31.525" layer="94"/>
+<rectangle x1="195.875" y1="31.475" x2="197.625" y2="31.525" layer="94"/>
+<rectangle x1="199.575" y1="31.475" x2="202.225" y2="31.525" layer="94"/>
+<rectangle x1="203.975" y1="31.475" x2="205.525" y2="31.525" layer="94"/>
+<rectangle x1="207.225" y1="31.475" x2="209.475" y2="31.525" layer="94"/>
+<rectangle x1="211.225" y1="31.475" x2="212.925" y2="31.525" layer="94"/>
+<rectangle x1="214.625" y1="31.475" x2="217.425" y2="31.525" layer="94"/>
+<rectangle x1="219.425" y1="31.475" x2="220.975" y2="31.525" layer="94"/>
+<rectangle x1="222.725" y1="31.475" x2="224.475" y2="31.525" layer="94"/>
+<rectangle x1="226.275" y1="31.475" x2="232.775" y2="31.525" layer="94"/>
+<rectangle x1="234.625" y1="31.475" x2="240.075" y2="31.525" layer="94"/>
+<rectangle x1="241.925" y1="31.475" x2="243.375" y2="31.525" layer="94"/>
+<rectangle x1="184.125" y1="31.525" x2="188.775" y2="31.575" layer="94"/>
+<rectangle x1="190.475" y1="31.525" x2="194.225" y2="31.575" layer="94"/>
+<rectangle x1="195.875" y1="31.525" x2="197.625" y2="31.575" layer="94"/>
+<rectangle x1="199.625" y1="31.525" x2="202.175" y2="31.575" layer="94"/>
+<rectangle x1="203.975" y1="31.525" x2="205.475" y2="31.575" layer="94"/>
+<rectangle x1="207.225" y1="31.525" x2="209.475" y2="31.575" layer="94"/>
+<rectangle x1="211.225" y1="31.525" x2="212.925" y2="31.575" layer="94"/>
+<rectangle x1="214.625" y1="31.525" x2="217.475" y2="31.575" layer="94"/>
+<rectangle x1="219.425" y1="31.525" x2="220.975" y2="31.575" layer="94"/>
+<rectangle x1="222.725" y1="31.525" x2="224.475" y2="31.575" layer="94"/>
+<rectangle x1="226.275" y1="31.525" x2="232.775" y2="31.575" layer="94"/>
+<rectangle x1="234.625" y1="31.525" x2="240.075" y2="31.575" layer="94"/>
+<rectangle x1="241.925" y1="31.525" x2="243.375" y2="31.575" layer="94"/>
+<rectangle x1="184.125" y1="31.575" x2="188.775" y2="31.625" layer="94"/>
+<rectangle x1="190.475" y1="31.575" x2="194.225" y2="31.625" layer="94"/>
+<rectangle x1="195.875" y1="31.575" x2="197.625" y2="31.625" layer="94"/>
+<rectangle x1="199.675" y1="31.575" x2="202.175" y2="31.625" layer="94"/>
+<rectangle x1="203.925" y1="31.575" x2="205.475" y2="31.625" layer="94"/>
+<rectangle x1="207.175" y1="31.575" x2="209.525" y2="31.625" layer="94"/>
+<rectangle x1="211.225" y1="31.575" x2="212.925" y2="31.625" layer="94"/>
+<rectangle x1="214.625" y1="31.575" x2="217.525" y2="31.625" layer="94"/>
+<rectangle x1="219.425" y1="31.575" x2="220.975" y2="31.625" layer="94"/>
+<rectangle x1="222.725" y1="31.575" x2="224.475" y2="31.625" layer="94"/>
+<rectangle x1="226.275" y1="31.575" x2="232.825" y2="31.625" layer="94"/>
+<rectangle x1="234.625" y1="31.575" x2="240.075" y2="31.625" layer="94"/>
+<rectangle x1="241.925" y1="31.575" x2="243.375" y2="31.625" layer="94"/>
+<rectangle x1="184.125" y1="31.625" x2="188.775" y2="31.675" layer="94"/>
+<rectangle x1="190.475" y1="31.625" x2="194.225" y2="31.675" layer="94"/>
+<rectangle x1="195.875" y1="31.625" x2="197.625" y2="31.675" layer="94"/>
+<rectangle x1="199.725" y1="31.625" x2="202.125" y2="31.675" layer="94"/>
+<rectangle x1="203.925" y1="31.625" x2="205.475" y2="31.675" layer="94"/>
+<rectangle x1="207.175" y1="31.625" x2="209.525" y2="31.675" layer="94"/>
+<rectangle x1="211.275" y1="31.625" x2="212.925" y2="31.675" layer="94"/>
+<rectangle x1="214.625" y1="31.625" x2="217.575" y2="31.675" layer="94"/>
+<rectangle x1="219.475" y1="31.625" x2="220.975" y2="31.675" layer="94"/>
+<rectangle x1="222.725" y1="31.625" x2="224.475" y2="31.675" layer="94"/>
+<rectangle x1="226.275" y1="31.625" x2="232.825" y2="31.675" layer="94"/>
+<rectangle x1="234.625" y1="31.625" x2="240.075" y2="31.675" layer="94"/>
+<rectangle x1="241.925" y1="31.625" x2="243.375" y2="31.675" layer="94"/>
+<rectangle x1="184.125" y1="31.675" x2="188.775" y2="31.725" layer="94"/>
+<rectangle x1="190.475" y1="31.675" x2="194.225" y2="31.725" layer="94"/>
+<rectangle x1="195.875" y1="31.675" x2="197.625" y2="31.725" layer="94"/>
+<rectangle x1="199.775" y1="31.675" x2="202.125" y2="31.725" layer="94"/>
+<rectangle x1="203.925" y1="31.675" x2="205.425" y2="31.725" layer="94"/>
+<rectangle x1="207.125" y1="31.675" x2="209.525" y2="31.725" layer="94"/>
+<rectangle x1="211.275" y1="31.675" x2="212.925" y2="31.725" layer="94"/>
+<rectangle x1="214.625" y1="31.675" x2="217.625" y2="31.725" layer="94"/>
+<rectangle x1="219.475" y1="31.675" x2="220.975" y2="31.725" layer="94"/>
+<rectangle x1="222.725" y1="31.675" x2="224.475" y2="31.725" layer="94"/>
+<rectangle x1="226.275" y1="31.675" x2="232.825" y2="31.725" layer="94"/>
+<rectangle x1="234.625" y1="31.675" x2="240.075" y2="31.725" layer="94"/>
+<rectangle x1="241.925" y1="31.675" x2="243.375" y2="31.725" layer="94"/>
+<rectangle x1="184.125" y1="31.725" x2="188.775" y2="31.775" layer="94"/>
+<rectangle x1="190.475" y1="31.725" x2="194.225" y2="31.775" layer="94"/>
+<rectangle x1="195.875" y1="31.725" x2="197.625" y2="31.775" layer="94"/>
+<rectangle x1="199.825" y1="31.725" x2="202.075" y2="31.775" layer="94"/>
+<rectangle x1="203.925" y1="31.725" x2="205.425" y2="31.775" layer="94"/>
+<rectangle x1="207.125" y1="31.725" x2="209.575" y2="31.775" layer="94"/>
+<rectangle x1="211.325" y1="31.725" x2="212.925" y2="31.775" layer="94"/>
+<rectangle x1="214.625" y1="31.725" x2="217.675" y2="31.775" layer="94"/>
+<rectangle x1="219.475" y1="31.725" x2="220.975" y2="31.775" layer="94"/>
+<rectangle x1="222.725" y1="31.725" x2="224.475" y2="31.775" layer="94"/>
+<rectangle x1="226.275" y1="31.725" x2="232.825" y2="31.775" layer="94"/>
+<rectangle x1="234.625" y1="31.725" x2="240.075" y2="31.775" layer="94"/>
+<rectangle x1="241.875" y1="31.725" x2="243.375" y2="31.775" layer="94"/>
+<rectangle x1="184.125" y1="31.775" x2="188.775" y2="31.825" layer="94"/>
+<rectangle x1="190.475" y1="31.775" x2="194.225" y2="31.825" layer="94"/>
+<rectangle x1="195.875" y1="31.775" x2="197.625" y2="31.825" layer="94"/>
+<rectangle x1="199.875" y1="31.775" x2="202.075" y2="31.825" layer="94"/>
+<rectangle x1="203.925" y1="31.775" x2="205.375" y2="31.825" layer="94"/>
+<rectangle x1="207.125" y1="31.775" x2="209.575" y2="31.825" layer="94"/>
+<rectangle x1="211.325" y1="31.775" x2="212.925" y2="31.825" layer="94"/>
+<rectangle x1="214.625" y1="31.775" x2="217.725" y2="31.825" layer="94"/>
+<rectangle x1="219.525" y1="31.775" x2="220.975" y2="31.825" layer="94"/>
+<rectangle x1="222.725" y1="31.775" x2="224.475" y2="31.825" layer="94"/>
+<rectangle x1="226.275" y1="31.775" x2="232.825" y2="31.825" layer="94"/>
+<rectangle x1="234.675" y1="31.775" x2="240.075" y2="31.825" layer="94"/>
+<rectangle x1="241.875" y1="31.775" x2="243.375" y2="31.825" layer="94"/>
+<rectangle x1="184.125" y1="31.825" x2="188.775" y2="31.875" layer="94"/>
+<rectangle x1="190.475" y1="31.825" x2="194.225" y2="31.875" layer="94"/>
+<rectangle x1="195.875" y1="31.825" x2="197.625" y2="31.875" layer="94"/>
+<rectangle x1="199.925" y1="31.825" x2="202.025" y2="31.875" layer="94"/>
+<rectangle x1="203.875" y1="31.825" x2="205.375" y2="31.875" layer="94"/>
+<rectangle x1="207.075" y1="31.825" x2="209.575" y2="31.875" layer="94"/>
+<rectangle x1="211.325" y1="31.825" x2="212.925" y2="31.875" layer="94"/>
+<rectangle x1="214.625" y1="31.825" x2="217.725" y2="31.875" layer="94"/>
+<rectangle x1="219.525" y1="31.825" x2="220.975" y2="31.875" layer="94"/>
+<rectangle x1="222.725" y1="31.825" x2="224.475" y2="31.875" layer="94"/>
+<rectangle x1="226.325" y1="31.825" x2="232.825" y2="31.875" layer="94"/>
+<rectangle x1="234.675" y1="31.825" x2="240.075" y2="31.875" layer="94"/>
+<rectangle x1="241.875" y1="31.825" x2="243.375" y2="31.875" layer="94"/>
+<rectangle x1="184.125" y1="31.875" x2="188.775" y2="31.925" layer="94"/>
+<rectangle x1="190.475" y1="31.875" x2="194.225" y2="31.925" layer="94"/>
+<rectangle x1="195.875" y1="31.875" x2="197.625" y2="31.925" layer="94"/>
+<rectangle x1="199.975" y1="31.875" x2="201.975" y2="31.925" layer="94"/>
+<rectangle x1="203.875" y1="31.875" x2="205.325" y2="31.925" layer="94"/>
+<rectangle x1="207.075" y1="31.875" x2="209.625" y2="31.925" layer="94"/>
+<rectangle x1="211.375" y1="31.875" x2="212.925" y2="31.925" layer="94"/>
+<rectangle x1="214.625" y1="31.875" x2="217.775" y2="31.925" layer="94"/>
+<rectangle x1="219.525" y1="31.875" x2="220.975" y2="31.925" layer="94"/>
+<rectangle x1="222.725" y1="31.875" x2="224.475" y2="31.925" layer="94"/>
+<rectangle x1="226.325" y1="31.875" x2="232.825" y2="31.925" layer="94"/>
+<rectangle x1="234.675" y1="31.875" x2="240.075" y2="31.925" layer="94"/>
+<rectangle x1="241.875" y1="31.875" x2="243.375" y2="31.925" layer="94"/>
+<rectangle x1="184.125" y1="31.925" x2="188.775" y2="31.975" layer="94"/>
+<rectangle x1="190.475" y1="31.925" x2="194.225" y2="31.975" layer="94"/>
+<rectangle x1="195.875" y1="31.925" x2="197.625" y2="31.975" layer="94"/>
+<rectangle x1="200.075" y1="31.925" x2="201.975" y2="31.975" layer="94"/>
+<rectangle x1="203.875" y1="31.925" x2="205.325" y2="31.975" layer="94"/>
+<rectangle x1="207.075" y1="31.925" x2="209.625" y2="31.975" layer="94"/>
+<rectangle x1="211.375" y1="31.925" x2="212.925" y2="31.975" layer="94"/>
+<rectangle x1="214.625" y1="31.925" x2="217.775" y2="31.975" layer="94"/>
+<rectangle x1="219.575" y1="31.925" x2="220.975" y2="31.975" layer="94"/>
+<rectangle x1="222.725" y1="31.925" x2="224.525" y2="31.975" layer="94"/>
+<rectangle x1="226.325" y1="31.925" x2="232.825" y2="31.975" layer="94"/>
+<rectangle x1="234.675" y1="31.925" x2="240.025" y2="31.975" layer="94"/>
+<rectangle x1="241.875" y1="31.925" x2="243.375" y2="31.975" layer="94"/>
+<rectangle x1="184.125" y1="31.975" x2="188.775" y2="32.025" layer="94"/>
+<rectangle x1="190.475" y1="31.975" x2="194.225" y2="32.025" layer="94"/>
+<rectangle x1="195.875" y1="31.975" x2="197.625" y2="32.025" layer="94"/>
+<rectangle x1="200.175" y1="31.975" x2="201.925" y2="32.025" layer="94"/>
+<rectangle x1="203.875" y1="31.975" x2="205.325" y2="32.025" layer="94"/>
+<rectangle x1="207.025" y1="31.975" x2="209.625" y2="32.025" layer="94"/>
+<rectangle x1="211.375" y1="31.975" x2="212.925" y2="32.025" layer="94"/>
+<rectangle x1="214.625" y1="31.975" x2="217.825" y2="32.025" layer="94"/>
+<rectangle x1="219.575" y1="31.975" x2="220.975" y2="32.025" layer="94"/>
+<rectangle x1="222.725" y1="31.975" x2="224.525" y2="32.025" layer="94"/>
+<rectangle x1="226.325" y1="31.975" x2="232.825" y2="32.025" layer="94"/>
+<rectangle x1="234.675" y1="31.975" x2="240.025" y2="32.025" layer="94"/>
+<rectangle x1="241.875" y1="31.975" x2="243.375" y2="32.025" layer="94"/>
+<rectangle x1="184.125" y1="32.025" x2="188.775" y2="32.075" layer="94"/>
+<rectangle x1="190.475" y1="32.025" x2="194.225" y2="32.075" layer="94"/>
+<rectangle x1="195.875" y1="32.025" x2="197.625" y2="32.075" layer="94"/>
+<rectangle x1="200.225" y1="32.025" x2="201.825" y2="32.075" layer="94"/>
+<rectangle x1="203.825" y1="32.025" x2="205.275" y2="32.075" layer="94"/>
+<rectangle x1="207.025" y1="32.025" x2="209.675" y2="32.075" layer="94"/>
+<rectangle x1="211.425" y1="32.025" x2="212.925" y2="32.075" layer="94"/>
+<rectangle x1="214.625" y1="32.025" x2="217.825" y2="32.075" layer="94"/>
+<rectangle x1="219.575" y1="32.025" x2="220.975" y2="32.075" layer="94"/>
+<rectangle x1="222.725" y1="32.025" x2="224.525" y2="32.075" layer="94"/>
+<rectangle x1="226.325" y1="32.025" x2="232.875" y2="32.075" layer="94"/>
+<rectangle x1="234.675" y1="32.025" x2="240.025" y2="32.075" layer="94"/>
+<rectangle x1="241.875" y1="32.025" x2="243.375" y2="32.075" layer="94"/>
+<rectangle x1="184.125" y1="32.075" x2="188.775" y2="32.125" layer="94"/>
+<rectangle x1="190.475" y1="32.075" x2="194.225" y2="32.125" layer="94"/>
+<rectangle x1="195.875" y1="32.075" x2="197.625" y2="32.125" layer="94"/>
+<rectangle x1="200.325" y1="32.075" x2="201.775" y2="32.125" layer="94"/>
+<rectangle x1="203.825" y1="32.075" x2="205.275" y2="32.125" layer="94"/>
+<rectangle x1="207.025" y1="32.075" x2="209.675" y2="32.125" layer="94"/>
+<rectangle x1="211.425" y1="32.075" x2="212.925" y2="32.125" layer="94"/>
+<rectangle x1="214.625" y1="32.075" x2="217.875" y2="32.125" layer="94"/>
+<rectangle x1="219.575" y1="32.075" x2="220.975" y2="32.125" layer="94"/>
+<rectangle x1="222.725" y1="32.075" x2="224.525" y2="32.125" layer="94"/>
+<rectangle x1="226.325" y1="32.075" x2="232.875" y2="32.125" layer="94"/>
+<rectangle x1="234.675" y1="32.075" x2="240.025" y2="32.125" layer="94"/>
+<rectangle x1="241.875" y1="32.075" x2="243.375" y2="32.125" layer="94"/>
+<rectangle x1="184.125" y1="32.125" x2="188.775" y2="32.175" layer="94"/>
+<rectangle x1="190.475" y1="32.125" x2="194.225" y2="32.175" layer="94"/>
+<rectangle x1="195.875" y1="32.125" x2="197.625" y2="32.175" layer="94"/>
+<rectangle x1="200.475" y1="32.125" x2="201.675" y2="32.175" layer="94"/>
+<rectangle x1="203.775" y1="32.125" x2="205.225" y2="32.175" layer="94"/>
+<rectangle x1="206.975" y1="32.125" x2="209.675" y2="32.175" layer="94"/>
+<rectangle x1="211.475" y1="32.125" x2="212.925" y2="32.175" layer="94"/>
+<rectangle x1="214.625" y1="32.125" x2="217.875" y2="32.175" layer="94"/>
+<rectangle x1="219.575" y1="32.125" x2="220.975" y2="32.175" layer="94"/>
+<rectangle x1="222.725" y1="32.125" x2="224.525" y2="32.175" layer="94"/>
+<rectangle x1="226.375" y1="32.125" x2="232.875" y2="32.175" layer="94"/>
+<rectangle x1="234.725" y1="32.125" x2="240.025" y2="32.175" layer="94"/>
+<rectangle x1="241.825" y1="32.125" x2="243.375" y2="32.175" layer="94"/>
+<rectangle x1="184.125" y1="32.175" x2="188.775" y2="32.225" layer="94"/>
+<rectangle x1="190.475" y1="32.175" x2="194.225" y2="32.225" layer="94"/>
+<rectangle x1="195.875" y1="32.175" x2="197.625" y2="32.225" layer="94"/>
+<rectangle x1="200.675" y1="32.175" x2="201.475" y2="32.225" layer="94"/>
+<rectangle x1="203.775" y1="32.175" x2="205.225" y2="32.225" layer="94"/>
+<rectangle x1="206.975" y1="32.175" x2="209.725" y2="32.225" layer="94"/>
+<rectangle x1="211.475" y1="32.175" x2="212.925" y2="32.225" layer="94"/>
+<rectangle x1="214.625" y1="32.175" x2="217.875" y2="32.225" layer="94"/>
+<rectangle x1="219.625" y1="32.175" x2="220.975" y2="32.225" layer="94"/>
+<rectangle x1="222.725" y1="32.175" x2="224.525" y2="32.225" layer="94"/>
+<rectangle x1="226.375" y1="32.175" x2="232.875" y2="32.225" layer="94"/>
+<rectangle x1="234.725" y1="32.175" x2="240.025" y2="32.225" layer="94"/>
+<rectangle x1="241.825" y1="32.175" x2="243.375" y2="32.225" layer="94"/>
+<rectangle x1="184.125" y1="32.225" x2="188.775" y2="32.275" layer="94"/>
+<rectangle x1="190.475" y1="32.225" x2="194.225" y2="32.275" layer="94"/>
+<rectangle x1="195.875" y1="32.225" x2="197.625" y2="32.275" layer="94"/>
+<rectangle x1="203.775" y1="32.225" x2="205.225" y2="32.275" layer="94"/>
+<rectangle x1="206.925" y1="32.225" x2="209.725" y2="32.275" layer="94"/>
+<rectangle x1="211.475" y1="32.225" x2="212.925" y2="32.275" layer="94"/>
+<rectangle x1="214.625" y1="32.225" x2="217.925" y2="32.275" layer="94"/>
+<rectangle x1="219.625" y1="32.225" x2="220.975" y2="32.275" layer="94"/>
+<rectangle x1="222.725" y1="32.225" x2="224.575" y2="32.275" layer="94"/>
+<rectangle x1="226.375" y1="32.225" x2="232.875" y2="32.275" layer="94"/>
+<rectangle x1="234.725" y1="32.225" x2="239.975" y2="32.275" layer="94"/>
+<rectangle x1="241.825" y1="32.225" x2="243.375" y2="32.275" layer="94"/>
+<rectangle x1="184.125" y1="32.275" x2="188.775" y2="32.325" layer="94"/>
+<rectangle x1="190.475" y1="32.275" x2="194.225" y2="32.325" layer="94"/>
+<rectangle x1="195.875" y1="32.275" x2="197.625" y2="32.325" layer="94"/>
+<rectangle x1="203.725" y1="32.275" x2="205.175" y2="32.325" layer="94"/>
+<rectangle x1="206.925" y1="32.275" x2="209.775" y2="32.325" layer="94"/>
+<rectangle x1="211.525" y1="32.275" x2="212.925" y2="32.325" layer="94"/>
+<rectangle x1="214.625" y1="32.275" x2="217.925" y2="32.325" layer="94"/>
+<rectangle x1="219.625" y1="32.275" x2="220.975" y2="32.325" layer="94"/>
+<rectangle x1="222.725" y1="32.275" x2="224.575" y2="32.325" layer="94"/>
+<rectangle x1="226.425" y1="32.275" x2="232.925" y2="32.325" layer="94"/>
+<rectangle x1="234.725" y1="32.275" x2="239.975" y2="32.325" layer="94"/>
+<rectangle x1="241.825" y1="32.275" x2="243.375" y2="32.325" layer="94"/>
+<rectangle x1="184.125" y1="32.325" x2="188.775" y2="32.375" layer="94"/>
+<rectangle x1="190.475" y1="32.325" x2="194.225" y2="32.375" layer="94"/>
+<rectangle x1="195.875" y1="32.325" x2="197.625" y2="32.375" layer="94"/>
+<rectangle x1="203.725" y1="32.325" x2="205.175" y2="32.375" layer="94"/>
+<rectangle x1="206.925" y1="32.325" x2="209.775" y2="32.375" layer="94"/>
+<rectangle x1="211.525" y1="32.325" x2="212.925" y2="32.375" layer="94"/>
+<rectangle x1="214.625" y1="32.325" x2="217.925" y2="32.375" layer="94"/>
+<rectangle x1="219.625" y1="32.325" x2="220.975" y2="32.375" layer="94"/>
+<rectangle x1="222.725" y1="32.325" x2="224.575" y2="32.375" layer="94"/>
+<rectangle x1="226.425" y1="32.325" x2="232.925" y2="32.375" layer="94"/>
+<rectangle x1="234.775" y1="32.325" x2="239.975" y2="32.375" layer="94"/>
+<rectangle x1="241.825" y1="32.325" x2="243.375" y2="32.375" layer="94"/>
+<rectangle x1="184.125" y1="32.375" x2="188.775" y2="32.425" layer="94"/>
+<rectangle x1="190.475" y1="32.375" x2="194.225" y2="32.425" layer="94"/>
+<rectangle x1="195.875" y1="32.375" x2="197.625" y2="32.425" layer="94"/>
+<rectangle x1="203.675" y1="32.375" x2="205.125" y2="32.425" layer="94"/>
+<rectangle x1="206.875" y1="32.375" x2="209.775" y2="32.425" layer="94"/>
+<rectangle x1="211.525" y1="32.375" x2="212.925" y2="32.425" layer="94"/>
+<rectangle x1="214.625" y1="32.375" x2="217.925" y2="32.425" layer="94"/>
+<rectangle x1="219.625" y1="32.375" x2="220.975" y2="32.425" layer="94"/>
+<rectangle x1="222.725" y1="32.375" x2="224.575" y2="32.425" layer="94"/>
+<rectangle x1="226.425" y1="32.375" x2="232.925" y2="32.425" layer="94"/>
+<rectangle x1="234.775" y1="32.375" x2="239.975" y2="32.425" layer="94"/>
+<rectangle x1="241.775" y1="32.375" x2="243.375" y2="32.425" layer="94"/>
+<rectangle x1="184.125" y1="32.425" x2="188.775" y2="32.475" layer="94"/>
+<rectangle x1="190.475" y1="32.425" x2="194.225" y2="32.475" layer="94"/>
+<rectangle x1="195.875" y1="32.425" x2="197.625" y2="32.475" layer="94"/>
+<rectangle x1="203.675" y1="32.425" x2="205.125" y2="32.475" layer="94"/>
+<rectangle x1="206.875" y1="32.425" x2="209.825" y2="32.475" layer="94"/>
+<rectangle x1="211.575" y1="32.425" x2="212.925" y2="32.475" layer="94"/>
+<rectangle x1="214.625" y1="32.425" x2="217.925" y2="32.475" layer="94"/>
+<rectangle x1="219.625" y1="32.425" x2="220.975" y2="32.475" layer="94"/>
+<rectangle x1="222.725" y1="32.425" x2="224.575" y2="32.475" layer="94"/>
+<rectangle x1="226.425" y1="32.425" x2="232.925" y2="32.475" layer="94"/>
+<rectangle x1="234.775" y1="32.425" x2="239.925" y2="32.475" layer="94"/>
+<rectangle x1="241.775" y1="32.425" x2="243.375" y2="32.475" layer="94"/>
+<rectangle x1="184.125" y1="32.475" x2="188.775" y2="32.525" layer="94"/>
+<rectangle x1="190.475" y1="32.475" x2="194.225" y2="32.525" layer="94"/>
+<rectangle x1="195.875" y1="32.475" x2="197.625" y2="32.525" layer="94"/>
+<rectangle x1="199.175" y1="32.475" x2="199.225" y2="32.525" layer="94"/>
+<rectangle x1="203.625" y1="32.475" x2="205.125" y2="32.525" layer="94"/>
+<rectangle x1="206.875" y1="32.475" x2="209.825" y2="32.525" layer="94"/>
+<rectangle x1="211.575" y1="32.475" x2="212.925" y2="32.525" layer="94"/>
+<rectangle x1="214.625" y1="32.475" x2="217.925" y2="32.525" layer="94"/>
+<rectangle x1="219.625" y1="32.475" x2="220.975" y2="32.525" layer="94"/>
+<rectangle x1="222.725" y1="32.475" x2="224.625" y2="32.525" layer="94"/>
+<rectangle x1="226.475" y1="32.475" x2="232.925" y2="32.525" layer="94"/>
+<rectangle x1="234.775" y1="32.475" x2="239.925" y2="32.525" layer="94"/>
+<rectangle x1="241.775" y1="32.475" x2="243.375" y2="32.525" layer="94"/>
+<rectangle x1="184.125" y1="32.525" x2="188.775" y2="32.575" layer="94"/>
+<rectangle x1="190.475" y1="32.525" x2="194.225" y2="32.575" layer="94"/>
+<rectangle x1="195.875" y1="32.525" x2="197.625" y2="32.575" layer="94"/>
+<rectangle x1="199.175" y1="32.525" x2="199.275" y2="32.575" layer="94"/>
+<rectangle x1="203.625" y1="32.525" x2="205.075" y2="32.575" layer="94"/>
+<rectangle x1="206.825" y1="32.525" x2="209.825" y2="32.575" layer="94"/>
+<rectangle x1="211.625" y1="32.525" x2="212.925" y2="32.575" layer="94"/>
+<rectangle x1="214.625" y1="32.525" x2="217.975" y2="32.575" layer="94"/>
+<rectangle x1="219.625" y1="32.525" x2="220.975" y2="32.575" layer="94"/>
+<rectangle x1="222.725" y1="32.525" x2="224.625" y2="32.575" layer="94"/>
+<rectangle x1="226.475" y1="32.525" x2="232.925" y2="32.575" layer="94"/>
+<rectangle x1="234.825" y1="32.525" x2="239.925" y2="32.575" layer="94"/>
+<rectangle x1="241.775" y1="32.525" x2="243.375" y2="32.575" layer="94"/>
+<rectangle x1="184.125" y1="32.575" x2="188.775" y2="32.625" layer="94"/>
+<rectangle x1="190.475" y1="32.575" x2="194.225" y2="32.625" layer="94"/>
+<rectangle x1="195.875" y1="32.575" x2="197.625" y2="32.625" layer="94"/>
+<rectangle x1="199.125" y1="32.575" x2="199.325" y2="32.625" layer="94"/>
+<rectangle x1="203.575" y1="32.575" x2="205.075" y2="32.625" layer="94"/>
+<rectangle x1="206.825" y1="32.575" x2="209.875" y2="32.625" layer="94"/>
+<rectangle x1="211.625" y1="32.575" x2="212.925" y2="32.625" layer="94"/>
+<rectangle x1="214.625" y1="32.575" x2="217.975" y2="32.625" layer="94"/>
+<rectangle x1="219.625" y1="32.575" x2="220.975" y2="32.625" layer="94"/>
+<rectangle x1="222.725" y1="32.575" x2="224.625" y2="32.625" layer="94"/>
+<rectangle x1="226.475" y1="32.575" x2="232.975" y2="32.625" layer="94"/>
+<rectangle x1="234.825" y1="32.575" x2="239.875" y2="32.625" layer="94"/>
+<rectangle x1="241.775" y1="32.575" x2="243.375" y2="32.625" layer="94"/>
+<rectangle x1="184.125" y1="32.625" x2="188.775" y2="32.675" layer="94"/>
+<rectangle x1="190.475" y1="32.625" x2="194.225" y2="32.675" layer="94"/>
+<rectangle x1="195.875" y1="32.625" x2="197.625" y2="32.675" layer="94"/>
+<rectangle x1="199.125" y1="32.625" x2="199.375" y2="32.675" layer="94"/>
+<rectangle x1="203.525" y1="32.625" x2="205.025" y2="32.675" layer="94"/>
+<rectangle x1="206.825" y1="32.625" x2="209.875" y2="32.675" layer="94"/>
+<rectangle x1="211.625" y1="32.625" x2="212.925" y2="32.675" layer="94"/>
+<rectangle x1="214.625" y1="32.625" x2="217.975" y2="32.675" layer="94"/>
+<rectangle x1="219.625" y1="32.625" x2="220.975" y2="32.675" layer="94"/>
+<rectangle x1="222.725" y1="32.625" x2="224.675" y2="32.675" layer="94"/>
+<rectangle x1="226.525" y1="32.625" x2="232.975" y2="32.675" layer="94"/>
+<rectangle x1="234.825" y1="32.625" x2="239.875" y2="32.675" layer="94"/>
+<rectangle x1="241.725" y1="32.625" x2="243.375" y2="32.675" layer="94"/>
+<rectangle x1="184.125" y1="32.675" x2="188.775" y2="32.725" layer="94"/>
+<rectangle x1="190.475" y1="32.675" x2="194.225" y2="32.725" layer="94"/>
+<rectangle x1="195.875" y1="32.675" x2="197.625" y2="32.725" layer="94"/>
+<rectangle x1="199.125" y1="32.675" x2="199.425" y2="32.725" layer="94"/>
+<rectangle x1="203.475" y1="32.675" x2="205.025" y2="32.725" layer="94"/>
+<rectangle x1="206.775" y1="32.675" x2="209.875" y2="32.725" layer="94"/>
+<rectangle x1="211.675" y1="32.675" x2="212.925" y2="32.725" layer="94"/>
+<rectangle x1="214.625" y1="32.675" x2="217.975" y2="32.725" layer="94"/>
+<rectangle x1="219.625" y1="32.675" x2="220.975" y2="32.725" layer="94"/>
+<rectangle x1="222.725" y1="32.675" x2="224.675" y2="32.725" layer="94"/>
+<rectangle x1="226.525" y1="32.675" x2="232.975" y2="32.725" layer="94"/>
+<rectangle x1="234.875" y1="32.675" x2="239.875" y2="32.725" layer="94"/>
+<rectangle x1="241.725" y1="32.675" x2="243.375" y2="32.725" layer="94"/>
+<rectangle x1="184.125" y1="32.725" x2="188.775" y2="32.775" layer="94"/>
+<rectangle x1="190.475" y1="32.725" x2="194.225" y2="32.775" layer="94"/>
+<rectangle x1="195.875" y1="32.725" x2="197.625" y2="32.775" layer="94"/>
+<rectangle x1="199.125" y1="32.725" x2="199.525" y2="32.775" layer="94"/>
+<rectangle x1="203.475" y1="32.725" x2="204.975" y2="32.775" layer="94"/>
+<rectangle x1="206.775" y1="32.725" x2="209.925" y2="32.775" layer="94"/>
+<rectangle x1="211.675" y1="32.725" x2="212.925" y2="32.775" layer="94"/>
+<rectangle x1="214.625" y1="32.725" x2="217.975" y2="32.775" layer="94"/>
+<rectangle x1="219.625" y1="32.725" x2="220.975" y2="32.775" layer="94"/>
+<rectangle x1="222.725" y1="32.725" x2="224.675" y2="32.775" layer="94"/>
+<rectangle x1="226.575" y1="32.725" x2="233.025" y2="32.775" layer="94"/>
+<rectangle x1="234.875" y1="32.725" x2="239.825" y2="32.775" layer="94"/>
+<rectangle x1="241.725" y1="32.725" x2="243.375" y2="32.775" layer="94"/>
+<rectangle x1="184.125" y1="32.775" x2="188.775" y2="32.825" layer="94"/>
+<rectangle x1="190.475" y1="32.775" x2="194.225" y2="32.825" layer="94"/>
+<rectangle x1="195.875" y1="32.775" x2="197.625" y2="32.825" layer="94"/>
+<rectangle x1="199.125" y1="32.775" x2="199.575" y2="32.825" layer="94"/>
+<rectangle x1="203.425" y1="32.775" x2="204.975" y2="32.825" layer="94"/>
+<rectangle x1="206.775" y1="32.775" x2="209.925" y2="32.825" layer="94"/>
+<rectangle x1="211.725" y1="32.775" x2="212.925" y2="32.825" layer="94"/>
+<rectangle x1="214.625" y1="32.775" x2="217.975" y2="32.825" layer="94"/>
+<rectangle x1="219.625" y1="32.775" x2="220.975" y2="32.825" layer="94"/>
+<rectangle x1="222.725" y1="32.775" x2="224.675" y2="32.825" layer="94"/>
+<rectangle x1="226.575" y1="32.775" x2="233.025" y2="32.825" layer="94"/>
+<rectangle x1="234.925" y1="32.775" x2="239.825" y2="32.825" layer="94"/>
+<rectangle x1="241.675" y1="32.775" x2="243.375" y2="32.825" layer="94"/>
+<rectangle x1="184.125" y1="32.825" x2="188.775" y2="32.875" layer="94"/>
+<rectangle x1="190.475" y1="32.825" x2="194.225" y2="32.875" layer="94"/>
+<rectangle x1="195.875" y1="32.825" x2="197.625" y2="32.875" layer="94"/>
+<rectangle x1="199.075" y1="32.825" x2="199.625" y2="32.875" layer="94"/>
+<rectangle x1="203.375" y1="32.825" x2="204.975" y2="32.875" layer="94"/>
+<rectangle x1="206.725" y1="32.825" x2="209.925" y2="32.875" layer="94"/>
+<rectangle x1="211.725" y1="32.825" x2="212.925" y2="32.875" layer="94"/>
+<rectangle x1="214.625" y1="32.825" x2="217.975" y2="32.875" layer="94"/>
+<rectangle x1="219.675" y1="32.825" x2="220.975" y2="32.875" layer="94"/>
+<rectangle x1="222.725" y1="32.825" x2="224.725" y2="32.875" layer="94"/>
+<rectangle x1="226.575" y1="32.825" x2="233.025" y2="32.875" layer="94"/>
+<rectangle x1="234.925" y1="32.825" x2="239.825" y2="32.875" layer="94"/>
+<rectangle x1="241.675" y1="32.825" x2="243.375" y2="32.875" layer="94"/>
+<rectangle x1="184.125" y1="32.875" x2="188.775" y2="32.925" layer="94"/>
+<rectangle x1="190.475" y1="32.875" x2="194.225" y2="32.925" layer="94"/>
+<rectangle x1="195.875" y1="32.875" x2="197.625" y2="32.925" layer="94"/>
+<rectangle x1="199.075" y1="32.875" x2="199.725" y2="32.925" layer="94"/>
+<rectangle x1="203.325" y1="32.875" x2="204.925" y2="32.925" layer="94"/>
+<rectangle x1="206.725" y1="32.875" x2="209.975" y2="32.925" layer="94"/>
+<rectangle x1="211.725" y1="32.875" x2="212.925" y2="32.925" layer="94"/>
+<rectangle x1="214.625" y1="32.875" x2="217.975" y2="32.925" layer="94"/>
+<rectangle x1="219.675" y1="32.875" x2="220.975" y2="32.925" layer="94"/>
+<rectangle x1="222.725" y1="32.875" x2="224.725" y2="32.925" layer="94"/>
+<rectangle x1="226.625" y1="32.875" x2="233.075" y2="32.925" layer="94"/>
+<rectangle x1="234.925" y1="32.875" x2="239.775" y2="32.925" layer="94"/>
+<rectangle x1="241.675" y1="32.875" x2="243.375" y2="32.925" layer="94"/>
+<rectangle x1="184.125" y1="32.925" x2="188.775" y2="32.975" layer="94"/>
+<rectangle x1="190.475" y1="32.925" x2="194.225" y2="32.975" layer="94"/>
+<rectangle x1="195.875" y1="32.925" x2="197.625" y2="32.975" layer="94"/>
+<rectangle x1="199.075" y1="32.925" x2="199.775" y2="32.975" layer="94"/>
+<rectangle x1="203.275" y1="32.925" x2="204.925" y2="32.975" layer="94"/>
+<rectangle x1="206.675" y1="32.925" x2="209.975" y2="32.975" layer="94"/>
+<rectangle x1="211.775" y1="32.925" x2="212.925" y2="32.975" layer="94"/>
+<rectangle x1="214.625" y1="32.925" x2="217.975" y2="32.975" layer="94"/>
+<rectangle x1="219.675" y1="32.925" x2="220.975" y2="32.975" layer="94"/>
+<rectangle x1="222.725" y1="32.925" x2="224.725" y2="32.975" layer="94"/>
+<rectangle x1="226.625" y1="32.925" x2="233.075" y2="32.975" layer="94"/>
+<rectangle x1="234.975" y1="32.925" x2="239.775" y2="32.975" layer="94"/>
+<rectangle x1="241.675" y1="32.925" x2="243.375" y2="32.975" layer="94"/>
+<rectangle x1="184.125" y1="32.975" x2="188.775" y2="33.025" layer="94"/>
+<rectangle x1="190.475" y1="32.975" x2="194.225" y2="33.025" layer="94"/>
+<rectangle x1="195.875" y1="32.975" x2="197.625" y2="33.025" layer="94"/>
+<rectangle x1="199.075" y1="32.975" x2="199.875" y2="33.025" layer="94"/>
+<rectangle x1="203.225" y1="32.975" x2="204.875" y2="33.025" layer="94"/>
+<rectangle x1="206.675" y1="32.975" x2="209.975" y2="33.025" layer="94"/>
+<rectangle x1="211.775" y1="32.975" x2="212.925" y2="33.025" layer="94"/>
+<rectangle x1="214.625" y1="32.975" x2="217.975" y2="33.025" layer="94"/>
+<rectangle x1="219.625" y1="32.975" x2="220.975" y2="33.025" layer="94"/>
+<rectangle x1="222.725" y1="32.975" x2="224.775" y2="33.025" layer="94"/>
+<rectangle x1="226.675" y1="32.975" x2="233.075" y2="33.025" layer="94"/>
+<rectangle x1="234.975" y1="32.975" x2="239.725" y2="33.025" layer="94"/>
+<rectangle x1="241.625" y1="32.975" x2="243.375" y2="33.025" layer="94"/>
+<rectangle x1="184.125" y1="33.025" x2="188.775" y2="33.075" layer="94"/>
+<rectangle x1="190.475" y1="33.025" x2="194.225" y2="33.075" layer="94"/>
+<rectangle x1="195.875" y1="33.025" x2="197.625" y2="33.075" layer="94"/>
+<rectangle x1="199.075" y1="33.025" x2="199.925" y2="33.075" layer="94"/>
+<rectangle x1="203.175" y1="33.025" x2="204.875" y2="33.075" layer="94"/>
+<rectangle x1="206.675" y1="33.025" x2="210.025" y2="33.075" layer="94"/>
+<rectangle x1="211.775" y1="33.025" x2="212.925" y2="33.075" layer="94"/>
+<rectangle x1="214.625" y1="33.025" x2="217.975" y2="33.075" layer="94"/>
+<rectangle x1="219.625" y1="33.025" x2="220.975" y2="33.075" layer="94"/>
+<rectangle x1="222.725" y1="33.025" x2="224.775" y2="33.075" layer="94"/>
+<rectangle x1="226.675" y1="33.025" x2="233.075" y2="33.075" layer="94"/>
+<rectangle x1="235.025" y1="33.025" x2="239.725" y2="33.075" layer="94"/>
+<rectangle x1="241.625" y1="33.025" x2="243.375" y2="33.075" layer="94"/>
+<rectangle x1="184.125" y1="33.075" x2="188.775" y2="33.125" layer="94"/>
+<rectangle x1="190.475" y1="33.075" x2="194.225" y2="33.125" layer="94"/>
+<rectangle x1="195.875" y1="33.075" x2="197.625" y2="33.125" layer="94"/>
+<rectangle x1="199.025" y1="33.075" x2="200.025" y2="33.125" layer="94"/>
+<rectangle x1="203.075" y1="33.075" x2="204.875" y2="33.125" layer="94"/>
+<rectangle x1="206.625" y1="33.075" x2="210.025" y2="33.125" layer="94"/>
+<rectangle x1="211.825" y1="33.075" x2="212.925" y2="33.125" layer="94"/>
+<rectangle x1="214.625" y1="33.075" x2="217.975" y2="33.125" layer="94"/>
+<rectangle x1="219.625" y1="33.075" x2="220.975" y2="33.125" layer="94"/>
+<rectangle x1="222.725" y1="33.075" x2="224.825" y2="33.125" layer="94"/>
+<rectangle x1="226.725" y1="33.075" x2="233.125" y2="33.125" layer="94"/>
+<rectangle x1="235.025" y1="33.075" x2="239.675" y2="33.125" layer="94"/>
+<rectangle x1="241.625" y1="33.075" x2="243.375" y2="33.125" layer="94"/>
+<rectangle x1="184.125" y1="33.125" x2="188.775" y2="33.175" layer="94"/>
+<rectangle x1="190.475" y1="33.125" x2="194.225" y2="33.175" layer="94"/>
+<rectangle x1="195.875" y1="33.125" x2="197.625" y2="33.175" layer="94"/>
+<rectangle x1="199.025" y1="33.125" x2="200.125" y2="33.175" layer="94"/>
+<rectangle x1="203.025" y1="33.125" x2="204.825" y2="33.175" layer="94"/>
+<rectangle x1="206.625" y1="33.125" x2="210.025" y2="33.175" layer="94"/>
+<rectangle x1="211.825" y1="33.125" x2="212.925" y2="33.175" layer="94"/>
+<rectangle x1="214.625" y1="33.125" x2="217.925" y2="33.175" layer="94"/>
+<rectangle x1="219.625" y1="33.125" x2="220.975" y2="33.175" layer="94"/>
+<rectangle x1="222.725" y1="33.125" x2="224.825" y2="33.175" layer="94"/>
+<rectangle x1="226.775" y1="33.125" x2="233.125" y2="33.175" layer="94"/>
+<rectangle x1="235.075" y1="33.125" x2="239.675" y2="33.175" layer="94"/>
+<rectangle x1="241.575" y1="33.125" x2="243.375" y2="33.175" layer="94"/>
+<rectangle x1="184.125" y1="33.175" x2="188.775" y2="33.225" layer="94"/>
+<rectangle x1="190.475" y1="33.175" x2="194.225" y2="33.225" layer="94"/>
+<rectangle x1="195.875" y1="33.175" x2="197.625" y2="33.225" layer="94"/>
+<rectangle x1="199.025" y1="33.175" x2="200.225" y2="33.225" layer="94"/>
+<rectangle x1="202.925" y1="33.175" x2="204.825" y2="33.225" layer="94"/>
+<rectangle x1="206.625" y1="33.175" x2="210.075" y2="33.225" layer="94"/>
+<rectangle x1="211.875" y1="33.175" x2="212.925" y2="33.225" layer="94"/>
+<rectangle x1="214.625" y1="33.175" x2="217.925" y2="33.225" layer="94"/>
+<rectangle x1="219.625" y1="33.175" x2="220.975" y2="33.225" layer="94"/>
+<rectangle x1="222.725" y1="33.175" x2="224.825" y2="33.225" layer="94"/>
+<rectangle x1="226.775" y1="33.175" x2="233.175" y2="33.225" layer="94"/>
+<rectangle x1="235.075" y1="33.175" x2="239.625" y2="33.225" layer="94"/>
+<rectangle x1="241.575" y1="33.175" x2="243.375" y2="33.225" layer="94"/>
+<rectangle x1="184.125" y1="33.225" x2="188.775" y2="33.275" layer="94"/>
+<rectangle x1="190.475" y1="33.225" x2="194.225" y2="33.275" layer="94"/>
+<rectangle x1="195.875" y1="33.225" x2="197.625" y2="33.275" layer="94"/>
+<rectangle x1="199.025" y1="33.225" x2="200.325" y2="33.275" layer="94"/>
+<rectangle x1="202.825" y1="33.225" x2="204.775" y2="33.275" layer="94"/>
+<rectangle x1="206.575" y1="33.225" x2="210.075" y2="33.275" layer="94"/>
+<rectangle x1="211.875" y1="33.225" x2="212.925" y2="33.275" layer="94"/>
+<rectangle x1="214.625" y1="33.225" x2="217.925" y2="33.275" layer="94"/>
+<rectangle x1="219.625" y1="33.225" x2="220.975" y2="33.275" layer="94"/>
+<rectangle x1="222.725" y1="33.225" x2="224.875" y2="33.275" layer="94"/>
+<rectangle x1="226.825" y1="33.225" x2="233.175" y2="33.275" layer="94"/>
+<rectangle x1="235.125" y1="33.225" x2="239.625" y2="33.275" layer="94"/>
+<rectangle x1="241.525" y1="33.225" x2="243.375" y2="33.275" layer="94"/>
+<rectangle x1="184.125" y1="33.275" x2="188.775" y2="33.325" layer="94"/>
+<rectangle x1="190.475" y1="33.275" x2="194.225" y2="33.325" layer="94"/>
+<rectangle x1="195.875" y1="33.275" x2="197.625" y2="33.325" layer="94"/>
+<rectangle x1="198.975" y1="33.275" x2="200.425" y2="33.325" layer="94"/>
+<rectangle x1="202.725" y1="33.275" x2="204.775" y2="33.325" layer="94"/>
+<rectangle x1="206.575" y1="33.275" x2="210.075" y2="33.325" layer="94"/>
+<rectangle x1="211.875" y1="33.275" x2="212.925" y2="33.325" layer="94"/>
+<rectangle x1="214.625" y1="33.275" x2="217.925" y2="33.325" layer="94"/>
+<rectangle x1="219.625" y1="33.275" x2="220.975" y2="33.325" layer="94"/>
+<rectangle x1="222.725" y1="33.275" x2="224.875" y2="33.325" layer="94"/>
+<rectangle x1="226.875" y1="33.275" x2="233.175" y2="33.325" layer="94"/>
+<rectangle x1="235.125" y1="33.275" x2="239.575" y2="33.325" layer="94"/>
+<rectangle x1="241.525" y1="33.275" x2="243.375" y2="33.325" layer="94"/>
+<rectangle x1="184.125" y1="33.325" x2="188.775" y2="33.375" layer="94"/>
+<rectangle x1="190.475" y1="33.325" x2="200.575" y2="33.375" layer="94"/>
+<rectangle x1="202.625" y1="33.325" x2="212.925" y2="33.375" layer="94"/>
+<rectangle x1="214.625" y1="33.325" x2="217.925" y2="33.375" layer="94"/>
+<rectangle x1="219.625" y1="33.325" x2="220.975" y2="33.375" layer="94"/>
+<rectangle x1="222.725" y1="33.325" x2="224.925" y2="33.375" layer="94"/>
+<rectangle x1="226.875" y1="33.325" x2="233.225" y2="33.375" layer="94"/>
+<rectangle x1="235.175" y1="33.325" x2="239.525" y2="33.375" layer="94"/>
+<rectangle x1="241.475" y1="33.325" x2="243.375" y2="33.375" layer="94"/>
+<rectangle x1="184.125" y1="33.375" x2="188.775" y2="33.425" layer="94"/>
+<rectangle x1="190.475" y1="33.375" x2="200.725" y2="33.425" layer="94"/>
+<rectangle x1="202.475" y1="33.375" x2="212.925" y2="33.425" layer="94"/>
+<rectangle x1="214.625" y1="33.375" x2="217.875" y2="33.425" layer="94"/>
+<rectangle x1="219.625" y1="33.375" x2="220.975" y2="33.425" layer="94"/>
+<rectangle x1="222.725" y1="33.375" x2="224.925" y2="33.425" layer="94"/>
+<rectangle x1="226.925" y1="33.375" x2="233.225" y2="33.425" layer="94"/>
+<rectangle x1="235.225" y1="33.375" x2="239.525" y2="33.425" layer="94"/>
+<rectangle x1="241.475" y1="33.375" x2="243.375" y2="33.425" layer="94"/>
+<rectangle x1="184.125" y1="33.425" x2="188.775" y2="33.475" layer="94"/>
+<rectangle x1="190.475" y1="33.425" x2="200.925" y2="33.475" layer="94"/>
+<rectangle x1="202.275" y1="33.425" x2="212.925" y2="33.475" layer="94"/>
+<rectangle x1="214.625" y1="33.425" x2="217.875" y2="33.475" layer="94"/>
+<rectangle x1="219.625" y1="33.425" x2="220.975" y2="33.475" layer="94"/>
+<rectangle x1="222.725" y1="33.425" x2="224.975" y2="33.475" layer="94"/>
+<rectangle x1="226.975" y1="33.425" x2="233.275" y2="33.475" layer="94"/>
+<rectangle x1="235.275" y1="33.425" x2="239.475" y2="33.475" layer="94"/>
+<rectangle x1="241.475" y1="33.425" x2="243.375" y2="33.475" layer="94"/>
+<rectangle x1="184.125" y1="33.475" x2="188.775" y2="33.525" layer="94"/>
+<rectangle x1="190.475" y1="33.475" x2="201.225" y2="33.525" layer="94"/>
+<rectangle x1="201.825" y1="33.475" x2="212.925" y2="33.525" layer="94"/>
+<rectangle x1="214.625" y1="33.475" x2="217.875" y2="33.525" layer="94"/>
+<rectangle x1="219.575" y1="33.475" x2="220.975" y2="33.525" layer="94"/>
+<rectangle x1="222.725" y1="33.475" x2="224.975" y2="33.525" layer="94"/>
+<rectangle x1="226.975" y1="33.475" x2="233.275" y2="33.525" layer="94"/>
+<rectangle x1="235.275" y1="33.475" x2="239.425" y2="33.525" layer="94"/>
+<rectangle x1="241.425" y1="33.475" x2="243.375" y2="33.525" layer="94"/>
+<rectangle x1="184.125" y1="33.525" x2="188.775" y2="33.575" layer="94"/>
+<rectangle x1="190.475" y1="33.525" x2="212.925" y2="33.575" layer="94"/>
+<rectangle x1="214.625" y1="33.525" x2="217.825" y2="33.575" layer="94"/>
+<rectangle x1="219.575" y1="33.525" x2="220.975" y2="33.575" layer="94"/>
+<rectangle x1="222.725" y1="33.525" x2="225.025" y2="33.575" layer="94"/>
+<rectangle x1="227.025" y1="33.525" x2="233.325" y2="33.575" layer="94"/>
+<rectangle x1="235.325" y1="33.525" x2="239.425" y2="33.575" layer="94"/>
+<rectangle x1="241.425" y1="33.525" x2="243.375" y2="33.575" layer="94"/>
+<rectangle x1="184.125" y1="33.575" x2="188.775" y2="33.625" layer="94"/>
+<rectangle x1="190.475" y1="33.575" x2="212.925" y2="33.625" layer="94"/>
+<rectangle x1="214.625" y1="33.575" x2="217.825" y2="33.625" layer="94"/>
+<rectangle x1="219.575" y1="33.575" x2="220.975" y2="33.625" layer="94"/>
+<rectangle x1="222.725" y1="33.575" x2="225.025" y2="33.625" layer="94"/>
+<rectangle x1="227.075" y1="33.575" x2="233.325" y2="33.625" layer="94"/>
+<rectangle x1="235.375" y1="33.575" x2="239.375" y2="33.625" layer="94"/>
+<rectangle x1="241.375" y1="33.575" x2="243.375" y2="33.625" layer="94"/>
+<rectangle x1="184.125" y1="33.625" x2="188.775" y2="33.675" layer="94"/>
+<rectangle x1="190.475" y1="33.625" x2="212.925" y2="33.675" layer="94"/>
+<rectangle x1="214.625" y1="33.625" x2="217.775" y2="33.675" layer="94"/>
+<rectangle x1="219.575" y1="33.625" x2="220.975" y2="33.675" layer="94"/>
+<rectangle x1="222.725" y1="33.625" x2="225.075" y2="33.675" layer="94"/>
+<rectangle x1="227.125" y1="33.625" x2="233.375" y2="33.675" layer="94"/>
+<rectangle x1="235.425" y1="33.625" x2="239.325" y2="33.675" layer="94"/>
+<rectangle x1="241.375" y1="33.625" x2="243.375" y2="33.675" layer="94"/>
+<rectangle x1="184.125" y1="33.675" x2="188.775" y2="33.725" layer="94"/>
+<rectangle x1="190.475" y1="33.675" x2="212.925" y2="33.725" layer="94"/>
+<rectangle x1="214.625" y1="33.675" x2="217.725" y2="33.725" layer="94"/>
+<rectangle x1="219.575" y1="33.675" x2="220.975" y2="33.725" layer="94"/>
+<rectangle x1="222.725" y1="33.675" x2="225.075" y2="33.725" layer="94"/>
+<rectangle x1="227.175" y1="33.675" x2="233.375" y2="33.725" layer="94"/>
+<rectangle x1="235.475" y1="33.675" x2="239.275" y2="33.725" layer="94"/>
+<rectangle x1="241.325" y1="33.675" x2="243.375" y2="33.725" layer="94"/>
+<rectangle x1="184.125" y1="33.725" x2="188.775" y2="33.775" layer="94"/>
+<rectangle x1="190.475" y1="33.725" x2="212.925" y2="33.775" layer="94"/>
+<rectangle x1="214.625" y1="33.725" x2="217.725" y2="33.775" layer="94"/>
+<rectangle x1="219.525" y1="33.725" x2="220.975" y2="33.775" layer="94"/>
+<rectangle x1="222.725" y1="33.725" x2="225.125" y2="33.775" layer="94"/>
+<rectangle x1="227.225" y1="33.725" x2="233.425" y2="33.775" layer="94"/>
+<rectangle x1="235.525" y1="33.725" x2="239.225" y2="33.775" layer="94"/>
+<rectangle x1="241.325" y1="33.725" x2="243.375" y2="33.775" layer="94"/>
+<rectangle x1="184.125" y1="33.775" x2="188.775" y2="33.825" layer="94"/>
+<rectangle x1="190.475" y1="33.775" x2="212.925" y2="33.825" layer="94"/>
+<rectangle x1="214.625" y1="33.775" x2="217.675" y2="33.825" layer="94"/>
+<rectangle x1="219.525" y1="33.775" x2="220.975" y2="33.825" layer="94"/>
+<rectangle x1="222.725" y1="33.775" x2="225.125" y2="33.825" layer="94"/>
+<rectangle x1="227.275" y1="33.775" x2="231.175" y2="33.825" layer="94"/>
+<rectangle x1="231.275" y1="33.775" x2="233.425" y2="33.825" layer="94"/>
+<rectangle x1="235.575" y1="33.775" x2="239.175" y2="33.825" layer="94"/>
+<rectangle x1="241.275" y1="33.775" x2="243.375" y2="33.825" layer="94"/>
+<rectangle x1="184.125" y1="33.825" x2="188.775" y2="33.875" layer="94"/>
+<rectangle x1="190.475" y1="33.825" x2="212.925" y2="33.875" layer="94"/>
+<rectangle x1="214.625" y1="33.825" x2="217.625" y2="33.875" layer="94"/>
+<rectangle x1="219.525" y1="33.825" x2="220.975" y2="33.875" layer="94"/>
+<rectangle x1="222.725" y1="33.825" x2="225.175" y2="33.875" layer="94"/>
+<rectangle x1="227.325" y1="33.825" x2="231.075" y2="33.875" layer="94"/>
+<rectangle x1="231.275" y1="33.825" x2="233.475" y2="33.875" layer="94"/>
+<rectangle x1="235.625" y1="33.825" x2="239.125" y2="33.875" layer="94"/>
+<rectangle x1="241.225" y1="33.825" x2="243.375" y2="33.875" layer="94"/>
+<rectangle x1="184.125" y1="33.875" x2="188.775" y2="33.925" layer="94"/>
+<rectangle x1="190.475" y1="33.875" x2="212.925" y2="33.925" layer="94"/>
+<rectangle x1="214.625" y1="33.875" x2="217.575" y2="33.925" layer="94"/>
+<rectangle x1="219.475" y1="33.875" x2="220.975" y2="33.925" layer="94"/>
+<rectangle x1="222.725" y1="33.875" x2="225.225" y2="33.925" layer="94"/>
+<rectangle x1="227.425" y1="33.875" x2="230.975" y2="33.925" layer="94"/>
+<rectangle x1="231.325" y1="33.875" x2="233.525" y2="33.925" layer="94"/>
+<rectangle x1="235.675" y1="33.875" x2="239.075" y2="33.925" layer="94"/>
+<rectangle x1="241.225" y1="33.875" x2="243.375" y2="33.925" layer="94"/>
+<rectangle x1="184.125" y1="33.925" x2="188.775" y2="33.975" layer="94"/>
+<rectangle x1="190.475" y1="33.925" x2="212.925" y2="33.975" layer="94"/>
+<rectangle x1="214.625" y1="33.925" x2="217.525" y2="33.975" layer="94"/>
+<rectangle x1="219.475" y1="33.925" x2="220.975" y2="33.975" layer="94"/>
+<rectangle x1="222.725" y1="33.925" x2="225.225" y2="33.975" layer="94"/>
+<rectangle x1="227.475" y1="33.925" x2="230.875" y2="33.975" layer="94"/>
+<rectangle x1="231.325" y1="33.925" x2="233.525" y2="33.975" layer="94"/>
+<rectangle x1="235.725" y1="33.925" x2="238.975" y2="33.975" layer="94"/>
+<rectangle x1="241.175" y1="33.925" x2="243.375" y2="33.975" layer="94"/>
+<rectangle x1="184.125" y1="33.975" x2="188.775" y2="34.025" layer="94"/>
+<rectangle x1="190.475" y1="33.975" x2="212.925" y2="34.025" layer="94"/>
+<rectangle x1="214.625" y1="33.975" x2="217.475" y2="34.025" layer="94"/>
+<rectangle x1="219.475" y1="33.975" x2="220.975" y2="34.025" layer="94"/>
+<rectangle x1="222.725" y1="33.975" x2="225.275" y2="34.025" layer="94"/>
+<rectangle x1="227.525" y1="33.975" x2="230.775" y2="34.025" layer="94"/>
+<rectangle x1="231.325" y1="33.975" x2="233.575" y2="34.025" layer="94"/>
+<rectangle x1="235.825" y1="33.975" x2="238.925" y2="34.025" layer="94"/>
+<rectangle x1="241.125" y1="33.975" x2="243.375" y2="34.025" layer="94"/>
+<rectangle x1="184.125" y1="34.025" x2="188.775" y2="34.075" layer="94"/>
+<rectangle x1="190.475" y1="34.025" x2="212.925" y2="34.075" layer="94"/>
+<rectangle x1="214.625" y1="34.025" x2="217.425" y2="34.075" layer="94"/>
+<rectangle x1="219.425" y1="34.025" x2="220.975" y2="34.075" layer="94"/>
+<rectangle x1="222.725" y1="34.025" x2="225.325" y2="34.075" layer="94"/>
+<rectangle x1="227.625" y1="34.025" x2="230.675" y2="34.075" layer="94"/>
+<rectangle x1="231.375" y1="34.025" x2="233.625" y2="34.075" layer="94"/>
+<rectangle x1="235.875" y1="34.025" x2="238.875" y2="34.075" layer="94"/>
+<rectangle x1="241.125" y1="34.025" x2="243.375" y2="34.075" layer="94"/>
+<rectangle x1="184.125" y1="34.075" x2="188.775" y2="34.125" layer="94"/>
+<rectangle x1="190.475" y1="34.075" x2="212.925" y2="34.125" layer="94"/>
+<rectangle x1="214.625" y1="34.075" x2="217.325" y2="34.125" layer="94"/>
+<rectangle x1="219.425" y1="34.075" x2="220.975" y2="34.125" layer="94"/>
+<rectangle x1="222.725" y1="34.075" x2="225.375" y2="34.125" layer="94"/>
+<rectangle x1="227.725" y1="34.075" x2="230.575" y2="34.125" layer="94"/>
+<rectangle x1="231.375" y1="34.075" x2="233.625" y2="34.125" layer="94"/>
+<rectangle x1="235.975" y1="34.075" x2="238.775" y2="34.125" layer="94"/>
+<rectangle x1="241.075" y1="34.075" x2="243.375" y2="34.125" layer="94"/>
+<rectangle x1="184.125" y1="34.125" x2="188.775" y2="34.175" layer="94"/>
+<rectangle x1="190.475" y1="34.125" x2="212.925" y2="34.175" layer="94"/>
+<rectangle x1="214.625" y1="34.125" x2="217.275" y2="34.175" layer="94"/>
+<rectangle x1="219.425" y1="34.125" x2="220.975" y2="34.175" layer="94"/>
+<rectangle x1="222.725" y1="34.125" x2="225.375" y2="34.175" layer="94"/>
+<rectangle x1="227.825" y1="34.125" x2="230.425" y2="34.175" layer="94"/>
+<rectangle x1="231.425" y1="34.125" x2="233.675" y2="34.175" layer="94"/>
+<rectangle x1="236.075" y1="34.125" x2="238.675" y2="34.175" layer="94"/>
+<rectangle x1="241.025" y1="34.125" x2="243.375" y2="34.175" layer="94"/>
+<rectangle x1="184.125" y1="34.175" x2="188.775" y2="34.225" layer="94"/>
+<rectangle x1="190.475" y1="34.175" x2="212.925" y2="34.225" layer="94"/>
+<rectangle x1="214.625" y1="34.175" x2="217.175" y2="34.225" layer="94"/>
+<rectangle x1="219.375" y1="34.175" x2="220.975" y2="34.225" layer="94"/>
+<rectangle x1="222.725" y1="34.175" x2="225.425" y2="34.225" layer="94"/>
+<rectangle x1="227.925" y1="34.175" x2="230.275" y2="34.225" layer="94"/>
+<rectangle x1="231.425" y1="34.175" x2="233.725" y2="34.225" layer="94"/>
+<rectangle x1="236.175" y1="34.175" x2="238.575" y2="34.225" layer="94"/>
+<rectangle x1="241.025" y1="34.175" x2="243.375" y2="34.225" layer="94"/>
+<rectangle x1="184.125" y1="34.225" x2="188.775" y2="34.275" layer="94"/>
+<rectangle x1="190.475" y1="34.225" x2="212.925" y2="34.275" layer="94"/>
+<rectangle x1="214.625" y1="34.225" x2="217.075" y2="34.275" layer="94"/>
+<rectangle x1="219.325" y1="34.225" x2="220.975" y2="34.275" layer="94"/>
+<rectangle x1="222.725" y1="34.225" x2="225.475" y2="34.275" layer="94"/>
+<rectangle x1="228.025" y1="34.225" x2="230.175" y2="34.275" layer="94"/>
+<rectangle x1="231.475" y1="34.225" x2="233.775" y2="34.275" layer="94"/>
+<rectangle x1="236.275" y1="34.225" x2="238.425" y2="34.275" layer="94"/>
+<rectangle x1="240.975" y1="34.225" x2="243.375" y2="34.275" layer="94"/>
+<rectangle x1="184.125" y1="34.275" x2="188.725" y2="34.325" layer="94"/>
+<rectangle x1="190.525" y1="34.275" x2="212.925" y2="34.325" layer="94"/>
+<rectangle x1="214.625" y1="34.275" x2="216.925" y2="34.325" layer="94"/>
+<rectangle x1="219.325" y1="34.275" x2="220.975" y2="34.325" layer="94"/>
+<rectangle x1="222.725" y1="34.275" x2="225.525" y2="34.325" layer="94"/>
+<rectangle x1="228.175" y1="34.275" x2="229.975" y2="34.325" layer="94"/>
+<rectangle x1="231.475" y1="34.275" x2="233.775" y2="34.325" layer="94"/>
+<rectangle x1="236.425" y1="34.275" x2="238.325" y2="34.325" layer="94"/>
+<rectangle x1="240.925" y1="34.275" x2="243.375" y2="34.325" layer="94"/>
+<rectangle x1="184.125" y1="34.325" x2="186.025" y2="34.375" layer="94"/>
+<rectangle x1="193.225" y1="34.325" x2="212.925" y2="34.375" layer="94"/>
+<rectangle x1="214.625" y1="34.325" x2="216.725" y2="34.375" layer="94"/>
+<rectangle x1="219.275" y1="34.325" x2="220.975" y2="34.375" layer="94"/>
+<rectangle x1="222.725" y1="34.325" x2="225.575" y2="34.375" layer="94"/>
+<rectangle x1="228.375" y1="34.325" x2="229.725" y2="34.375" layer="94"/>
+<rectangle x1="231.475" y1="34.325" x2="233.825" y2="34.375" layer="94"/>
+<rectangle x1="236.625" y1="34.325" x2="238.125" y2="34.375" layer="94"/>
+<rectangle x1="240.875" y1="34.325" x2="243.375" y2="34.375" layer="94"/>
+<rectangle x1="184.125" y1="34.375" x2="186.025" y2="34.425" layer="94"/>
+<rectangle x1="193.225" y1="34.375" x2="194.225" y2="34.425" layer="94"/>
+<rectangle x1="195.875" y1="34.375" x2="212.925" y2="34.425" layer="94"/>
+<rectangle x1="214.625" y1="34.375" x2="216.475" y2="34.425" layer="94"/>
+<rectangle x1="219.275" y1="34.375" x2="220.975" y2="34.425" layer="94"/>
+<rectangle x1="222.725" y1="34.375" x2="225.625" y2="34.425" layer="94"/>
+<rectangle x1="228.675" y1="34.375" x2="229.375" y2="34.425" layer="94"/>
+<rectangle x1="231.525" y1="34.375" x2="233.875" y2="34.425" layer="94"/>
+<rectangle x1="236.925" y1="34.375" x2="237.825" y2="34.425" layer="94"/>
+<rectangle x1="240.825" y1="34.375" x2="243.375" y2="34.425" layer="94"/>
+<rectangle x1="184.125" y1="34.425" x2="186.025" y2="34.475" layer="94"/>
+<rectangle x1="193.225" y1="34.425" x2="194.225" y2="34.475" layer="94"/>
+<rectangle x1="195.875" y1="34.425" x2="212.925" y2="34.475" layer="94"/>
+<rectangle x1="219.225" y1="34.425" x2="220.975" y2="34.475" layer="94"/>
+<rectangle x1="222.725" y1="34.425" x2="225.625" y2="34.475" layer="94"/>
+<rectangle x1="231.525" y1="34.425" x2="233.925" y2="34.475" layer="94"/>
+<rectangle x1="240.775" y1="34.425" x2="243.375" y2="34.475" layer="94"/>
+<rectangle x1="184.125" y1="34.475" x2="186.025" y2="34.525" layer="94"/>
+<rectangle x1="193.225" y1="34.475" x2="194.225" y2="34.525" layer="94"/>
+<rectangle x1="195.875" y1="34.475" x2="212.925" y2="34.525" layer="94"/>
+<rectangle x1="219.225" y1="34.475" x2="220.975" y2="34.525" layer="94"/>
+<rectangle x1="222.725" y1="34.475" x2="225.675" y2="34.525" layer="94"/>
+<rectangle x1="231.575" y1="34.475" x2="233.975" y2="34.525" layer="94"/>
+<rectangle x1="240.775" y1="34.475" x2="243.325" y2="34.525" layer="94"/>
+<rectangle x1="184.125" y1="34.525" x2="186.025" y2="34.575" layer="94"/>
+<rectangle x1="193.225" y1="34.525" x2="194.225" y2="34.575" layer="94"/>
+<rectangle x1="195.875" y1="34.525" x2="212.925" y2="34.575" layer="94"/>
+<rectangle x1="219.175" y1="34.525" x2="220.975" y2="34.575" layer="94"/>
+<rectangle x1="222.725" y1="34.525" x2="225.725" y2="34.575" layer="94"/>
+<rectangle x1="231.575" y1="34.525" x2="234.025" y2="34.575" layer="94"/>
+<rectangle x1="240.725" y1="34.525" x2="243.325" y2="34.575" layer="94"/>
+<rectangle x1="184.125" y1="34.575" x2="186.025" y2="34.625" layer="94"/>
+<rectangle x1="193.225" y1="34.575" x2="194.225" y2="34.625" layer="94"/>
+<rectangle x1="195.875" y1="34.575" x2="212.925" y2="34.625" layer="94"/>
+<rectangle x1="219.125" y1="34.575" x2="220.975" y2="34.625" layer="94"/>
+<rectangle x1="222.725" y1="34.575" x2="225.775" y2="34.625" layer="94"/>
+<rectangle x1="231.575" y1="34.575" x2="234.075" y2="34.625" layer="94"/>
+<rectangle x1="240.675" y1="34.575" x2="243.325" y2="34.625" layer="94"/>
+<rectangle x1="184.125" y1="34.625" x2="186.025" y2="34.675" layer="94"/>
+<rectangle x1="193.225" y1="34.625" x2="194.225" y2="34.675" layer="94"/>
+<rectangle x1="195.875" y1="34.625" x2="212.925" y2="34.675" layer="94"/>
+<rectangle x1="219.075" y1="34.625" x2="220.975" y2="34.675" layer="94"/>
+<rectangle x1="222.725" y1="34.625" x2="225.825" y2="34.675" layer="94"/>
+<rectangle x1="231.625" y1="34.625" x2="234.125" y2="34.675" layer="94"/>
+<rectangle x1="240.625" y1="34.625" x2="243.325" y2="34.675" layer="94"/>
+<rectangle x1="184.125" y1="34.675" x2="186.025" y2="34.725" layer="94"/>
+<rectangle x1="193.225" y1="34.675" x2="194.225" y2="34.725" layer="94"/>
+<rectangle x1="195.875" y1="34.675" x2="212.925" y2="34.725" layer="94"/>
+<rectangle x1="219.025" y1="34.675" x2="220.975" y2="34.725" layer="94"/>
+<rectangle x1="222.725" y1="34.675" x2="225.875" y2="34.725" layer="94"/>
+<rectangle x1="231.625" y1="34.675" x2="234.175" y2="34.725" layer="94"/>
+<rectangle x1="240.575" y1="34.675" x2="243.325" y2="34.725" layer="94"/>
+<rectangle x1="184.125" y1="34.725" x2="186.025" y2="34.775" layer="94"/>
+<rectangle x1="193.225" y1="34.725" x2="194.225" y2="34.775" layer="94"/>
+<rectangle x1="195.875" y1="34.725" x2="212.925" y2="34.775" layer="94"/>
+<rectangle x1="218.975" y1="34.725" x2="220.975" y2="34.775" layer="94"/>
+<rectangle x1="222.725" y1="34.725" x2="225.925" y2="34.775" layer="94"/>
+<rectangle x1="231.675" y1="34.725" x2="234.225" y2="34.775" layer="94"/>
+<rectangle x1="240.475" y1="34.725" x2="243.325" y2="34.775" layer="94"/>
+<rectangle x1="184.125" y1="34.775" x2="186.025" y2="34.825" layer="94"/>
+<rectangle x1="193.225" y1="34.775" x2="194.225" y2="34.825" layer="94"/>
+<rectangle x1="195.875" y1="34.775" x2="212.925" y2="34.825" layer="94"/>
+<rectangle x1="218.975" y1="34.775" x2="220.975" y2="34.825" layer="94"/>
+<rectangle x1="222.725" y1="34.775" x2="226.025" y2="34.825" layer="94"/>
+<rectangle x1="231.675" y1="34.775" x2="234.275" y2="34.825" layer="94"/>
+<rectangle x1="240.425" y1="34.775" x2="243.275" y2="34.825" layer="94"/>
+<rectangle x1="184.125" y1="34.825" x2="186.025" y2="34.875" layer="94"/>
+<rectangle x1="193.225" y1="34.825" x2="194.225" y2="34.875" layer="94"/>
+<rectangle x1="195.875" y1="34.825" x2="212.925" y2="34.875" layer="94"/>
+<rectangle x1="218.875" y1="34.825" x2="220.975" y2="34.875" layer="94"/>
+<rectangle x1="222.725" y1="34.825" x2="226.075" y2="34.875" layer="94"/>
+<rectangle x1="231.725" y1="34.825" x2="234.325" y2="34.875" layer="94"/>
+<rectangle x1="240.375" y1="34.825" x2="243.275" y2="34.875" layer="94"/>
+<rectangle x1="184.125" y1="34.875" x2="186.025" y2="34.925" layer="94"/>
+<rectangle x1="193.225" y1="34.875" x2="194.225" y2="34.925" layer="94"/>
+<rectangle x1="195.875" y1="34.875" x2="212.925" y2="34.925" layer="94"/>
+<rectangle x1="218.825" y1="34.875" x2="220.975" y2="34.925" layer="94"/>
+<rectangle x1="222.725" y1="34.875" x2="226.125" y2="34.925" layer="94"/>
+<rectangle x1="231.725" y1="34.875" x2="234.375" y2="34.925" layer="94"/>
+<rectangle x1="240.325" y1="34.875" x2="243.275" y2="34.925" layer="94"/>
+<rectangle x1="184.125" y1="34.925" x2="186.025" y2="34.975" layer="94"/>
+<rectangle x1="193.225" y1="34.925" x2="194.225" y2="34.975" layer="94"/>
+<rectangle x1="195.875" y1="34.925" x2="212.925" y2="34.975" layer="94"/>
+<rectangle x1="218.775" y1="34.925" x2="220.975" y2="34.975" layer="94"/>
+<rectangle x1="222.725" y1="34.925" x2="226.175" y2="34.975" layer="94"/>
+<rectangle x1="231.725" y1="34.925" x2="234.475" y2="34.975" layer="94"/>
+<rectangle x1="240.275" y1="34.925" x2="243.275" y2="34.975" layer="94"/>
+<rectangle x1="184.125" y1="34.975" x2="186.025" y2="35.025" layer="94"/>
+<rectangle x1="193.225" y1="34.975" x2="194.225" y2="35.025" layer="94"/>
+<rectangle x1="195.875" y1="34.975" x2="212.925" y2="35.025" layer="94"/>
+<rectangle x1="218.725" y1="34.975" x2="220.975" y2="35.025" layer="94"/>
+<rectangle x1="222.725" y1="34.975" x2="226.275" y2="35.025" layer="94"/>
+<rectangle x1="231.775" y1="34.975" x2="234.525" y2="35.025" layer="94"/>
+<rectangle x1="240.175" y1="34.975" x2="243.225" y2="35.025" layer="94"/>
+<rectangle x1="184.125" y1="35.025" x2="186.025" y2="35.075" layer="94"/>
+<rectangle x1="193.225" y1="35.025" x2="194.225" y2="35.075" layer="94"/>
+<rectangle x1="195.875" y1="35.025" x2="212.925" y2="35.075" layer="94"/>
+<rectangle x1="218.675" y1="35.025" x2="220.975" y2="35.075" layer="94"/>
+<rectangle x1="222.725" y1="35.025" x2="226.325" y2="35.075" layer="94"/>
+<rectangle x1="231.775" y1="35.025" x2="234.625" y2="35.075" layer="94"/>
+<rectangle x1="240.125" y1="35.025" x2="243.225" y2="35.075" layer="94"/>
+<rectangle x1="184.125" y1="35.075" x2="186.025" y2="35.125" layer="94"/>
+<rectangle x1="193.225" y1="35.075" x2="194.225" y2="35.125" layer="94"/>
+<rectangle x1="195.875" y1="35.075" x2="212.925" y2="35.125" layer="94"/>
+<rectangle x1="218.575" y1="35.075" x2="220.975" y2="35.125" layer="94"/>
+<rectangle x1="222.725" y1="35.075" x2="226.375" y2="35.125" layer="94"/>
+<rectangle x1="231.725" y1="35.075" x2="234.675" y2="35.125" layer="94"/>
+<rectangle x1="240.075" y1="35.075" x2="243.225" y2="35.125" layer="94"/>
+<rectangle x1="184.125" y1="35.125" x2="186.025" y2="35.175" layer="94"/>
+<rectangle x1="193.225" y1="35.125" x2="194.225" y2="35.175" layer="94"/>
+<rectangle x1="195.875" y1="35.125" x2="212.925" y2="35.175" layer="94"/>
+<rectangle x1="218.525" y1="35.125" x2="220.975" y2="35.175" layer="94"/>
+<rectangle x1="222.725" y1="35.125" x2="226.475" y2="35.175" layer="94"/>
+<rectangle x1="231.675" y1="35.125" x2="234.725" y2="35.175" layer="94"/>
+<rectangle x1="239.975" y1="35.125" x2="243.175" y2="35.175" layer="94"/>
+<rectangle x1="184.125" y1="35.175" x2="186.025" y2="35.225" layer="94"/>
+<rectangle x1="193.225" y1="35.175" x2="194.225" y2="35.225" layer="94"/>
+<rectangle x1="195.875" y1="35.175" x2="212.925" y2="35.225" layer="94"/>
+<rectangle x1="218.425" y1="35.175" x2="220.975" y2="35.225" layer="94"/>
+<rectangle x1="222.725" y1="35.175" x2="226.575" y2="35.225" layer="94"/>
+<rectangle x1="231.575" y1="35.175" x2="234.825" y2="35.225" layer="94"/>
+<rectangle x1="239.875" y1="35.175" x2="243.175" y2="35.225" layer="94"/>
+<rectangle x1="184.125" y1="35.225" x2="186.025" y2="35.275" layer="94"/>
+<rectangle x1="193.225" y1="35.225" x2="194.225" y2="35.275" layer="94"/>
+<rectangle x1="195.875" y1="35.225" x2="212.925" y2="35.275" layer="94"/>
+<rectangle x1="218.375" y1="35.225" x2="220.975" y2="35.275" layer="94"/>
+<rectangle x1="222.725" y1="35.225" x2="226.625" y2="35.275" layer="94"/>
+<rectangle x1="231.475" y1="35.225" x2="234.925" y2="35.275" layer="94"/>
+<rectangle x1="239.825" y1="35.225" x2="243.125" y2="35.275" layer="94"/>
+<rectangle x1="184.125" y1="35.275" x2="186.025" y2="35.325" layer="94"/>
+<rectangle x1="193.225" y1="35.275" x2="194.225" y2="35.325" layer="94"/>
+<rectangle x1="195.875" y1="35.275" x2="212.925" y2="35.325" layer="94"/>
+<rectangle x1="218.275" y1="35.275" x2="220.975" y2="35.325" layer="94"/>
+<rectangle x1="222.725" y1="35.275" x2="226.725" y2="35.325" layer="94"/>
+<rectangle x1="231.375" y1="35.275" x2="235.025" y2="35.325" layer="94"/>
+<rectangle x1="239.725" y1="35.275" x2="243.125" y2="35.325" layer="94"/>
+<rectangle x1="184.125" y1="35.325" x2="186.025" y2="35.375" layer="94"/>
+<rectangle x1="193.225" y1="35.325" x2="194.225" y2="35.375" layer="94"/>
+<rectangle x1="195.875" y1="35.325" x2="212.925" y2="35.375" layer="94"/>
+<rectangle x1="218.125" y1="35.325" x2="220.975" y2="35.375" layer="94"/>
+<rectangle x1="222.725" y1="35.325" x2="226.825" y2="35.375" layer="94"/>
+<rectangle x1="231.275" y1="35.325" x2="235.125" y2="35.375" layer="94"/>
+<rectangle x1="239.625" y1="35.325" x2="243.125" y2="35.375" layer="94"/>
+<rectangle x1="184.125" y1="35.375" x2="186.025" y2="35.425" layer="94"/>
+<rectangle x1="193.225" y1="35.375" x2="194.225" y2="35.425" layer="94"/>
+<rectangle x1="195.875" y1="35.375" x2="212.925" y2="35.425" layer="94"/>
+<rectangle x1="218.025" y1="35.375" x2="220.975" y2="35.425" layer="94"/>
+<rectangle x1="222.725" y1="35.375" x2="226.925" y2="35.425" layer="94"/>
+<rectangle x1="231.175" y1="35.375" x2="235.225" y2="35.425" layer="94"/>
+<rectangle x1="239.525" y1="35.375" x2="243.075" y2="35.425" layer="94"/>
+<rectangle x1="184.125" y1="35.425" x2="186.025" y2="35.475" layer="94"/>
+<rectangle x1="193.225" y1="35.425" x2="194.225" y2="35.475" layer="94"/>
+<rectangle x1="195.875" y1="35.425" x2="212.925" y2="35.475" layer="94"/>
+<rectangle x1="217.875" y1="35.425" x2="220.975" y2="35.475" layer="94"/>
+<rectangle x1="222.725" y1="35.425" x2="227.025" y2="35.475" layer="94"/>
+<rectangle x1="231.075" y1="35.425" x2="235.325" y2="35.475" layer="94"/>
+<rectangle x1="239.375" y1="35.425" x2="243.075" y2="35.475" layer="94"/>
+<rectangle x1="184.125" y1="35.475" x2="186.025" y2="35.525" layer="94"/>
+<rectangle x1="193.225" y1="35.475" x2="194.225" y2="35.525" layer="94"/>
+<rectangle x1="195.875" y1="35.475" x2="212.925" y2="35.525" layer="94"/>
+<rectangle x1="217.725" y1="35.475" x2="220.975" y2="35.525" layer="94"/>
+<rectangle x1="222.725" y1="35.475" x2="227.175" y2="35.525" layer="94"/>
+<rectangle x1="230.925" y1="35.475" x2="235.425" y2="35.525" layer="94"/>
+<rectangle x1="239.275" y1="35.475" x2="243.025" y2="35.525" layer="94"/>
+<rectangle x1="184.125" y1="35.525" x2="186.025" y2="35.575" layer="94"/>
+<rectangle x1="193.225" y1="35.525" x2="194.225" y2="35.575" layer="94"/>
+<rectangle x1="195.875" y1="35.525" x2="212.925" y2="35.575" layer="94"/>
+<rectangle x1="217.575" y1="35.525" x2="220.975" y2="35.575" layer="94"/>
+<rectangle x1="222.725" y1="35.525" x2="227.325" y2="35.575" layer="94"/>
+<rectangle x1="230.825" y1="35.525" x2="235.575" y2="35.575" layer="94"/>
+<rectangle x1="239.125" y1="35.525" x2="243.025" y2="35.575" layer="94"/>
+<rectangle x1="184.125" y1="35.575" x2="186.025" y2="35.625" layer="94"/>
+<rectangle x1="193.225" y1="35.575" x2="194.225" y2="35.625" layer="94"/>
+<rectangle x1="195.875" y1="35.575" x2="212.925" y2="35.625" layer="94"/>
+<rectangle x1="217.325" y1="35.575" x2="220.975" y2="35.625" layer="94"/>
+<rectangle x1="222.725" y1="35.575" x2="227.475" y2="35.625" layer="94"/>
+<rectangle x1="230.625" y1="35.575" x2="235.725" y2="35.625" layer="94"/>
+<rectangle x1="238.975" y1="35.575" x2="242.975" y2="35.625" layer="94"/>
+<rectangle x1="184.125" y1="35.625" x2="186.025" y2="35.675" layer="94"/>
+<rectangle x1="193.225" y1="35.625" x2="194.225" y2="35.675" layer="94"/>
+<rectangle x1="195.875" y1="35.625" x2="212.925" y2="35.675" layer="94"/>
+<rectangle x1="217.075" y1="35.625" x2="220.975" y2="35.675" layer="94"/>
+<rectangle x1="222.725" y1="35.625" x2="227.625" y2="35.675" layer="94"/>
+<rectangle x1="230.475" y1="35.625" x2="235.925" y2="35.675" layer="94"/>
+<rectangle x1="238.825" y1="35.625" x2="242.925" y2="35.675" layer="94"/>
+<rectangle x1="184.125" y1="35.675" x2="194.225" y2="35.725" layer="94"/>
+<rectangle x1="195.875" y1="35.675" x2="212.925" y2="35.725" layer="94"/>
+<rectangle x1="216.625" y1="35.675" x2="227.825" y2="35.725" layer="94"/>
+<rectangle x1="230.275" y1="35.675" x2="236.125" y2="35.725" layer="94"/>
+<rectangle x1="238.575" y1="35.675" x2="242.925" y2="35.725" layer="94"/>
+<rectangle x1="184.125" y1="35.725" x2="194.225" y2="35.775" layer="94"/>
+<rectangle x1="195.875" y1="35.725" x2="228.075" y2="35.775" layer="94"/>
+<rectangle x1="229.975" y1="35.725" x2="236.375" y2="35.775" layer="94"/>
+<rectangle x1="238.375" y1="35.725" x2="242.875" y2="35.775" layer="94"/>
+<rectangle x1="184.125" y1="35.775" x2="194.225" y2="35.825" layer="94"/>
+<rectangle x1="195.875" y1="35.775" x2="228.425" y2="35.825" layer="94"/>
+<rectangle x1="229.475" y1="35.775" x2="236.775" y2="35.825" layer="94"/>
+<rectangle x1="237.975" y1="35.775" x2="242.875" y2="35.825" layer="94"/>
+<rectangle x1="184.125" y1="35.825" x2="242.825" y2="35.875" layer="94"/>
+<rectangle x1="184.125" y1="35.875" x2="242.775" y2="35.925" layer="94"/>
+<rectangle x1="184.125" y1="35.925" x2="242.725" y2="35.975" layer="94"/>
+<rectangle x1="184.125" y1="35.975" x2="242.725" y2="36.025" layer="94"/>
+<rectangle x1="184.125" y1="36.025" x2="242.675" y2="36.075" layer="94"/>
+<rectangle x1="184.125" y1="36.075" x2="242.625" y2="36.125" layer="94"/>
+<rectangle x1="184.125" y1="36.125" x2="242.575" y2="36.175" layer="94"/>
+<rectangle x1="184.125" y1="36.175" x2="242.525" y2="36.225" layer="94"/>
+<rectangle x1="184.125" y1="36.225" x2="242.475" y2="36.275" layer="94"/>
+<rectangle x1="243.275" y1="36.225" x2="243.475" y2="36.275" layer="94"/>
+<rectangle x1="243.875" y1="36.225" x2="244.025" y2="36.275" layer="94"/>
+<rectangle x1="244.775" y1="36.225" x2="244.925" y2="36.275" layer="94"/>
+<rectangle x1="184.125" y1="36.275" x2="242.425" y2="36.325" layer="94"/>
+<rectangle x1="243.275" y1="36.275" x2="243.475" y2="36.325" layer="94"/>
+<rectangle x1="243.875" y1="36.275" x2="244.025" y2="36.325" layer="94"/>
+<rectangle x1="244.325" y1="36.275" x2="244.475" y2="36.325" layer="94"/>
+<rectangle x1="244.775" y1="36.275" x2="244.925" y2="36.325" layer="94"/>
+<rectangle x1="184.125" y1="36.325" x2="242.375" y2="36.375" layer="94"/>
+<rectangle x1="243.275" y1="36.325" x2="243.475" y2="36.375" layer="94"/>
+<rectangle x1="243.875" y1="36.325" x2="244.025" y2="36.375" layer="94"/>
+<rectangle x1="244.275" y1="36.325" x2="244.525" y2="36.375" layer="94"/>
+<rectangle x1="244.775" y1="36.325" x2="244.925" y2="36.375" layer="94"/>
+<rectangle x1="184.125" y1="36.375" x2="242.325" y2="36.425" layer="94"/>
+<rectangle x1="243.275" y1="36.375" x2="243.475" y2="36.425" layer="94"/>
+<rectangle x1="243.875" y1="36.375" x2="244.025" y2="36.425" layer="94"/>
+<rectangle x1="244.275" y1="36.375" x2="244.525" y2="36.425" layer="94"/>
+<rectangle x1="244.775" y1="36.375" x2="244.925" y2="36.425" layer="94"/>
+<rectangle x1="184.125" y1="36.425" x2="242.275" y2="36.475" layer="94"/>
+<rectangle x1="243.275" y1="36.425" x2="243.475" y2="36.475" layer="94"/>
+<rectangle x1="243.875" y1="36.425" x2="244.025" y2="36.475" layer="94"/>
+<rectangle x1="244.225" y1="36.425" x2="244.525" y2="36.475" layer="94"/>
+<rectangle x1="244.775" y1="36.425" x2="244.925" y2="36.475" layer="94"/>
+<rectangle x1="184.125" y1="36.475" x2="242.225" y2="36.525" layer="94"/>
+<rectangle x1="243.275" y1="36.475" x2="243.475" y2="36.525" layer="94"/>
+<rectangle x1="243.875" y1="36.475" x2="244.025" y2="36.525" layer="94"/>
+<rectangle x1="244.225" y1="36.475" x2="244.575" y2="36.525" layer="94"/>
+<rectangle x1="244.775" y1="36.475" x2="244.925" y2="36.525" layer="94"/>
+<rectangle x1="184.125" y1="36.525" x2="242.175" y2="36.575" layer="94"/>
+<rectangle x1="243.275" y1="36.525" x2="243.475" y2="36.575" layer="94"/>
+<rectangle x1="243.875" y1="36.525" x2="244.025" y2="36.575" layer="94"/>
+<rectangle x1="244.225" y1="36.525" x2="244.375" y2="36.575" layer="94"/>
+<rectangle x1="244.425" y1="36.525" x2="244.575" y2="36.575" layer="94"/>
+<rectangle x1="244.775" y1="36.525" x2="244.925" y2="36.575" layer="94"/>
+<rectangle x1="184.125" y1="36.575" x2="242.075" y2="36.625" layer="94"/>
+<rectangle x1="243.275" y1="36.575" x2="243.475" y2="36.625" layer="94"/>
+<rectangle x1="243.875" y1="36.575" x2="244.025" y2="36.625" layer="94"/>
+<rectangle x1="244.175" y1="36.575" x2="244.375" y2="36.625" layer="94"/>
+<rectangle x1="244.425" y1="36.575" x2="244.625" y2="36.625" layer="94"/>
+<rectangle x1="244.775" y1="36.575" x2="244.925" y2="36.625" layer="94"/>
+<rectangle x1="184.125" y1="36.625" x2="242.025" y2="36.675" layer="94"/>
+<rectangle x1="243.275" y1="36.625" x2="243.475" y2="36.675" layer="94"/>
+<rectangle x1="243.875" y1="36.625" x2="244.025" y2="36.675" layer="94"/>
+<rectangle x1="244.175" y1="36.625" x2="244.325" y2="36.675" layer="94"/>
+<rectangle x1="244.475" y1="36.625" x2="244.625" y2="36.675" layer="94"/>
+<rectangle x1="244.775" y1="36.625" x2="244.925" y2="36.675" layer="94"/>
+<rectangle x1="184.125" y1="36.675" x2="241.975" y2="36.725" layer="94"/>
+<rectangle x1="243.275" y1="36.675" x2="243.475" y2="36.725" layer="94"/>
+<rectangle x1="243.875" y1="36.675" x2="244.025" y2="36.725" layer="94"/>
+<rectangle x1="244.125" y1="36.675" x2="244.325" y2="36.725" layer="94"/>
+<rectangle x1="244.475" y1="36.675" x2="244.625" y2="36.725" layer="94"/>
+<rectangle x1="244.775" y1="36.675" x2="244.925" y2="36.725" layer="94"/>
+<rectangle x1="184.125" y1="36.725" x2="241.875" y2="36.775" layer="94"/>
+<rectangle x1="243.275" y1="36.725" x2="243.475" y2="36.775" layer="94"/>
+<rectangle x1="243.875" y1="36.725" x2="244.025" y2="36.775" layer="94"/>
+<rectangle x1="244.125" y1="36.725" x2="244.275" y2="36.775" layer="94"/>
+<rectangle x1="244.525" y1="36.725" x2="244.675" y2="36.775" layer="94"/>
+<rectangle x1="244.775" y1="36.725" x2="244.925" y2="36.775" layer="94"/>
+<rectangle x1="184.125" y1="36.775" x2="241.775" y2="36.825" layer="94"/>
+<rectangle x1="243.275" y1="36.775" x2="243.475" y2="36.825" layer="94"/>
+<rectangle x1="243.875" y1="36.775" x2="244.025" y2="36.825" layer="94"/>
+<rectangle x1="244.125" y1="36.775" x2="244.275" y2="36.825" layer="94"/>
+<rectangle x1="244.525" y1="36.775" x2="244.675" y2="36.825" layer="94"/>
+<rectangle x1="244.775" y1="36.775" x2="244.925" y2="36.825" layer="94"/>
+<rectangle x1="184.125" y1="36.825" x2="241.725" y2="36.875" layer="94"/>
+<rectangle x1="243.275" y1="36.825" x2="243.475" y2="36.875" layer="94"/>
+<rectangle x1="243.875" y1="36.825" x2="244.025" y2="36.875" layer="94"/>
+<rectangle x1="244.075" y1="36.825" x2="244.225" y2="36.875" layer="94"/>
+<rectangle x1="244.525" y1="36.825" x2="244.725" y2="36.875" layer="94"/>
+<rectangle x1="244.775" y1="36.825" x2="244.925" y2="36.875" layer="94"/>
+<rectangle x1="184.125" y1="36.875" x2="241.575" y2="36.925" layer="94"/>
+<rectangle x1="243.275" y1="36.875" x2="243.475" y2="36.925" layer="94"/>
+<rectangle x1="243.875" y1="36.875" x2="244.025" y2="36.925" layer="94"/>
+<rectangle x1="244.075" y1="36.875" x2="244.225" y2="36.925" layer="94"/>
+<rectangle x1="244.575" y1="36.875" x2="244.725" y2="36.925" layer="94"/>
+<rectangle x1="244.775" y1="36.875" x2="244.925" y2="36.925" layer="94"/>
+<rectangle x1="184.125" y1="36.925" x2="241.475" y2="36.975" layer="94"/>
+<rectangle x1="243.275" y1="36.925" x2="243.475" y2="36.975" layer="94"/>
+<rectangle x1="243.875" y1="36.925" x2="244.225" y2="36.975" layer="94"/>
+<rectangle x1="244.575" y1="36.925" x2="244.925" y2="36.975" layer="94"/>
+<rectangle x1="184.125" y1="36.975" x2="241.375" y2="37.025" layer="94"/>
+<rectangle x1="243.275" y1="36.975" x2="243.475" y2="37.025" layer="94"/>
+<rectangle x1="243.875" y1="36.975" x2="244.175" y2="37.025" layer="94"/>
+<rectangle x1="244.625" y1="36.975" x2="244.925" y2="37.025" layer="94"/>
+<rectangle x1="184.125" y1="37.025" x2="241.225" y2="37.075" layer="94"/>
+<rectangle x1="243.275" y1="37.025" x2="243.475" y2="37.075" layer="94"/>
+<rectangle x1="243.875" y1="37.025" x2="244.175" y2="37.075" layer="94"/>
+<rectangle x1="244.625" y1="37.025" x2="244.925" y2="37.075" layer="94"/>
+<rectangle x1="184.125" y1="37.075" x2="241.075" y2="37.125" layer="94"/>
+<rectangle x1="242.975" y1="37.075" x2="243.775" y2="37.125" layer="94"/>
+<rectangle x1="243.875" y1="37.075" x2="244.125" y2="37.125" layer="94"/>
+<rectangle x1="244.675" y1="37.075" x2="244.925" y2="37.125" layer="94"/>
+<rectangle x1="184.125" y1="37.125" x2="240.875" y2="37.175" layer="94"/>
+<rectangle x1="242.975" y1="37.125" x2="243.775" y2="37.175" layer="94"/>
+<rectangle x1="243.875" y1="37.125" x2="244.125" y2="37.175" layer="94"/>
+<rectangle x1="244.675" y1="37.125" x2="244.925" y2="37.175" layer="94"/>
+<rectangle x1="184.125" y1="37.175" x2="240.575" y2="37.225" layer="94"/>
+<rectangle x1="242.975" y1="37.175" x2="243.775" y2="37.225" layer="94"/>
+<rectangle x1="243.875" y1="37.175" x2="244.125" y2="37.225" layer="94"/>
+<rectangle x1="244.675" y1="37.175" x2="244.925" y2="37.225" layer="94"/>
+<rectangle x1="216.095" y1="8.185" x2="216.105" y2="8.195" layer="94"/>
+<rectangle x1="216.085" y1="9.065" x2="216.125" y2="9.075" layer="94"/>
+<rectangle x1="216.085" y1="9.075" x2="216.105" y2="9.085" layer="94"/>
+<rectangle x1="216.085" y1="9.085" x2="216.095" y2="9.095" layer="94"/>
+<text x="0" y="-0.05" size="0.02" layer="94" font="vector">/Users/seon/Dropbox/Unexpected Maker/Branding/UM_Logo_White.bmp</text>
+<rectangle x1="219.145" y1="5.215" x2="219.165" y2="5.225" layer="94"/>
+<rectangle x1="219.145" y1="5.225" x2="219.205" y2="5.235" layer="94"/>
+<rectangle x1="220.045" y1="5.225" x2="220.055" y2="5.235" layer="94"/>
+<rectangle x1="219.155" y1="5.235" x2="219.235" y2="5.245" layer="94"/>
+<rectangle x1="220.045" y1="5.235" x2="220.065" y2="5.245" layer="94"/>
+<rectangle x1="219.165" y1="5.245" x2="219.265" y2="5.255" layer="94"/>
+<rectangle x1="220.045" y1="5.245" x2="220.085" y2="5.255" layer="94"/>
+<rectangle x1="219.165" y1="5.255" x2="219.305" y2="5.265" layer="94"/>
+<rectangle x1="220.045" y1="5.255" x2="220.105" y2="5.265" layer="94"/>
+<rectangle x1="219.175" y1="5.265" x2="219.335" y2="5.275" layer="94"/>
+<rectangle x1="220.055" y1="5.265" x2="220.115" y2="5.275" layer="94"/>
+<rectangle x1="219.175" y1="5.275" x2="219.365" y2="5.285" layer="94"/>
+<rectangle x1="220.055" y1="5.275" x2="220.135" y2="5.285" layer="94"/>
+<rectangle x1="219.185" y1="5.285" x2="219.405" y2="5.295" layer="94"/>
+<rectangle x1="220.055" y1="5.285" x2="220.155" y2="5.295" layer="94"/>
+<rectangle x1="219.195" y1="5.295" x2="219.435" y2="5.305" layer="94"/>
+<rectangle x1="220.065" y1="5.295" x2="220.165" y2="5.305" layer="94"/>
+<rectangle x1="219.195" y1="5.305" x2="219.475" y2="5.315" layer="94"/>
+<rectangle x1="220.065" y1="5.305" x2="220.185" y2="5.315" layer="94"/>
+<rectangle x1="219.205" y1="5.315" x2="219.505" y2="5.325" layer="94"/>
+<rectangle x1="220.065" y1="5.315" x2="220.205" y2="5.325" layer="94"/>
+<rectangle x1="219.205" y1="5.325" x2="219.535" y2="5.335" layer="94"/>
+<rectangle x1="220.075" y1="5.325" x2="220.215" y2="5.335" layer="94"/>
+<rectangle x1="219.215" y1="5.335" x2="219.575" y2="5.345" layer="94"/>
+<rectangle x1="220.075" y1="5.335" x2="220.235" y2="5.345" layer="94"/>
+<rectangle x1="219.225" y1="5.345" x2="219.605" y2="5.355" layer="94"/>
+<rectangle x1="220.075" y1="5.345" x2="220.245" y2="5.355" layer="94"/>
+<rectangle x1="219.225" y1="5.355" x2="219.635" y2="5.365" layer="94"/>
+<rectangle x1="220.075" y1="5.355" x2="220.265" y2="5.365" layer="94"/>
+<rectangle x1="219.235" y1="5.365" x2="219.675" y2="5.375" layer="94"/>
+<rectangle x1="220.085" y1="5.365" x2="220.285" y2="5.375" layer="94"/>
+<rectangle x1="219.245" y1="5.375" x2="219.705" y2="5.385" layer="94"/>
+<rectangle x1="220.085" y1="5.375" x2="220.295" y2="5.385" layer="94"/>
+<rectangle x1="219.245" y1="5.385" x2="219.735" y2="5.395" layer="94"/>
+<rectangle x1="220.085" y1="5.385" x2="220.315" y2="5.395" layer="94"/>
+<rectangle x1="219.255" y1="5.395" x2="219.775" y2="5.405" layer="94"/>
+<rectangle x1="220.095" y1="5.395" x2="220.335" y2="5.405" layer="94"/>
+<rectangle x1="219.255" y1="5.405" x2="219.795" y2="5.415" layer="94"/>
+<rectangle x1="220.095" y1="5.405" x2="220.345" y2="5.415" layer="94"/>
+<rectangle x1="219.265" y1="5.415" x2="219.795" y2="5.425" layer="94"/>
+<rectangle x1="220.095" y1="5.415" x2="220.365" y2="5.425" layer="94"/>
+<rectangle x1="219.275" y1="5.425" x2="219.805" y2="5.435" layer="94"/>
+<rectangle x1="220.105" y1="5.425" x2="220.385" y2="5.435" layer="94"/>
+<rectangle x1="219.275" y1="5.435" x2="219.805" y2="5.445" layer="94"/>
+<rectangle x1="220.105" y1="5.435" x2="220.395" y2="5.445" layer="94"/>
+<rectangle x1="218.245" y1="5.445" x2="218.645" y2="5.455" layer="94"/>
+<rectangle x1="219.285" y1="5.445" x2="219.805" y2="5.455" layer="94"/>
+<rectangle x1="220.105" y1="5.445" x2="220.415" y2="5.455" layer="94"/>
+<rectangle x1="218.255" y1="5.455" x2="218.925" y2="5.465" layer="94"/>
+<rectangle x1="219.295" y1="5.455" x2="219.815" y2="5.465" layer="94"/>
+<rectangle x1="220.105" y1="5.455" x2="220.435" y2="5.465" layer="94"/>
+<rectangle x1="218.265" y1="5.465" x2="218.935" y2="5.475" layer="94"/>
+<rectangle x1="219.295" y1="5.465" x2="219.815" y2="5.475" layer="94"/>
+<rectangle x1="220.115" y1="5.465" x2="220.445" y2="5.475" layer="94"/>
+<rectangle x1="218.275" y1="5.475" x2="218.935" y2="5.485" layer="94"/>
+<rectangle x1="219.305" y1="5.475" x2="219.815" y2="5.485" layer="94"/>
+<rectangle x1="220.115" y1="5.475" x2="220.465" y2="5.485" layer="94"/>
+<rectangle x1="220.935" y1="5.475" x2="220.945" y2="5.485" layer="94"/>
+<rectangle x1="218.285" y1="5.485" x2="218.945" y2="5.495" layer="94"/>
+<rectangle x1="219.305" y1="5.485" x2="219.825" y2="5.495" layer="94"/>
+<rectangle x1="220.115" y1="5.485" x2="220.475" y2="5.495" layer="94"/>
+<rectangle x1="220.935" y1="5.485" x2="220.955" y2="5.495" layer="94"/>
+<rectangle x1="218.295" y1="5.495" x2="218.955" y2="5.505" layer="94"/>
+<rectangle x1="219.315" y1="5.495" x2="219.825" y2="5.505" layer="94"/>
+<rectangle x1="220.125" y1="5.495" x2="220.495" y2="5.505" layer="94"/>
+<rectangle x1="220.935" y1="5.495" x2="220.955" y2="5.505" layer="94"/>
+<rectangle x1="218.305" y1="5.505" x2="218.965" y2="5.515" layer="94"/>
+<rectangle x1="219.325" y1="5.505" x2="219.835" y2="5.515" layer="94"/>
+<rectangle x1="220.125" y1="5.505" x2="220.515" y2="5.515" layer="94"/>
+<rectangle x1="220.935" y1="5.505" x2="220.965" y2="5.515" layer="94"/>
+<rectangle x1="218.315" y1="5.515" x2="218.965" y2="5.525" layer="94"/>
+<rectangle x1="219.325" y1="5.515" x2="219.835" y2="5.525" layer="94"/>
+<rectangle x1="220.125" y1="5.515" x2="220.525" y2="5.525" layer="94"/>
+<rectangle x1="220.935" y1="5.515" x2="220.975" y2="5.525" layer="94"/>
+<rectangle x1="218.335" y1="5.525" x2="218.975" y2="5.535" layer="94"/>
+<rectangle x1="219.335" y1="5.525" x2="219.835" y2="5.535" layer="94"/>
+<rectangle x1="220.135" y1="5.525" x2="220.545" y2="5.535" layer="94"/>
+<rectangle x1="220.935" y1="5.525" x2="220.985" y2="5.535" layer="94"/>
+<rectangle x1="218.345" y1="5.535" x2="218.985" y2="5.545" layer="94"/>
+<rectangle x1="219.335" y1="5.535" x2="219.845" y2="5.545" layer="94"/>
+<rectangle x1="220.135" y1="5.535" x2="220.565" y2="5.545" layer="94"/>
+<rectangle x1="220.935" y1="5.535" x2="220.995" y2="5.545" layer="94"/>
+<rectangle x1="218.355" y1="5.545" x2="218.995" y2="5.555" layer="94"/>
+<rectangle x1="219.335" y1="5.545" x2="219.845" y2="5.555" layer="94"/>
+<rectangle x1="220.135" y1="5.545" x2="220.575" y2="5.555" layer="94"/>
+<rectangle x1="220.935" y1="5.545" x2="221.005" y2="5.555" layer="94"/>
+<rectangle x1="218.365" y1="5.555" x2="218.995" y2="5.565" layer="94"/>
+<rectangle x1="219.325" y1="5.555" x2="219.845" y2="5.565" layer="94"/>
+<rectangle x1="220.135" y1="5.555" x2="220.595" y2="5.565" layer="94"/>
+<rectangle x1="220.935" y1="5.555" x2="221.015" y2="5.565" layer="94"/>
+<rectangle x1="218.375" y1="5.565" x2="219.005" y2="5.575" layer="94"/>
+<rectangle x1="219.325" y1="5.565" x2="219.855" y2="5.575" layer="94"/>
+<rectangle x1="220.145" y1="5.565" x2="220.615" y2="5.575" layer="94"/>
+<rectangle x1="220.935" y1="5.565" x2="221.025" y2="5.575" layer="94"/>
+<rectangle x1="218.385" y1="5.575" x2="219.015" y2="5.585" layer="94"/>
+<rectangle x1="219.315" y1="5.575" x2="219.855" y2="5.585" layer="94"/>
+<rectangle x1="220.145" y1="5.575" x2="220.625" y2="5.585" layer="94"/>
+<rectangle x1="220.935" y1="5.575" x2="221.035" y2="5.585" layer="94"/>
+<rectangle x1="218.395" y1="5.585" x2="219.015" y2="5.595" layer="94"/>
+<rectangle x1="219.315" y1="5.585" x2="219.865" y2="5.595" layer="94"/>
+<rectangle x1="220.145" y1="5.585" x2="220.625" y2="5.595" layer="94"/>
+<rectangle x1="220.935" y1="5.585" x2="221.045" y2="5.595" layer="94"/>
+<rectangle x1="218.405" y1="5.595" x2="219.025" y2="5.605" layer="94"/>
+<rectangle x1="219.305" y1="5.595" x2="219.865" y2="5.605" layer="94"/>
+<rectangle x1="220.135" y1="5.595" x2="220.625" y2="5.605" layer="94"/>
+<rectangle x1="220.935" y1="5.595" x2="221.055" y2="5.605" layer="94"/>
+<rectangle x1="218.415" y1="5.605" x2="219.035" y2="5.615" layer="94"/>
+<rectangle x1="219.295" y1="5.605" x2="219.865" y2="5.615" layer="94"/>
+<rectangle x1="220.125" y1="5.605" x2="220.625" y2="5.615" layer="94"/>
+<rectangle x1="220.935" y1="5.605" x2="221.065" y2="5.615" layer="94"/>
+<rectangle x1="218.425" y1="5.615" x2="219.045" y2="5.625" layer="94"/>
+<rectangle x1="219.295" y1="5.615" x2="219.875" y2="5.625" layer="94"/>
+<rectangle x1="220.115" y1="5.615" x2="220.625" y2="5.625" layer="94"/>
+<rectangle x1="220.935" y1="5.615" x2="221.075" y2="5.625" layer="94"/>
+<rectangle x1="218.435" y1="5.625" x2="219.045" y2="5.635" layer="94"/>
+<rectangle x1="219.285" y1="5.625" x2="219.875" y2="5.635" layer="94"/>
+<rectangle x1="220.105" y1="5.625" x2="220.625" y2="5.635" layer="94"/>
+<rectangle x1="220.935" y1="5.625" x2="221.085" y2="5.635" layer="94"/>
+<rectangle x1="218.445" y1="5.635" x2="219.055" y2="5.645" layer="94"/>
+<rectangle x1="219.285" y1="5.635" x2="219.875" y2="5.645" layer="94"/>
+<rectangle x1="220.105" y1="5.635" x2="220.625" y2="5.645" layer="94"/>
+<rectangle x1="220.935" y1="5.635" x2="221.095" y2="5.645" layer="94"/>
+<rectangle x1="218.455" y1="5.645" x2="219.065" y2="5.655" layer="94"/>
+<rectangle x1="219.275" y1="5.645" x2="219.885" y2="5.655" layer="94"/>
+<rectangle x1="220.095" y1="5.645" x2="220.635" y2="5.655" layer="94"/>
+<rectangle x1="220.935" y1="5.645" x2="221.105" y2="5.655" layer="94"/>
+<rectangle x1="218.465" y1="5.655" x2="219.075" y2="5.665" layer="94"/>
+<rectangle x1="219.275" y1="5.655" x2="219.885" y2="5.665" layer="94"/>
+<rectangle x1="220.085" y1="5.655" x2="220.635" y2="5.665" layer="94"/>
+<rectangle x1="220.935" y1="5.655" x2="221.115" y2="5.665" layer="94"/>
+<rectangle x1="218.475" y1="5.665" x2="219.075" y2="5.675" layer="94"/>
+<rectangle x1="219.265" y1="5.665" x2="219.895" y2="5.675" layer="94"/>
+<rectangle x1="220.075" y1="5.665" x2="220.635" y2="5.675" layer="94"/>
+<rectangle x1="220.935" y1="5.665" x2="221.125" y2="5.675" layer="94"/>
+<rectangle x1="218.495" y1="5.675" x2="219.085" y2="5.685" layer="94"/>
+<rectangle x1="219.265" y1="5.675" x2="219.895" y2="5.685" layer="94"/>
+<rectangle x1="220.065" y1="5.675" x2="220.635" y2="5.685" layer="94"/>
+<rectangle x1="220.935" y1="5.675" x2="221.135" y2="5.685" layer="94"/>
+<rectangle x1="218.505" y1="5.685" x2="219.095" y2="5.695" layer="94"/>
+<rectangle x1="219.255" y1="5.685" x2="219.895" y2="5.695" layer="94"/>
+<rectangle x1="220.055" y1="5.685" x2="220.635" y2="5.695" layer="94"/>
+<rectangle x1="220.935" y1="5.685" x2="221.145" y2="5.695" layer="94"/>
+<rectangle x1="218.515" y1="5.695" x2="219.105" y2="5.705" layer="94"/>
+<rectangle x1="219.245" y1="5.695" x2="219.905" y2="5.705" layer="94"/>
+<rectangle x1="220.045" y1="5.695" x2="220.635" y2="5.705" layer="94"/>
+<rectangle x1="220.935" y1="5.695" x2="221.145" y2="5.705" layer="94"/>
+<rectangle x1="218.515" y1="5.705" x2="219.105" y2="5.715" layer="94"/>
+<rectangle x1="219.245" y1="5.705" x2="219.905" y2="5.715" layer="94"/>
+<rectangle x1="220.035" y1="5.705" x2="220.635" y2="5.715" layer="94"/>
+<rectangle x1="220.935" y1="5.705" x2="221.155" y2="5.715" layer="94"/>
+<rectangle x1="218.125" y1="5.715" x2="218.135" y2="5.725" layer="94"/>
+<rectangle x1="218.515" y1="5.715" x2="219.115" y2="5.725" layer="94"/>
+<rectangle x1="219.235" y1="5.715" x2="219.905" y2="5.725" layer="94"/>
+<rectangle x1="220.025" y1="5.715" x2="220.635" y2="5.725" layer="94"/>
+<rectangle x1="220.935" y1="5.715" x2="221.165" y2="5.725" layer="94"/>
+<rectangle x1="218.085" y1="5.725" x2="218.145" y2="5.735" layer="94"/>
+<rectangle x1="218.515" y1="5.725" x2="219.125" y2="5.735" layer="94"/>
+<rectangle x1="219.235" y1="5.725" x2="219.915" y2="5.735" layer="94"/>
+<rectangle x1="220.015" y1="5.725" x2="220.635" y2="5.735" layer="94"/>
+<rectangle x1="220.935" y1="5.725" x2="221.175" y2="5.735" layer="94"/>
+<rectangle x1="218.035" y1="5.735" x2="218.155" y2="5.745" layer="94"/>
+<rectangle x1="218.505" y1="5.735" x2="219.135" y2="5.745" layer="94"/>
+<rectangle x1="219.225" y1="5.735" x2="219.915" y2="5.745" layer="94"/>
+<rectangle x1="220.005" y1="5.735" x2="220.645" y2="5.745" layer="94"/>
+<rectangle x1="220.935" y1="5.735" x2="221.185" y2="5.745" layer="94"/>
+<rectangle x1="217.995" y1="5.745" x2="218.165" y2="5.755" layer="94"/>
+<rectangle x1="218.505" y1="5.745" x2="219.135" y2="5.755" layer="94"/>
+<rectangle x1="219.145" y1="5.745" x2="219.945" y2="5.755" layer="94"/>
+<rectangle x1="219.995" y1="5.745" x2="220.645" y2="5.755" layer="94"/>
+<rectangle x1="220.945" y1="5.745" x2="221.195" y2="5.755" layer="94"/>
+<rectangle x1="217.955" y1="5.755" x2="218.185" y2="5.765" layer="94"/>
+<rectangle x1="218.505" y1="5.755" x2="220.645" y2="5.765" layer="94"/>
+<rectangle x1="220.945" y1="5.755" x2="221.205" y2="5.765" layer="94"/>
+<rectangle x1="217.915" y1="5.765" x2="218.195" y2="5.775" layer="94"/>
+<rectangle x1="218.505" y1="5.765" x2="220.645" y2="5.775" layer="94"/>
+<rectangle x1="220.945" y1="5.765" x2="221.215" y2="5.775" layer="94"/>
+<rectangle x1="217.875" y1="5.775" x2="218.205" y2="5.785" layer="94"/>
+<rectangle x1="218.495" y1="5.775" x2="220.645" y2="5.785" layer="94"/>
+<rectangle x1="220.945" y1="5.775" x2="221.225" y2="5.785" layer="94"/>
+<rectangle x1="217.825" y1="5.785" x2="218.215" y2="5.795" layer="94"/>
+<rectangle x1="218.495" y1="5.785" x2="220.645" y2="5.795" layer="94"/>
+<rectangle x1="220.945" y1="5.785" x2="221.235" y2="5.795" layer="94"/>
+<rectangle x1="217.785" y1="5.795" x2="218.235" y2="5.805" layer="94"/>
+<rectangle x1="218.495" y1="5.795" x2="220.645" y2="5.805" layer="94"/>
+<rectangle x1="220.945" y1="5.795" x2="221.245" y2="5.805" layer="94"/>
+<rectangle x1="217.745" y1="5.805" x2="218.245" y2="5.815" layer="94"/>
+<rectangle x1="218.495" y1="5.805" x2="220.645" y2="5.815" layer="94"/>
+<rectangle x1="220.945" y1="5.805" x2="221.255" y2="5.815" layer="94"/>
+<rectangle x1="217.705" y1="5.815" x2="218.255" y2="5.825" layer="94"/>
+<rectangle x1="218.485" y1="5.815" x2="220.655" y2="5.825" layer="94"/>
+<rectangle x1="220.945" y1="5.815" x2="221.265" y2="5.825" layer="94"/>
+<rectangle x1="217.665" y1="5.825" x2="218.265" y2="5.835" layer="94"/>
+<rectangle x1="218.485" y1="5.825" x2="220.655" y2="5.835" layer="94"/>
+<rectangle x1="220.945" y1="5.825" x2="221.275" y2="5.835" layer="94"/>
+<rectangle x1="217.615" y1="5.835" x2="218.275" y2="5.845" layer="94"/>
+<rectangle x1="218.485" y1="5.835" x2="220.655" y2="5.845" layer="94"/>
+<rectangle x1="220.945" y1="5.835" x2="221.285" y2="5.845" layer="94"/>
+<rectangle x1="217.575" y1="5.845" x2="218.295" y2="5.855" layer="94"/>
+<rectangle x1="218.485" y1="5.845" x2="220.655" y2="5.855" layer="94"/>
+<rectangle x1="220.945" y1="5.845" x2="221.295" y2="5.855" layer="94"/>
+<rectangle x1="217.535" y1="5.855" x2="218.305" y2="5.865" layer="94"/>
+<rectangle x1="218.475" y1="5.855" x2="220.655" y2="5.865" layer="94"/>
+<rectangle x1="220.935" y1="5.855" x2="221.305" y2="5.865" layer="94"/>
+<rectangle x1="217.495" y1="5.865" x2="218.315" y2="5.875" layer="94"/>
+<rectangle x1="218.475" y1="5.865" x2="220.655" y2="5.875" layer="94"/>
+<rectangle x1="220.915" y1="5.865" x2="221.315" y2="5.875" layer="94"/>
+<rectangle x1="217.475" y1="5.875" x2="218.325" y2="5.885" layer="94"/>
+<rectangle x1="218.475" y1="5.875" x2="220.655" y2="5.885" layer="94"/>
+<rectangle x1="220.905" y1="5.875" x2="221.325" y2="5.885" layer="94"/>
+<rectangle x1="217.485" y1="5.885" x2="218.345" y2="5.895" layer="94"/>
+<rectangle x1="218.475" y1="5.885" x2="219.535" y2="5.895" layer="94"/>
+<rectangle x1="219.575" y1="5.885" x2="220.655" y2="5.895" layer="94"/>
+<rectangle x1="220.885" y1="5.885" x2="221.325" y2="5.895" layer="94"/>
+<rectangle x1="217.505" y1="5.895" x2="218.355" y2="5.905" layer="94"/>
+<rectangle x1="218.465" y1="5.895" x2="219.315" y2="5.905" layer="94"/>
+<rectangle x1="219.785" y1="5.895" x2="220.655" y2="5.905" layer="94"/>
+<rectangle x1="220.865" y1="5.895" x2="221.335" y2="5.905" layer="94"/>
+<rectangle x1="217.525" y1="5.905" x2="218.365" y2="5.915" layer="94"/>
+<rectangle x1="218.465" y1="5.905" x2="219.215" y2="5.915" layer="94"/>
+<rectangle x1="219.885" y1="5.905" x2="220.665" y2="5.915" layer="94"/>
+<rectangle x1="220.855" y1="5.905" x2="221.345" y2="5.915" layer="94"/>
+<rectangle x1="217.545" y1="5.915" x2="218.375" y2="5.925" layer="94"/>
+<rectangle x1="218.465" y1="5.915" x2="219.145" y2="5.925" layer="94"/>
+<rectangle x1="219.965" y1="5.915" x2="220.665" y2="5.925" layer="94"/>
+<rectangle x1="220.835" y1="5.915" x2="221.355" y2="5.925" layer="94"/>
+<rectangle x1="217.565" y1="5.925" x2="218.395" y2="5.935" layer="94"/>
+<rectangle x1="218.455" y1="5.925" x2="219.085" y2="5.935" layer="94"/>
+<rectangle x1="220.025" y1="5.925" x2="220.665" y2="5.935" layer="94"/>
+<rectangle x1="220.815" y1="5.925" x2="221.365" y2="5.935" layer="94"/>
+<rectangle x1="217.575" y1="5.935" x2="218.405" y2="5.945" layer="94"/>
+<rectangle x1="218.425" y1="5.935" x2="219.025" y2="5.945" layer="94"/>
+<rectangle x1="220.075" y1="5.935" x2="220.665" y2="5.945" layer="94"/>
+<rectangle x1="220.805" y1="5.935" x2="221.375" y2="5.945" layer="94"/>
+<rectangle x1="221.705" y1="5.935" x2="221.715" y2="5.945" layer="94"/>
+<rectangle x1="217.595" y1="5.945" x2="218.975" y2="5.955" layer="94"/>
+<rectangle x1="220.135" y1="5.945" x2="220.695" y2="5.955" layer="94"/>
+<rectangle x1="220.785" y1="5.945" x2="221.385" y2="5.955" layer="94"/>
+<rectangle x1="221.705" y1="5.945" x2="221.715" y2="5.955" layer="94"/>
+<rectangle x1="217.615" y1="5.955" x2="218.935" y2="5.965" layer="94"/>
+<rectangle x1="220.175" y1="5.955" x2="220.715" y2="5.965" layer="94"/>
+<rectangle x1="220.765" y1="5.955" x2="221.395" y2="5.965" layer="94"/>
+<rectangle x1="221.705" y1="5.955" x2="221.725" y2="5.965" layer="94"/>
+<rectangle x1="217.635" y1="5.965" x2="218.885" y2="5.975" layer="94"/>
+<rectangle x1="220.215" y1="5.965" x2="220.735" y2="5.975" layer="94"/>
+<rectangle x1="220.755" y1="5.965" x2="221.405" y2="5.975" layer="94"/>
+<rectangle x1="221.705" y1="5.965" x2="221.725" y2="5.975" layer="94"/>
+<rectangle x1="217.655" y1="5.975" x2="218.845" y2="5.985" layer="94"/>
+<rectangle x1="220.255" y1="5.975" x2="221.405" y2="5.985" layer="94"/>
+<rectangle x1="221.695" y1="5.975" x2="221.735" y2="5.985" layer="94"/>
+<rectangle x1="217.675" y1="5.985" x2="218.815" y2="5.995" layer="94"/>
+<rectangle x1="220.295" y1="5.985" x2="221.395" y2="5.995" layer="94"/>
+<rectangle x1="221.695" y1="5.985" x2="221.745" y2="5.995" layer="94"/>
+<rectangle x1="217.695" y1="5.995" x2="218.775" y2="6.005" layer="94"/>
+<rectangle x1="220.325" y1="5.995" x2="221.395" y2="6.005" layer="94"/>
+<rectangle x1="221.695" y1="5.995" x2="221.745" y2="6.005" layer="94"/>
+<rectangle x1="217.705" y1="6.005" x2="218.745" y2="6.015" layer="94"/>
+<rectangle x1="220.365" y1="6.005" x2="221.395" y2="6.015" layer="94"/>
+<rectangle x1="221.695" y1="6.005" x2="221.755" y2="6.015" layer="94"/>
+<rectangle x1="217.725" y1="6.015" x2="218.705" y2="6.025" layer="94"/>
+<rectangle x1="220.395" y1="6.015" x2="221.395" y2="6.025" layer="94"/>
+<rectangle x1="221.685" y1="6.015" x2="221.755" y2="6.025" layer="94"/>
+<rectangle x1="217.745" y1="6.025" x2="218.675" y2="6.035" layer="94"/>
+<rectangle x1="220.425" y1="6.025" x2="221.395" y2="6.035" layer="94"/>
+<rectangle x1="221.685" y1="6.025" x2="221.765" y2="6.035" layer="94"/>
+<rectangle x1="217.765" y1="6.035" x2="218.645" y2="6.045" layer="94"/>
+<rectangle x1="220.455" y1="6.035" x2="221.395" y2="6.045" layer="94"/>
+<rectangle x1="221.685" y1="6.035" x2="221.765" y2="6.045" layer="94"/>
+<rectangle x1="217.785" y1="6.045" x2="218.615" y2="6.055" layer="94"/>
+<rectangle x1="220.485" y1="6.045" x2="221.395" y2="6.055" layer="94"/>
+<rectangle x1="221.685" y1="6.045" x2="221.775" y2="6.055" layer="94"/>
+<rectangle x1="217.795" y1="6.055" x2="218.595" y2="6.065" layer="94"/>
+<rectangle x1="220.515" y1="6.055" x2="221.385" y2="6.065" layer="94"/>
+<rectangle x1="221.675" y1="6.055" x2="221.775" y2="6.065" layer="94"/>
+<rectangle x1="217.805" y1="6.065" x2="218.565" y2="6.075" layer="94"/>
+<rectangle x1="220.535" y1="6.065" x2="221.385" y2="6.075" layer="94"/>
+<rectangle x1="221.675" y1="6.065" x2="221.785" y2="6.075" layer="94"/>
+<rectangle x1="217.805" y1="6.075" x2="218.535" y2="6.085" layer="94"/>
+<rectangle x1="220.565" y1="6.075" x2="221.385" y2="6.085" layer="94"/>
+<rectangle x1="221.675" y1="6.075" x2="221.785" y2="6.085" layer="94"/>
+<rectangle x1="217.805" y1="6.085" x2="218.515" y2="6.095" layer="94"/>
+<rectangle x1="220.595" y1="6.085" x2="221.385" y2="6.095" layer="94"/>
+<rectangle x1="221.675" y1="6.085" x2="221.795" y2="6.095" layer="94"/>
+<rectangle x1="217.805" y1="6.095" x2="218.485" y2="6.105" layer="94"/>
+<rectangle x1="220.615" y1="6.095" x2="221.385" y2="6.105" layer="94"/>
+<rectangle x1="221.675" y1="6.095" x2="221.795" y2="6.105" layer="94"/>
+<rectangle x1="217.805" y1="6.105" x2="218.465" y2="6.115" layer="94"/>
+<rectangle x1="219.535" y1="6.105" x2="219.565" y2="6.115" layer="94"/>
+<rectangle x1="220.645" y1="6.105" x2="221.385" y2="6.115" layer="94"/>
+<rectangle x1="221.665" y1="6.105" x2="221.805" y2="6.115" layer="94"/>
+<rectangle x1="217.805" y1="6.115" x2="218.445" y2="6.125" layer="94"/>
+<rectangle x1="219.325" y1="6.115" x2="219.775" y2="6.125" layer="94"/>
+<rectangle x1="220.665" y1="6.115" x2="221.375" y2="6.125" layer="94"/>
+<rectangle x1="221.665" y1="6.115" x2="221.815" y2="6.125" layer="94"/>
+<rectangle x1="217.805" y1="6.125" x2="218.415" y2="6.135" layer="94"/>
+<rectangle x1="219.235" y1="6.125" x2="219.875" y2="6.135" layer="94"/>
+<rectangle x1="220.685" y1="6.125" x2="221.375" y2="6.135" layer="94"/>
+<rectangle x1="221.665" y1="6.125" x2="221.815" y2="6.135" layer="94"/>
+<rectangle x1="217.805" y1="6.135" x2="218.395" y2="6.145" layer="94"/>
+<rectangle x1="219.155" y1="6.135" x2="219.945" y2="6.145" layer="94"/>
+<rectangle x1="220.705" y1="6.135" x2="221.375" y2="6.145" layer="94"/>
+<rectangle x1="221.665" y1="6.135" x2="221.825" y2="6.145" layer="94"/>
+<rectangle x1="217.805" y1="6.145" x2="218.375" y2="6.155" layer="94"/>
+<rectangle x1="219.105" y1="6.145" x2="220.005" y2="6.155" layer="94"/>
+<rectangle x1="220.725" y1="6.145" x2="221.375" y2="6.155" layer="94"/>
+<rectangle x1="221.655" y1="6.145" x2="221.825" y2="6.155" layer="94"/>
+<rectangle x1="217.805" y1="6.155" x2="218.355" y2="6.165" layer="94"/>
+<rectangle x1="219.045" y1="6.155" x2="220.055" y2="6.165" layer="94"/>
+<rectangle x1="220.755" y1="6.155" x2="221.375" y2="6.165" layer="94"/>
+<rectangle x1="221.655" y1="6.155" x2="221.835" y2="6.165" layer="94"/>
+<rectangle x1="217.805" y1="6.165" x2="218.335" y2="6.175" layer="94"/>
+<rectangle x1="218.995" y1="6.165" x2="220.105" y2="6.175" layer="94"/>
+<rectangle x1="220.775" y1="6.165" x2="221.375" y2="6.175" layer="94"/>
+<rectangle x1="221.655" y1="6.165" x2="221.835" y2="6.175" layer="94"/>
+<rectangle x1="217.805" y1="6.175" x2="218.315" y2="6.185" layer="94"/>
+<rectangle x1="218.955" y1="6.175" x2="220.145" y2="6.185" layer="94"/>
+<rectangle x1="220.795" y1="6.175" x2="221.375" y2="6.185" layer="94"/>
+<rectangle x1="221.655" y1="6.175" x2="221.845" y2="6.185" layer="94"/>
+<rectangle x1="217.805" y1="6.185" x2="218.295" y2="6.195" layer="94"/>
+<rectangle x1="218.915" y1="6.185" x2="220.195" y2="6.195" layer="94"/>
+<rectangle x1="220.815" y1="6.185" x2="221.365" y2="6.195" layer="94"/>
+<rectangle x1="221.645" y1="6.185" x2="221.845" y2="6.195" layer="94"/>
+<rectangle x1="217.395" y1="6.195" x2="217.405" y2="6.205" layer="94"/>
+<rectangle x1="217.805" y1="6.195" x2="218.275" y2="6.205" layer="94"/>
+<rectangle x1="218.875" y1="6.195" x2="220.225" y2="6.205" layer="94"/>
+<rectangle x1="220.835" y1="6.195" x2="221.365" y2="6.205" layer="94"/>
+<rectangle x1="221.645" y1="6.195" x2="221.855" y2="6.205" layer="94"/>
+<rectangle x1="217.375" y1="6.205" x2="217.425" y2="6.215" layer="94"/>
+<rectangle x1="217.805" y1="6.205" x2="218.255" y2="6.215" layer="94"/>
+<rectangle x1="218.845" y1="6.205" x2="220.265" y2="6.215" layer="94"/>
+<rectangle x1="220.855" y1="6.205" x2="221.365" y2="6.215" layer="94"/>
+<rectangle x1="221.645" y1="6.205" x2="221.855" y2="6.215" layer="94"/>
+<rectangle x1="217.355" y1="6.215" x2="217.455" y2="6.225" layer="94"/>
+<rectangle x1="217.805" y1="6.215" x2="218.235" y2="6.225" layer="94"/>
+<rectangle x1="218.805" y1="6.215" x2="220.295" y2="6.225" layer="94"/>
+<rectangle x1="220.875" y1="6.215" x2="221.365" y2="6.225" layer="94"/>
+<rectangle x1="221.645" y1="6.215" x2="221.865" y2="6.225" layer="94"/>
+<rectangle x1="217.335" y1="6.225" x2="217.475" y2="6.235" layer="94"/>
+<rectangle x1="217.805" y1="6.225" x2="218.215" y2="6.235" layer="94"/>
+<rectangle x1="218.775" y1="6.225" x2="220.335" y2="6.235" layer="94"/>
+<rectangle x1="220.885" y1="6.225" x2="221.365" y2="6.235" layer="94"/>
+<rectangle x1="221.635" y1="6.225" x2="221.875" y2="6.235" layer="94"/>
+<rectangle x1="217.325" y1="6.235" x2="217.495" y2="6.245" layer="94"/>
+<rectangle x1="217.805" y1="6.235" x2="218.195" y2="6.245" layer="94"/>
+<rectangle x1="218.745" y1="6.235" x2="220.365" y2="6.245" layer="94"/>
+<rectangle x1="220.905" y1="6.235" x2="221.365" y2="6.245" layer="94"/>
+<rectangle x1="221.635" y1="6.235" x2="221.875" y2="6.245" layer="94"/>
+<rectangle x1="217.305" y1="6.245" x2="217.515" y2="6.255" layer="94"/>
+<rectangle x1="217.805" y1="6.245" x2="218.185" y2="6.255" layer="94"/>
+<rectangle x1="218.715" y1="6.245" x2="220.385" y2="6.255" layer="94"/>
+<rectangle x1="220.925" y1="6.245" x2="221.355" y2="6.255" layer="94"/>
+<rectangle x1="221.635" y1="6.245" x2="221.885" y2="6.255" layer="94"/>
+<rectangle x1="217.285" y1="6.255" x2="217.545" y2="6.265" layer="94"/>
+<rectangle x1="217.805" y1="6.255" x2="218.165" y2="6.265" layer="94"/>
+<rectangle x1="218.685" y1="6.255" x2="220.415" y2="6.265" layer="94"/>
+<rectangle x1="220.945" y1="6.255" x2="221.355" y2="6.265" layer="94"/>
+<rectangle x1="221.635" y1="6.255" x2="221.885" y2="6.265" layer="94"/>
+<rectangle x1="217.265" y1="6.265" x2="217.565" y2="6.275" layer="94"/>
+<rectangle x1="217.805" y1="6.265" x2="218.145" y2="6.275" layer="94"/>
+<rectangle x1="218.655" y1="6.265" x2="220.445" y2="6.275" layer="94"/>
+<rectangle x1="220.955" y1="6.265" x2="221.355" y2="6.275" layer="94"/>
+<rectangle x1="221.635" y1="6.265" x2="221.895" y2="6.275" layer="94"/>
+<rectangle x1="217.245" y1="6.275" x2="217.585" y2="6.285" layer="94"/>
+<rectangle x1="217.805" y1="6.275" x2="218.125" y2="6.285" layer="94"/>
+<rectangle x1="218.635" y1="6.275" x2="220.475" y2="6.285" layer="94"/>
+<rectangle x1="220.975" y1="6.275" x2="221.355" y2="6.285" layer="94"/>
+<rectangle x1="221.625" y1="6.275" x2="221.895" y2="6.285" layer="94"/>
+<rectangle x1="217.225" y1="6.285" x2="217.615" y2="6.295" layer="94"/>
+<rectangle x1="217.805" y1="6.285" x2="218.115" y2="6.295" layer="94"/>
+<rectangle x1="218.605" y1="6.285" x2="220.495" y2="6.295" layer="94"/>
+<rectangle x1="220.995" y1="6.285" x2="221.355" y2="6.295" layer="94"/>
+<rectangle x1="221.625" y1="6.285" x2="221.905" y2="6.295" layer="94"/>
+<rectangle x1="217.215" y1="6.295" x2="217.635" y2="6.305" layer="94"/>
+<rectangle x1="217.785" y1="6.295" x2="218.095" y2="6.305" layer="94"/>
+<rectangle x1="218.585" y1="6.295" x2="220.525" y2="6.305" layer="94"/>
+<rectangle x1="221.005" y1="6.295" x2="221.355" y2="6.305" layer="94"/>
+<rectangle x1="221.625" y1="6.295" x2="221.905" y2="6.305" layer="94"/>
+<rectangle x1="217.195" y1="6.305" x2="217.655" y2="6.315" layer="94"/>
+<rectangle x1="217.775" y1="6.305" x2="218.075" y2="6.315" layer="94"/>
+<rectangle x1="218.555" y1="6.305" x2="220.545" y2="6.315" layer="94"/>
+<rectangle x1="221.025" y1="6.305" x2="221.345" y2="6.315" layer="94"/>
+<rectangle x1="221.615" y1="6.305" x2="221.915" y2="6.315" layer="94"/>
+<rectangle x1="217.175" y1="6.315" x2="217.675" y2="6.325" layer="94"/>
+<rectangle x1="217.765" y1="6.315" x2="218.065" y2="6.325" layer="94"/>
+<rectangle x1="218.535" y1="6.315" x2="220.575" y2="6.325" layer="94"/>
+<rectangle x1="221.045" y1="6.315" x2="221.345" y2="6.325" layer="94"/>
+<rectangle x1="221.585" y1="6.315" x2="221.915" y2="6.325" layer="94"/>
+<rectangle x1="217.155" y1="6.325" x2="217.705" y2="6.335" layer="94"/>
+<rectangle x1="217.745" y1="6.325" x2="218.045" y2="6.335" layer="94"/>
+<rectangle x1="218.515" y1="6.325" x2="220.595" y2="6.335" layer="94"/>
+<rectangle x1="221.055" y1="6.325" x2="221.355" y2="6.335" layer="94"/>
+<rectangle x1="221.545" y1="6.325" x2="221.925" y2="6.335" layer="94"/>
+<rectangle x1="217.135" y1="6.335" x2="217.725" y2="6.345" layer="94"/>
+<rectangle x1="217.735" y1="6.335" x2="218.035" y2="6.345" layer="94"/>
+<rectangle x1="218.485" y1="6.335" x2="220.615" y2="6.345" layer="94"/>
+<rectangle x1="221.075" y1="6.335" x2="221.365" y2="6.345" layer="94"/>
+<rectangle x1="221.515" y1="6.335" x2="221.935" y2="6.345" layer="94"/>
+<rectangle x1="217.115" y1="6.345" x2="218.015" y2="6.355" layer="94"/>
+<rectangle x1="218.465" y1="6.345" x2="220.635" y2="6.355" layer="94"/>
+<rectangle x1="221.085" y1="6.345" x2="221.375" y2="6.355" layer="94"/>
+<rectangle x1="221.475" y1="6.345" x2="221.935" y2="6.355" layer="94"/>
+<rectangle x1="217.105" y1="6.355" x2="218.005" y2="6.365" layer="94"/>
+<rectangle x1="218.445" y1="6.355" x2="220.655" y2="6.365" layer="94"/>
+<rectangle x1="221.105" y1="6.355" x2="221.395" y2="6.365" layer="94"/>
+<rectangle x1="221.445" y1="6.355" x2="221.945" y2="6.365" layer="94"/>
+<rectangle x1="217.085" y1="6.365" x2="217.985" y2="6.375" layer="94"/>
+<rectangle x1="218.425" y1="6.365" x2="220.685" y2="6.375" layer="94"/>
+<rectangle x1="221.115" y1="6.365" x2="221.405" y2="6.375" layer="94"/>
+<rectangle x1="221.415" y1="6.365" x2="221.945" y2="6.375" layer="94"/>
+<rectangle x1="217.065" y1="6.375" x2="217.975" y2="6.385" layer="94"/>
+<rectangle x1="218.405" y1="6.375" x2="220.695" y2="6.385" layer="94"/>
+<rectangle x1="221.135" y1="6.375" x2="221.955" y2="6.385" layer="94"/>
+<rectangle x1="217.045" y1="6.385" x2="217.955" y2="6.395" layer="94"/>
+<rectangle x1="218.385" y1="6.385" x2="220.715" y2="6.395" layer="94"/>
+<rectangle x1="221.145" y1="6.385" x2="221.955" y2="6.395" layer="94"/>
+<rectangle x1="217.025" y1="6.395" x2="217.945" y2="6.405" layer="94"/>
+<rectangle x1="218.365" y1="6.395" x2="220.735" y2="6.405" layer="94"/>
+<rectangle x1="221.165" y1="6.395" x2="221.965" y2="6.405" layer="94"/>
+<rectangle x1="217.005" y1="6.405" x2="217.925" y2="6.415" layer="94"/>
+<rectangle x1="218.345" y1="6.405" x2="220.755" y2="6.415" layer="94"/>
+<rectangle x1="221.175" y1="6.405" x2="221.965" y2="6.415" layer="94"/>
+<rectangle x1="216.995" y1="6.415" x2="217.915" y2="6.425" layer="94"/>
+<rectangle x1="218.325" y1="6.415" x2="220.775" y2="6.425" layer="94"/>
+<rectangle x1="221.185" y1="6.415" x2="221.975" y2="6.425" layer="94"/>
+<rectangle x1="216.975" y1="6.425" x2="217.905" y2="6.435" layer="94"/>
+<rectangle x1="218.305" y1="6.425" x2="220.795" y2="6.435" layer="94"/>
+<rectangle x1="221.205" y1="6.425" x2="221.975" y2="6.435" layer="94"/>
+<rectangle x1="216.955" y1="6.435" x2="217.885" y2="6.445" layer="94"/>
+<rectangle x1="218.295" y1="6.435" x2="220.815" y2="6.445" layer="94"/>
+<rectangle x1="221.215" y1="6.435" x2="221.985" y2="6.445" layer="94"/>
+<rectangle x1="216.935" y1="6.445" x2="217.875" y2="6.455" layer="94"/>
+<rectangle x1="218.275" y1="6.445" x2="220.835" y2="6.455" layer="94"/>
+<rectangle x1="221.235" y1="6.445" x2="221.995" y2="6.455" layer="94"/>
+<rectangle x1="216.915" y1="6.455" x2="217.865" y2="6.465" layer="94"/>
+<rectangle x1="218.255" y1="6.455" x2="220.845" y2="6.465" layer="94"/>
+<rectangle x1="221.245" y1="6.455" x2="221.995" y2="6.465" layer="94"/>
+<rectangle x1="216.895" y1="6.465" x2="217.845" y2="6.475" layer="94"/>
+<rectangle x1="218.235" y1="6.465" x2="220.865" y2="6.475" layer="94"/>
+<rectangle x1="221.255" y1="6.465" x2="222.005" y2="6.475" layer="94"/>
+<rectangle x1="216.885" y1="6.475" x2="217.835" y2="6.485" layer="94"/>
+<rectangle x1="218.225" y1="6.475" x2="220.885" y2="6.485" layer="94"/>
+<rectangle x1="221.265" y1="6.475" x2="222.005" y2="6.485" layer="94"/>
+<rectangle x1="216.865" y1="6.485" x2="217.825" y2="6.495" layer="94"/>
+<rectangle x1="218.205" y1="6.485" x2="220.895" y2="6.495" layer="94"/>
+<rectangle x1="221.285" y1="6.485" x2="222.015" y2="6.495" layer="94"/>
+<rectangle x1="216.845" y1="6.495" x2="217.815" y2="6.505" layer="94"/>
+<rectangle x1="218.195" y1="6.495" x2="220.915" y2="6.505" layer="94"/>
+<rectangle x1="221.295" y1="6.495" x2="222.015" y2="6.505" layer="94"/>
+<rectangle x1="216.825" y1="6.505" x2="217.795" y2="6.515" layer="94"/>
+<rectangle x1="218.175" y1="6.505" x2="220.925" y2="6.515" layer="94"/>
+<rectangle x1="221.305" y1="6.505" x2="222.025" y2="6.515" layer="94"/>
+<rectangle x1="216.805" y1="6.515" x2="217.785" y2="6.525" layer="94"/>
+<rectangle x1="218.155" y1="6.515" x2="220.945" y2="6.525" layer="94"/>
+<rectangle x1="221.315" y1="6.515" x2="222.025" y2="6.525" layer="94"/>
+<rectangle x1="216.825" y1="6.525" x2="217.775" y2="6.535" layer="94"/>
+<rectangle x1="218.145" y1="6.525" x2="220.965" y2="6.535" layer="94"/>
+<rectangle x1="221.335" y1="6.525" x2="222.035" y2="6.535" layer="94"/>
+<rectangle x1="216.865" y1="6.535" x2="217.765" y2="6.545" layer="94"/>
+<rectangle x1="218.125" y1="6.535" x2="220.975" y2="6.545" layer="94"/>
+<rectangle x1="221.345" y1="6.535" x2="222.035" y2="6.545" layer="94"/>
+<rectangle x1="216.905" y1="6.545" x2="217.745" y2="6.555" layer="94"/>
+<rectangle x1="218.115" y1="6.545" x2="220.995" y2="6.555" layer="94"/>
+<rectangle x1="221.355" y1="6.545" x2="222.025" y2="6.555" layer="94"/>
+<rectangle x1="216.955" y1="6.555" x2="217.735" y2="6.565" layer="94"/>
+<rectangle x1="218.095" y1="6.555" x2="221.005" y2="6.565" layer="94"/>
+<rectangle x1="221.365" y1="6.555" x2="222.025" y2="6.565" layer="94"/>
+<rectangle x1="216.995" y1="6.565" x2="217.725" y2="6.575" layer="94"/>
+<rectangle x1="218.085" y1="6.565" x2="221.025" y2="6.575" layer="94"/>
+<rectangle x1="221.375" y1="6.565" x2="222.025" y2="6.575" layer="94"/>
+<rectangle x1="217.035" y1="6.575" x2="217.715" y2="6.585" layer="94"/>
+<rectangle x1="218.075" y1="6.575" x2="221.035" y2="6.585" layer="94"/>
+<rectangle x1="221.385" y1="6.575" x2="222.015" y2="6.585" layer="94"/>
+<rectangle x1="217.075" y1="6.585" x2="217.705" y2="6.595" layer="94"/>
+<rectangle x1="218.055" y1="6.585" x2="221.045" y2="6.595" layer="94"/>
+<rectangle x1="221.405" y1="6.585" x2="222.015" y2="6.595" layer="94"/>
+<rectangle x1="217.125" y1="6.595" x2="217.695" y2="6.605" layer="94"/>
+<rectangle x1="218.045" y1="6.595" x2="221.065" y2="6.605" layer="94"/>
+<rectangle x1="221.415" y1="6.595" x2="222.005" y2="6.605" layer="94"/>
+<rectangle x1="217.165" y1="6.605" x2="217.685" y2="6.615" layer="94"/>
+<rectangle x1="218.025" y1="6.605" x2="221.075" y2="6.615" layer="94"/>
+<rectangle x1="221.425" y1="6.605" x2="222.005" y2="6.615" layer="94"/>
+<rectangle x1="222.355" y1="6.605" x2="222.365" y2="6.615" layer="94"/>
+<rectangle x1="217.175" y1="6.615" x2="217.665" y2="6.625" layer="94"/>
+<rectangle x1="218.015" y1="6.615" x2="221.095" y2="6.625" layer="94"/>
+<rectangle x1="221.435" y1="6.615" x2="221.995" y2="6.625" layer="94"/>
+<rectangle x1="222.345" y1="6.615" x2="222.365" y2="6.625" layer="94"/>
+<rectangle x1="217.185" y1="6.625" x2="217.655" y2="6.635" layer="94"/>
+<rectangle x1="218.005" y1="6.625" x2="221.105" y2="6.635" layer="94"/>
+<rectangle x1="221.445" y1="6.625" x2="221.995" y2="6.635" layer="94"/>
+<rectangle x1="222.345" y1="6.625" x2="222.365" y2="6.635" layer="94"/>
+<rectangle x1="217.185" y1="6.635" x2="217.645" y2="6.645" layer="94"/>
+<rectangle x1="217.985" y1="6.635" x2="221.115" y2="6.645" layer="94"/>
+<rectangle x1="221.455" y1="6.635" x2="221.985" y2="6.645" layer="94"/>
+<rectangle x1="222.335" y1="6.635" x2="222.365" y2="6.645" layer="94"/>
+<rectangle x1="217.185" y1="6.645" x2="217.635" y2="6.655" layer="94"/>
+<rectangle x1="217.975" y1="6.645" x2="221.125" y2="6.655" layer="94"/>
+<rectangle x1="221.465" y1="6.645" x2="221.985" y2="6.655" layer="94"/>
+<rectangle x1="222.325" y1="6.645" x2="222.375" y2="6.655" layer="94"/>
+<rectangle x1="217.185" y1="6.655" x2="217.625" y2="6.665" layer="94"/>
+<rectangle x1="217.965" y1="6.655" x2="221.145" y2="6.665" layer="94"/>
+<rectangle x1="221.475" y1="6.655" x2="221.985" y2="6.665" layer="94"/>
+<rectangle x1="222.325" y1="6.655" x2="222.375" y2="6.665" layer="94"/>
+<rectangle x1="217.195" y1="6.665" x2="217.615" y2="6.675" layer="94"/>
+<rectangle x1="217.955" y1="6.665" x2="221.155" y2="6.675" layer="94"/>
+<rectangle x1="221.485" y1="6.665" x2="221.975" y2="6.675" layer="94"/>
+<rectangle x1="222.315" y1="6.665" x2="222.375" y2="6.675" layer="94"/>
+<rectangle x1="217.195" y1="6.675" x2="217.605" y2="6.685" layer="94"/>
+<rectangle x1="217.935" y1="6.675" x2="221.165" y2="6.685" layer="94"/>
+<rectangle x1="221.495" y1="6.675" x2="221.975" y2="6.685" layer="94"/>
+<rectangle x1="222.315" y1="6.675" x2="222.375" y2="6.685" layer="94"/>
+<rectangle x1="217.195" y1="6.685" x2="217.595" y2="6.695" layer="94"/>
+<rectangle x1="217.925" y1="6.685" x2="221.175" y2="6.695" layer="94"/>
+<rectangle x1="221.505" y1="6.685" x2="221.965" y2="6.695" layer="94"/>
+<rectangle x1="222.305" y1="6.685" x2="222.385" y2="6.695" layer="94"/>
+<rectangle x1="217.205" y1="6.695" x2="217.585" y2="6.705" layer="94"/>
+<rectangle x1="217.915" y1="6.695" x2="221.195" y2="6.705" layer="94"/>
+<rectangle x1="221.515" y1="6.695" x2="221.965" y2="6.705" layer="94"/>
+<rectangle x1="222.305" y1="6.695" x2="222.385" y2="6.705" layer="94"/>
+<rectangle x1="217.205" y1="6.705" x2="217.575" y2="6.715" layer="94"/>
+<rectangle x1="217.905" y1="6.705" x2="221.205" y2="6.715" layer="94"/>
+<rectangle x1="221.525" y1="6.705" x2="221.955" y2="6.715" layer="94"/>
+<rectangle x1="222.295" y1="6.705" x2="222.385" y2="6.715" layer="94"/>
+<rectangle x1="217.205" y1="6.715" x2="217.565" y2="6.725" layer="94"/>
+<rectangle x1="217.885" y1="6.715" x2="221.215" y2="6.725" layer="94"/>
+<rectangle x1="221.535" y1="6.715" x2="221.955" y2="6.725" layer="94"/>
+<rectangle x1="222.295" y1="6.715" x2="222.385" y2="6.725" layer="94"/>
+<rectangle x1="217.205" y1="6.725" x2="217.555" y2="6.735" layer="94"/>
+<rectangle x1="217.875" y1="6.725" x2="221.225" y2="6.735" layer="94"/>
+<rectangle x1="221.545" y1="6.725" x2="221.955" y2="6.735" layer="94"/>
+<rectangle x1="222.285" y1="6.725" x2="222.395" y2="6.735" layer="94"/>
+<rectangle x1="217.215" y1="6.735" x2="217.545" y2="6.745" layer="94"/>
+<rectangle x1="217.865" y1="6.735" x2="221.235" y2="6.745" layer="94"/>
+<rectangle x1="221.555" y1="6.735" x2="221.945" y2="6.745" layer="94"/>
+<rectangle x1="222.285" y1="6.735" x2="222.395" y2="6.745" layer="94"/>
+<rectangle x1="217.215" y1="6.745" x2="217.535" y2="6.755" layer="94"/>
+<rectangle x1="217.855" y1="6.745" x2="221.245" y2="6.755" layer="94"/>
+<rectangle x1="221.565" y1="6.745" x2="221.945" y2="6.755" layer="94"/>
+<rectangle x1="222.275" y1="6.745" x2="222.395" y2="6.755" layer="94"/>
+<rectangle x1="217.215" y1="6.755" x2="217.525" y2="6.765" layer="94"/>
+<rectangle x1="217.845" y1="6.755" x2="221.265" y2="6.765" layer="94"/>
+<rectangle x1="221.575" y1="6.755" x2="221.935" y2="6.765" layer="94"/>
+<rectangle x1="222.275" y1="6.755" x2="222.395" y2="6.765" layer="94"/>
+<rectangle x1="217.225" y1="6.765" x2="217.515" y2="6.775" layer="94"/>
+<rectangle x1="217.835" y1="6.765" x2="221.275" y2="6.775" layer="94"/>
+<rectangle x1="221.585" y1="6.765" x2="221.935" y2="6.775" layer="94"/>
+<rectangle x1="222.265" y1="6.765" x2="222.405" y2="6.775" layer="94"/>
+<rectangle x1="217.225" y1="6.775" x2="217.505" y2="6.785" layer="94"/>
+<rectangle x1="217.825" y1="6.775" x2="221.285" y2="6.785" layer="94"/>
+<rectangle x1="221.595" y1="6.775" x2="221.925" y2="6.785" layer="94"/>
+<rectangle x1="222.255" y1="6.775" x2="222.405" y2="6.785" layer="94"/>
+<rectangle x1="217.225" y1="6.785" x2="217.495" y2="6.795" layer="94"/>
+<rectangle x1="217.805" y1="6.785" x2="221.295" y2="6.795" layer="94"/>
+<rectangle x1="221.605" y1="6.785" x2="221.925" y2="6.795" layer="94"/>
+<rectangle x1="222.255" y1="6.785" x2="222.405" y2="6.795" layer="94"/>
+<rectangle x1="217.225" y1="6.795" x2="217.485" y2="6.805" layer="94"/>
+<rectangle x1="217.795" y1="6.795" x2="221.305" y2="6.805" layer="94"/>
+<rectangle x1="221.615" y1="6.795" x2="221.915" y2="6.805" layer="94"/>
+<rectangle x1="222.245" y1="6.795" x2="222.405" y2="6.805" layer="94"/>
+<rectangle x1="217.235" y1="6.805" x2="217.475" y2="6.815" layer="94"/>
+<rectangle x1="217.785" y1="6.805" x2="221.315" y2="6.815" layer="94"/>
+<rectangle x1="221.625" y1="6.805" x2="221.915" y2="6.815" layer="94"/>
+<rectangle x1="222.245" y1="6.805" x2="222.405" y2="6.815" layer="94"/>
+<rectangle x1="217.235" y1="6.815" x2="217.475" y2="6.825" layer="94"/>
+<rectangle x1="217.775" y1="6.815" x2="221.325" y2="6.825" layer="94"/>
+<rectangle x1="221.635" y1="6.815" x2="221.915" y2="6.825" layer="94"/>
+<rectangle x1="222.235" y1="6.815" x2="222.415" y2="6.825" layer="94"/>
+<rectangle x1="217.235" y1="6.825" x2="217.465" y2="6.835" layer="94"/>
+<rectangle x1="217.765" y1="6.825" x2="221.335" y2="6.835" layer="94"/>
+<rectangle x1="221.645" y1="6.825" x2="221.905" y2="6.835" layer="94"/>
+<rectangle x1="222.235" y1="6.825" x2="222.415" y2="6.835" layer="94"/>
+<rectangle x1="216.825" y1="6.835" x2="216.895" y2="6.845" layer="94"/>
+<rectangle x1="217.225" y1="6.835" x2="217.455" y2="6.845" layer="94"/>
+<rectangle x1="217.755" y1="6.835" x2="221.345" y2="6.845" layer="94"/>
+<rectangle x1="221.655" y1="6.835" x2="221.905" y2="6.845" layer="94"/>
+<rectangle x1="222.225" y1="6.835" x2="222.415" y2="6.845" layer="94"/>
+<rectangle x1="216.815" y1="6.845" x2="216.965" y2="6.855" layer="94"/>
+<rectangle x1="217.215" y1="6.845" x2="217.445" y2="6.855" layer="94"/>
+<rectangle x1="217.745" y1="6.845" x2="221.355" y2="6.855" layer="94"/>
+<rectangle x1="221.655" y1="6.845" x2="221.895" y2="6.855" layer="94"/>
+<rectangle x1="222.225" y1="6.845" x2="222.415" y2="6.855" layer="94"/>
+<rectangle x1="216.805" y1="6.855" x2="217.025" y2="6.865" layer="94"/>
+<rectangle x1="217.205" y1="6.855" x2="217.435" y2="6.865" layer="94"/>
+<rectangle x1="217.735" y1="6.855" x2="221.365" y2="6.865" layer="94"/>
+<rectangle x1="221.665" y1="6.855" x2="221.895" y2="6.865" layer="94"/>
+<rectangle x1="222.215" y1="6.855" x2="222.425" y2="6.865" layer="94"/>
+<rectangle x1="216.795" y1="6.865" x2="217.085" y2="6.875" layer="94"/>
+<rectangle x1="217.205" y1="6.865" x2="217.425" y2="6.875" layer="94"/>
+<rectangle x1="217.725" y1="6.865" x2="221.375" y2="6.875" layer="94"/>
+<rectangle x1="221.675" y1="6.865" x2="221.905" y2="6.875" layer="94"/>
+<rectangle x1="222.215" y1="6.865" x2="222.425" y2="6.875" layer="94"/>
+<rectangle x1="216.785" y1="6.875" x2="217.155" y2="6.885" layer="94"/>
+<rectangle x1="217.195" y1="6.875" x2="217.415" y2="6.885" layer="94"/>
+<rectangle x1="217.715" y1="6.875" x2="221.385" y2="6.885" layer="94"/>
+<rectangle x1="221.685" y1="6.875" x2="221.915" y2="6.885" layer="94"/>
+<rectangle x1="222.205" y1="6.875" x2="222.425" y2="6.885" layer="94"/>
+<rectangle x1="216.775" y1="6.885" x2="217.415" y2="6.895" layer="94"/>
+<rectangle x1="217.705" y1="6.885" x2="221.395" y2="6.895" layer="94"/>
+<rectangle x1="221.695" y1="6.885" x2="221.915" y2="6.895" layer="94"/>
+<rectangle x1="222.195" y1="6.885" x2="222.425" y2="6.895" layer="94"/>
+<rectangle x1="216.765" y1="6.895" x2="217.405" y2="6.905" layer="94"/>
+<rectangle x1="217.695" y1="6.895" x2="221.405" y2="6.905" layer="94"/>
+<rectangle x1="221.705" y1="6.895" x2="221.925" y2="6.905" layer="94"/>
+<rectangle x1="222.195" y1="6.895" x2="222.435" y2="6.905" layer="94"/>
+<rectangle x1="216.755" y1="6.905" x2="217.395" y2="6.915" layer="94"/>
+<rectangle x1="217.685" y1="6.905" x2="221.415" y2="6.915" layer="94"/>
+<rectangle x1="221.715" y1="6.905" x2="221.935" y2="6.915" layer="94"/>
+<rectangle x1="222.185" y1="6.905" x2="222.435" y2="6.915" layer="94"/>
+<rectangle x1="216.745" y1="6.915" x2="217.385" y2="6.925" layer="94"/>
+<rectangle x1="217.675" y1="6.915" x2="221.425" y2="6.925" layer="94"/>
+<rectangle x1="221.715" y1="6.915" x2="221.945" y2="6.925" layer="94"/>
+<rectangle x1="222.185" y1="6.915" x2="222.435" y2="6.925" layer="94"/>
+<rectangle x1="216.735" y1="6.925" x2="217.375" y2="6.935" layer="94"/>
+<rectangle x1="217.665" y1="6.925" x2="221.435" y2="6.935" layer="94"/>
+<rectangle x1="221.725" y1="6.925" x2="221.945" y2="6.935" layer="94"/>
+<rectangle x1="222.175" y1="6.925" x2="222.435" y2="6.935" layer="94"/>
+<rectangle x1="216.715" y1="6.935" x2="217.365" y2="6.945" layer="94"/>
+<rectangle x1="217.655" y1="6.935" x2="221.445" y2="6.945" layer="94"/>
+<rectangle x1="221.735" y1="6.935" x2="222.445" y2="6.945" layer="94"/>
+<rectangle x1="216.705" y1="6.945" x2="217.365" y2="6.955" layer="94"/>
+<rectangle x1="217.655" y1="6.945" x2="221.455" y2="6.955" layer="94"/>
+<rectangle x1="221.745" y1="6.945" x2="222.445" y2="6.955" layer="94"/>
+<rectangle x1="216.695" y1="6.955" x2="217.355" y2="6.965" layer="94"/>
+<rectangle x1="217.645" y1="6.955" x2="221.465" y2="6.965" layer="94"/>
+<rectangle x1="221.755" y1="6.955" x2="222.445" y2="6.965" layer="94"/>
+<rectangle x1="216.685" y1="6.965" x2="217.345" y2="6.975" layer="94"/>
+<rectangle x1="217.635" y1="6.965" x2="221.475" y2="6.975" layer="94"/>
+<rectangle x1="221.755" y1="6.965" x2="222.445" y2="6.975" layer="94"/>
+<rectangle x1="216.675" y1="6.975" x2="217.335" y2="6.985" layer="94"/>
+<rectangle x1="217.625" y1="6.975" x2="221.485" y2="6.985" layer="94"/>
+<rectangle x1="221.765" y1="6.975" x2="222.455" y2="6.985" layer="94"/>
+<rectangle x1="216.665" y1="6.985" x2="217.335" y2="6.995" layer="94"/>
+<rectangle x1="217.615" y1="6.985" x2="221.485" y2="6.995" layer="94"/>
+<rectangle x1="221.775" y1="6.985" x2="222.455" y2="6.995" layer="94"/>
+<rectangle x1="216.655" y1="6.995" x2="217.325" y2="7.005" layer="94"/>
+<rectangle x1="217.605" y1="6.995" x2="221.495" y2="7.005" layer="94"/>
+<rectangle x1="221.785" y1="6.995" x2="222.455" y2="7.005" layer="94"/>
+<rectangle x1="216.645" y1="7.005" x2="217.315" y2="7.015" layer="94"/>
+<rectangle x1="217.595" y1="7.005" x2="221.505" y2="7.015" layer="94"/>
+<rectangle x1="221.785" y1="7.005" x2="222.455" y2="7.015" layer="94"/>
+<rectangle x1="216.635" y1="7.015" x2="217.305" y2="7.025" layer="94"/>
+<rectangle x1="217.585" y1="7.015" x2="221.515" y2="7.025" layer="94"/>
+<rectangle x1="221.795" y1="7.015" x2="222.465" y2="7.025" layer="94"/>
+<rectangle x1="216.625" y1="7.025" x2="217.305" y2="7.035" layer="94"/>
+<rectangle x1="217.585" y1="7.025" x2="221.525" y2="7.035" layer="94"/>
+<rectangle x1="221.805" y1="7.025" x2="222.465" y2="7.035" layer="94"/>
+<rectangle x1="216.615" y1="7.035" x2="217.295" y2="7.045" layer="94"/>
+<rectangle x1="217.575" y1="7.035" x2="221.535" y2="7.045" layer="94"/>
+<rectangle x1="221.815" y1="7.035" x2="222.465" y2="7.045" layer="94"/>
+<rectangle x1="216.605" y1="7.045" x2="217.285" y2="7.055" layer="94"/>
+<rectangle x1="217.565" y1="7.045" x2="221.545" y2="7.055" layer="94"/>
+<rectangle x1="221.815" y1="7.045" x2="222.465" y2="7.055" layer="94"/>
+<rectangle x1="216.595" y1="7.055" x2="217.275" y2="7.065" layer="94"/>
+<rectangle x1="217.555" y1="7.055" x2="221.545" y2="7.065" layer="94"/>
+<rectangle x1="221.825" y1="7.055" x2="222.465" y2="7.065" layer="94"/>
+<rectangle x1="216.585" y1="7.065" x2="217.275" y2="7.075" layer="94"/>
+<rectangle x1="217.545" y1="7.065" x2="221.555" y2="7.075" layer="94"/>
+<rectangle x1="221.835" y1="7.065" x2="222.475" y2="7.075" layer="94"/>
+<rectangle x1="216.575" y1="7.075" x2="217.265" y2="7.085" layer="94"/>
+<rectangle x1="217.535" y1="7.075" x2="221.565" y2="7.085" layer="94"/>
+<rectangle x1="221.835" y1="7.075" x2="222.475" y2="7.085" layer="94"/>
+<rectangle x1="216.565" y1="7.085" x2="217.255" y2="7.095" layer="94"/>
+<rectangle x1="217.535" y1="7.085" x2="221.575" y2="7.095" layer="94"/>
+<rectangle x1="221.845" y1="7.085" x2="222.475" y2="7.095" layer="94"/>
+<rectangle x1="216.555" y1="7.095" x2="217.255" y2="7.105" layer="94"/>
+<rectangle x1="217.525" y1="7.095" x2="221.585" y2="7.105" layer="94"/>
+<rectangle x1="221.855" y1="7.095" x2="222.475" y2="7.105" layer="94"/>
+<rectangle x1="216.545" y1="7.105" x2="217.245" y2="7.115" layer="94"/>
+<rectangle x1="217.515" y1="7.105" x2="221.585" y2="7.115" layer="94"/>
+<rectangle x1="221.865" y1="7.105" x2="222.485" y2="7.115" layer="94"/>
+<rectangle x1="216.525" y1="7.115" x2="217.235" y2="7.125" layer="94"/>
+<rectangle x1="217.505" y1="7.115" x2="221.595" y2="7.125" layer="94"/>
+<rectangle x1="221.865" y1="7.115" x2="222.485" y2="7.125" layer="94"/>
+<rectangle x1="216.515" y1="7.125" x2="217.225" y2="7.135" layer="94"/>
+<rectangle x1="217.505" y1="7.125" x2="221.605" y2="7.135" layer="94"/>
+<rectangle x1="221.875" y1="7.125" x2="222.485" y2="7.135" layer="94"/>
+<rectangle x1="216.505" y1="7.135" x2="217.225" y2="7.145" layer="94"/>
+<rectangle x1="217.495" y1="7.135" x2="221.615" y2="7.145" layer="94"/>
+<rectangle x1="221.885" y1="7.135" x2="222.485" y2="7.145" layer="94"/>
+<rectangle x1="216.495" y1="7.145" x2="217.215" y2="7.155" layer="94"/>
+<rectangle x1="217.485" y1="7.145" x2="221.615" y2="7.155" layer="94"/>
+<rectangle x1="221.885" y1="7.145" x2="222.495" y2="7.155" layer="94"/>
+<rectangle x1="216.485" y1="7.155" x2="217.215" y2="7.165" layer="94"/>
+<rectangle x1="217.475" y1="7.155" x2="221.625" y2="7.165" layer="94"/>
+<rectangle x1="221.895" y1="7.155" x2="222.495" y2="7.165" layer="94"/>
+<rectangle x1="216.475" y1="7.165" x2="217.205" y2="7.175" layer="94"/>
+<rectangle x1="217.475" y1="7.165" x2="221.635" y2="7.175" layer="94"/>
+<rectangle x1="221.905" y1="7.165" x2="222.495" y2="7.175" layer="94"/>
+<rectangle x1="216.465" y1="7.175" x2="217.195" y2="7.185" layer="94"/>
+<rectangle x1="217.465" y1="7.175" x2="221.645" y2="7.185" layer="94"/>
+<rectangle x1="221.905" y1="7.175" x2="222.495" y2="7.185" layer="94"/>
+<rectangle x1="216.455" y1="7.185" x2="217.195" y2="7.195" layer="94"/>
+<rectangle x1="217.455" y1="7.185" x2="221.645" y2="7.195" layer="94"/>
+<rectangle x1="221.915" y1="7.185" x2="222.505" y2="7.195" layer="94"/>
+<rectangle x1="216.445" y1="7.195" x2="217.185" y2="7.205" layer="94"/>
+<rectangle x1="217.445" y1="7.195" x2="221.655" y2="7.205" layer="94"/>
+<rectangle x1="221.915" y1="7.195" x2="222.505" y2="7.205" layer="94"/>
+<rectangle x1="216.435" y1="7.205" x2="217.175" y2="7.215" layer="94"/>
+<rectangle x1="217.445" y1="7.205" x2="221.665" y2="7.215" layer="94"/>
+<rectangle x1="221.925" y1="7.205" x2="222.505" y2="7.215" layer="94"/>
+<rectangle x1="216.425" y1="7.215" x2="217.175" y2="7.225" layer="94"/>
+<rectangle x1="217.435" y1="7.215" x2="221.665" y2="7.225" layer="94"/>
+<rectangle x1="221.935" y1="7.215" x2="222.505" y2="7.225" layer="94"/>
+<rectangle x1="216.415" y1="7.225" x2="217.165" y2="7.235" layer="94"/>
+<rectangle x1="217.425" y1="7.225" x2="221.675" y2="7.235" layer="94"/>
+<rectangle x1="221.935" y1="7.225" x2="222.515" y2="7.235" layer="94"/>
+<rectangle x1="216.405" y1="7.235" x2="217.155" y2="7.245" layer="94"/>
+<rectangle x1="217.425" y1="7.235" x2="221.685" y2="7.245" layer="94"/>
+<rectangle x1="221.945" y1="7.235" x2="222.515" y2="7.245" layer="94"/>
+<rectangle x1="216.395" y1="7.245" x2="217.155" y2="7.255" layer="94"/>
+<rectangle x1="217.415" y1="7.245" x2="221.695" y2="7.255" layer="94"/>
+<rectangle x1="221.955" y1="7.245" x2="222.515" y2="7.255" layer="94"/>
+<rectangle x1="216.385" y1="7.255" x2="217.145" y2="7.265" layer="94"/>
+<rectangle x1="217.405" y1="7.255" x2="221.695" y2="7.265" layer="94"/>
+<rectangle x1="221.955" y1="7.255" x2="222.515" y2="7.265" layer="94"/>
+<rectangle x1="216.375" y1="7.265" x2="217.145" y2="7.275" layer="94"/>
+<rectangle x1="217.405" y1="7.265" x2="221.705" y2="7.275" layer="94"/>
+<rectangle x1="221.965" y1="7.265" x2="222.515" y2="7.275" layer="94"/>
+<rectangle x1="216.365" y1="7.275" x2="217.135" y2="7.285" layer="94"/>
+<rectangle x1="217.395" y1="7.275" x2="221.705" y2="7.285" layer="94"/>
+<rectangle x1="221.965" y1="7.275" x2="222.505" y2="7.285" layer="94"/>
+<rectangle x1="216.355" y1="7.285" x2="217.135" y2="7.295" layer="94"/>
+<rectangle x1="217.385" y1="7.285" x2="221.715" y2="7.295" layer="94"/>
+<rectangle x1="221.975" y1="7.285" x2="222.495" y2="7.295" layer="94"/>
+<rectangle x1="216.345" y1="7.295" x2="216.385" y2="7.305" layer="94"/>
+<rectangle x1="216.735" y1="7.295" x2="217.125" y2="7.305" layer="94"/>
+<rectangle x1="217.385" y1="7.295" x2="221.725" y2="7.305" layer="94"/>
+<rectangle x1="221.975" y1="7.295" x2="222.485" y2="7.305" layer="94"/>
+<rectangle x1="216.735" y1="7.305" x2="217.115" y2="7.315" layer="94"/>
+<rectangle x1="217.375" y1="7.305" x2="221.725" y2="7.315" layer="94"/>
+<rectangle x1="221.985" y1="7.305" x2="222.475" y2="7.315" layer="94"/>
+<rectangle x1="216.745" y1="7.315" x2="217.115" y2="7.325" layer="94"/>
+<rectangle x1="217.365" y1="7.315" x2="221.735" y2="7.325" layer="94"/>
+<rectangle x1="221.995" y1="7.315" x2="222.475" y2="7.325" layer="94"/>
+<rectangle x1="216.745" y1="7.325" x2="217.105" y2="7.335" layer="94"/>
+<rectangle x1="217.365" y1="7.325" x2="221.745" y2="7.335" layer="94"/>
+<rectangle x1="221.995" y1="7.325" x2="222.465" y2="7.335" layer="94"/>
+<rectangle x1="216.755" y1="7.335" x2="217.105" y2="7.345" layer="94"/>
+<rectangle x1="217.355" y1="7.335" x2="221.745" y2="7.345" layer="94"/>
+<rectangle x1="222.005" y1="7.335" x2="222.455" y2="7.345" layer="94"/>
+<rectangle x1="216.765" y1="7.345" x2="217.095" y2="7.355" layer="94"/>
+<rectangle x1="217.355" y1="7.345" x2="221.755" y2="7.355" layer="94"/>
+<rectangle x1="222.005" y1="7.345" x2="222.445" y2="7.355" layer="94"/>
+<rectangle x1="216.765" y1="7.355" x2="217.095" y2="7.365" layer="94"/>
+<rectangle x1="217.345" y1="7.355" x2="221.765" y2="7.365" layer="94"/>
+<rectangle x1="222.015" y1="7.355" x2="222.435" y2="7.365" layer="94"/>
+<rectangle x1="216.775" y1="7.365" x2="217.085" y2="7.375" layer="94"/>
+<rectangle x1="217.335" y1="7.365" x2="221.765" y2="7.375" layer="94"/>
+<rectangle x1="222.015" y1="7.365" x2="222.435" y2="7.375" layer="94"/>
+<rectangle x1="216.775" y1="7.375" x2="217.085" y2="7.385" layer="94"/>
+<rectangle x1="217.335" y1="7.375" x2="221.775" y2="7.385" layer="94"/>
+<rectangle x1="222.025" y1="7.375" x2="222.425" y2="7.385" layer="94"/>
+<rectangle x1="222.785" y1="7.375" x2="222.795" y2="7.385" layer="94"/>
+<rectangle x1="216.785" y1="7.385" x2="217.075" y2="7.395" layer="94"/>
+<rectangle x1="217.325" y1="7.385" x2="221.775" y2="7.395" layer="94"/>
+<rectangle x1="222.025" y1="7.385" x2="222.415" y2="7.395" layer="94"/>
+<rectangle x1="222.775" y1="7.385" x2="222.795" y2="7.395" layer="94"/>
+<rectangle x1="216.795" y1="7.395" x2="217.075" y2="7.405" layer="94"/>
+<rectangle x1="217.325" y1="7.395" x2="221.785" y2="7.405" layer="94"/>
+<rectangle x1="222.035" y1="7.395" x2="222.405" y2="7.405" layer="94"/>
+<rectangle x1="222.765" y1="7.395" x2="222.795" y2="7.405" layer="94"/>
+<rectangle x1="216.795" y1="7.405" x2="217.065" y2="7.415" layer="94"/>
+<rectangle x1="217.315" y1="7.405" x2="221.785" y2="7.415" layer="94"/>
+<rectangle x1="222.035" y1="7.405" x2="222.395" y2="7.415" layer="94"/>
+<rectangle x1="222.755" y1="7.405" x2="222.795" y2="7.415" layer="94"/>
+<rectangle x1="216.805" y1="7.415" x2="217.055" y2="7.425" layer="94"/>
+<rectangle x1="217.305" y1="7.415" x2="221.795" y2="7.425" layer="94"/>
+<rectangle x1="222.045" y1="7.415" x2="222.395" y2="7.425" layer="94"/>
+<rectangle x1="222.745" y1="7.415" x2="222.795" y2="7.425" layer="94"/>
+<rectangle x1="216.805" y1="7.425" x2="217.055" y2="7.435" layer="94"/>
+<rectangle x1="217.305" y1="7.425" x2="221.805" y2="7.435" layer="94"/>
+<rectangle x1="222.045" y1="7.425" x2="222.385" y2="7.435" layer="94"/>
+<rectangle x1="222.735" y1="7.425" x2="222.795" y2="7.435" layer="94"/>
+<rectangle x1="216.815" y1="7.435" x2="217.045" y2="7.445" layer="94"/>
+<rectangle x1="217.295" y1="7.435" x2="221.805" y2="7.445" layer="94"/>
+<rectangle x1="222.055" y1="7.435" x2="222.375" y2="7.445" layer="94"/>
+<rectangle x1="222.725" y1="7.435" x2="222.795" y2="7.445" layer="94"/>
+<rectangle x1="216.825" y1="7.445" x2="217.045" y2="7.455" layer="94"/>
+<rectangle x1="217.295" y1="7.445" x2="221.815" y2="7.455" layer="94"/>
+<rectangle x1="222.065" y1="7.445" x2="222.365" y2="7.455" layer="94"/>
+<rectangle x1="222.715" y1="7.445" x2="222.795" y2="7.455" layer="94"/>
+<rectangle x1="216.825" y1="7.455" x2="217.035" y2="7.465" layer="94"/>
+<rectangle x1="217.285" y1="7.455" x2="221.815" y2="7.465" layer="94"/>
+<rectangle x1="222.065" y1="7.455" x2="222.355" y2="7.465" layer="94"/>
+<rectangle x1="222.705" y1="7.455" x2="222.795" y2="7.465" layer="94"/>
+<rectangle x1="216.835" y1="7.465" x2="217.035" y2="7.475" layer="94"/>
+<rectangle x1="217.285" y1="7.465" x2="221.825" y2="7.475" layer="94"/>
+<rectangle x1="222.075" y1="7.465" x2="222.345" y2="7.475" layer="94"/>
+<rectangle x1="222.695" y1="7.465" x2="222.795" y2="7.475" layer="94"/>
+<rectangle x1="216.835" y1="7.475" x2="217.025" y2="7.485" layer="94"/>
+<rectangle x1="217.275" y1="7.475" x2="221.825" y2="7.485" layer="94"/>
+<rectangle x1="222.075" y1="7.475" x2="222.345" y2="7.485" layer="94"/>
+<rectangle x1="222.685" y1="7.475" x2="222.795" y2="7.485" layer="94"/>
+<rectangle x1="216.825" y1="7.485" x2="217.025" y2="7.495" layer="94"/>
+<rectangle x1="217.275" y1="7.485" x2="221.835" y2="7.495" layer="94"/>
+<rectangle x1="222.075" y1="7.485" x2="222.335" y2="7.495" layer="94"/>
+<rectangle x1="222.675" y1="7.485" x2="222.795" y2="7.495" layer="94"/>
+<rectangle x1="216.825" y1="7.495" x2="217.025" y2="7.505" layer="94"/>
+<rectangle x1="217.265" y1="7.495" x2="221.835" y2="7.505" layer="94"/>
+<rectangle x1="222.085" y1="7.495" x2="222.325" y2="7.505" layer="94"/>
+<rectangle x1="222.665" y1="7.495" x2="222.795" y2="7.505" layer="94"/>
+<rectangle x1="216.815" y1="7.505" x2="217.015" y2="7.515" layer="94"/>
+<rectangle x1="217.265" y1="7.505" x2="221.845" y2="7.515" layer="94"/>
+<rectangle x1="222.085" y1="7.505" x2="222.315" y2="7.515" layer="94"/>
+<rectangle x1="222.655" y1="7.505" x2="222.795" y2="7.515" layer="94"/>
+<rectangle x1="216.815" y1="7.515" x2="217.015" y2="7.525" layer="94"/>
+<rectangle x1="217.255" y1="7.515" x2="221.845" y2="7.525" layer="94"/>
+<rectangle x1="222.095" y1="7.515" x2="222.305" y2="7.525" layer="94"/>
+<rectangle x1="222.645" y1="7.515" x2="222.795" y2="7.525" layer="94"/>
+<rectangle x1="216.815" y1="7.525" x2="217.005" y2="7.535" layer="94"/>
+<rectangle x1="217.255" y1="7.525" x2="221.855" y2="7.535" layer="94"/>
+<rectangle x1="222.095" y1="7.525" x2="222.305" y2="7.535" layer="94"/>
+<rectangle x1="222.645" y1="7.525" x2="222.785" y2="7.535" layer="94"/>
+<rectangle x1="216.805" y1="7.535" x2="217.005" y2="7.545" layer="94"/>
+<rectangle x1="217.245" y1="7.535" x2="221.855" y2="7.545" layer="94"/>
+<rectangle x1="222.105" y1="7.535" x2="222.295" y2="7.545" layer="94"/>
+<rectangle x1="222.635" y1="7.535" x2="222.785" y2="7.545" layer="94"/>
+<rectangle x1="216.805" y1="7.545" x2="216.995" y2="7.555" layer="94"/>
+<rectangle x1="217.245" y1="7.545" x2="221.865" y2="7.555" layer="94"/>
+<rectangle x1="222.105" y1="7.545" x2="222.305" y2="7.555" layer="94"/>
+<rectangle x1="222.625" y1="7.545" x2="222.785" y2="7.555" layer="94"/>
+<rectangle x1="216.795" y1="7.555" x2="216.995" y2="7.565" layer="94"/>
+<rectangle x1="217.235" y1="7.555" x2="221.865" y2="7.565" layer="94"/>
+<rectangle x1="222.115" y1="7.555" x2="222.305" y2="7.565" layer="94"/>
+<rectangle x1="222.615" y1="7.555" x2="222.785" y2="7.565" layer="94"/>
+<rectangle x1="216.795" y1="7.565" x2="216.985" y2="7.575" layer="94"/>
+<rectangle x1="217.235" y1="7.565" x2="221.875" y2="7.575" layer="94"/>
+<rectangle x1="222.115" y1="7.565" x2="222.315" y2="7.575" layer="94"/>
+<rectangle x1="222.605" y1="7.565" x2="222.785" y2="7.575" layer="94"/>
+<rectangle x1="216.725" y1="7.575" x2="216.985" y2="7.585" layer="94"/>
+<rectangle x1="217.225" y1="7.575" x2="221.875" y2="7.585" layer="94"/>
+<rectangle x1="222.125" y1="7.575" x2="222.315" y2="7.585" layer="94"/>
+<rectangle x1="222.595" y1="7.575" x2="222.785" y2="7.585" layer="94"/>
+<rectangle x1="216.635" y1="7.585" x2="216.975" y2="7.595" layer="94"/>
+<rectangle x1="217.225" y1="7.585" x2="221.885" y2="7.595" layer="94"/>
+<rectangle x1="222.125" y1="7.585" x2="222.315" y2="7.595" layer="94"/>
+<rectangle x1="222.585" y1="7.585" x2="222.785" y2="7.595" layer="94"/>
+<rectangle x1="216.545" y1="7.595" x2="216.975" y2="7.605" layer="94"/>
+<rectangle x1="217.215" y1="7.595" x2="221.885" y2="7.605" layer="94"/>
+<rectangle x1="222.125" y1="7.595" x2="222.335" y2="7.605" layer="94"/>
+<rectangle x1="222.575" y1="7.595" x2="222.785" y2="7.605" layer="94"/>
+<rectangle x1="216.455" y1="7.605" x2="216.975" y2="7.615" layer="94"/>
+<rectangle x1="217.215" y1="7.605" x2="221.895" y2="7.615" layer="94"/>
+<rectangle x1="222.135" y1="7.605" x2="222.375" y2="7.615" layer="94"/>
+<rectangle x1="222.565" y1="7.605" x2="222.785" y2="7.615" layer="94"/>
+<rectangle x1="216.435" y1="7.615" x2="216.965" y2="7.625" layer="94"/>
+<rectangle x1="217.205" y1="7.615" x2="221.895" y2="7.625" layer="94"/>
+<rectangle x1="222.135" y1="7.615" x2="222.415" y2="7.625" layer="94"/>
+<rectangle x1="222.555" y1="7.615" x2="222.785" y2="7.625" layer="94"/>
+<rectangle x1="216.435" y1="7.625" x2="216.965" y2="7.635" layer="94"/>
+<rectangle x1="217.205" y1="7.625" x2="221.905" y2="7.635" layer="94"/>
+<rectangle x1="222.145" y1="7.625" x2="222.455" y2="7.635" layer="94"/>
+<rectangle x1="222.545" y1="7.625" x2="222.785" y2="7.635" layer="94"/>
+<rectangle x1="216.425" y1="7.635" x2="216.955" y2="7.645" layer="94"/>
+<rectangle x1="217.195" y1="7.635" x2="221.905" y2="7.645" layer="94"/>
+<rectangle x1="222.145" y1="7.635" x2="222.495" y2="7.645" layer="94"/>
+<rectangle x1="222.535" y1="7.635" x2="222.785" y2="7.645" layer="94"/>
+<rectangle x1="216.425" y1="7.645" x2="216.955" y2="7.655" layer="94"/>
+<rectangle x1="217.195" y1="7.645" x2="221.915" y2="7.655" layer="94"/>
+<rectangle x1="222.145" y1="7.645" x2="222.785" y2="7.655" layer="94"/>
+<rectangle x1="216.415" y1="7.655" x2="216.955" y2="7.665" layer="94"/>
+<rectangle x1="217.185" y1="7.655" x2="221.915" y2="7.665" layer="94"/>
+<rectangle x1="222.155" y1="7.655" x2="222.785" y2="7.665" layer="94"/>
+<rectangle x1="216.405" y1="7.665" x2="216.945" y2="7.675" layer="94"/>
+<rectangle x1="217.185" y1="7.665" x2="221.915" y2="7.675" layer="94"/>
+<rectangle x1="222.155" y1="7.665" x2="222.785" y2="7.675" layer="94"/>
+<rectangle x1="216.405" y1="7.675" x2="216.945" y2="7.685" layer="94"/>
+<rectangle x1="217.185" y1="7.675" x2="221.925" y2="7.685" layer="94"/>
+<rectangle x1="222.165" y1="7.675" x2="222.785" y2="7.685" layer="94"/>
+<rectangle x1="216.395" y1="7.685" x2="216.935" y2="7.695" layer="94"/>
+<rectangle x1="217.175" y1="7.685" x2="221.925" y2="7.695" layer="94"/>
+<rectangle x1="222.165" y1="7.685" x2="222.785" y2="7.695" layer="94"/>
+<rectangle x1="216.395" y1="7.695" x2="216.935" y2="7.705" layer="94"/>
+<rectangle x1="217.175" y1="7.695" x2="221.935" y2="7.705" layer="94"/>
+<rectangle x1="222.165" y1="7.695" x2="222.785" y2="7.705" layer="94"/>
+<rectangle x1="216.385" y1="7.705" x2="216.935" y2="7.715" layer="94"/>
+<rectangle x1="217.165" y1="7.705" x2="221.935" y2="7.715" layer="94"/>
+<rectangle x1="222.175" y1="7.705" x2="222.785" y2="7.715" layer="94"/>
+<rectangle x1="216.375" y1="7.715" x2="216.925" y2="7.725" layer="94"/>
+<rectangle x1="217.165" y1="7.715" x2="221.945" y2="7.725" layer="94"/>
+<rectangle x1="222.175" y1="7.715" x2="222.785" y2="7.725" layer="94"/>
+<rectangle x1="216.375" y1="7.725" x2="216.925" y2="7.735" layer="94"/>
+<rectangle x1="217.165" y1="7.725" x2="221.945" y2="7.735" layer="94"/>
+<rectangle x1="222.185" y1="7.725" x2="222.785" y2="7.735" layer="94"/>
+<rectangle x1="216.365" y1="7.735" x2="216.925" y2="7.745" layer="94"/>
+<rectangle x1="217.155" y1="7.735" x2="221.945" y2="7.745" layer="94"/>
+<rectangle x1="222.185" y1="7.735" x2="222.785" y2="7.745" layer="94"/>
+<rectangle x1="216.355" y1="7.745" x2="216.915" y2="7.755" layer="94"/>
+<rectangle x1="217.155" y1="7.745" x2="218.285" y2="7.755" layer="94"/>
+<rectangle x1="218.535" y1="7.745" x2="218.775" y2="7.755" layer="94"/>
+<rectangle x1="219.195" y1="7.745" x2="219.915" y2="7.755" layer="94"/>
+<rectangle x1="220.345" y1="7.745" x2="221.065" y2="7.755" layer="94"/>
+<rectangle x1="221.485" y1="7.745" x2="221.955" y2="7.755" layer="94"/>
+<rectangle x1="222.185" y1="7.745" x2="222.785" y2="7.755" layer="94"/>
+<rectangle x1="216.355" y1="7.755" x2="216.915" y2="7.765" layer="94"/>
+<rectangle x1="217.145" y1="7.755" x2="218.215" y2="7.765" layer="94"/>
+<rectangle x1="218.595" y1="7.755" x2="218.775" y2="7.765" layer="94"/>
+<rectangle x1="219.195" y1="7.755" x2="219.915" y2="7.765" layer="94"/>
+<rectangle x1="220.345" y1="7.755" x2="221.065" y2="7.765" layer="94"/>
+<rectangle x1="221.485" y1="7.755" x2="221.955" y2="7.765" layer="94"/>
+<rectangle x1="222.195" y1="7.755" x2="222.785" y2="7.765" layer="94"/>
+<rectangle x1="216.345" y1="7.765" x2="216.915" y2="7.775" layer="94"/>
+<rectangle x1="217.145" y1="7.765" x2="218.175" y2="7.775" layer="94"/>
+<rectangle x1="218.645" y1="7.765" x2="218.775" y2="7.775" layer="94"/>
+<rectangle x1="219.195" y1="7.765" x2="219.915" y2="7.775" layer="94"/>
+<rectangle x1="220.345" y1="7.765" x2="221.065" y2="7.775" layer="94"/>
+<rectangle x1="221.485" y1="7.765" x2="221.955" y2="7.775" layer="94"/>
+<rectangle x1="222.195" y1="7.765" x2="222.785" y2="7.775" layer="94"/>
+<rectangle x1="216.345" y1="7.775" x2="216.905" y2="7.785" layer="94"/>
+<rectangle x1="217.145" y1="7.775" x2="218.135" y2="7.785" layer="94"/>
+<rectangle x1="218.685" y1="7.775" x2="218.775" y2="7.785" layer="94"/>
+<rectangle x1="219.195" y1="7.775" x2="219.915" y2="7.785" layer="94"/>
+<rectangle x1="220.345" y1="7.775" x2="221.065" y2="7.785" layer="94"/>
+<rectangle x1="221.485" y1="7.775" x2="221.965" y2="7.785" layer="94"/>
+<rectangle x1="222.195" y1="7.775" x2="222.785" y2="7.785" layer="94"/>
+<rectangle x1="216.335" y1="7.785" x2="216.905" y2="7.795" layer="94"/>
+<rectangle x1="217.135" y1="7.785" x2="218.105" y2="7.795" layer="94"/>
+<rectangle x1="218.715" y1="7.785" x2="218.775" y2="7.795" layer="94"/>
+<rectangle x1="219.195" y1="7.785" x2="219.915" y2="7.795" layer="94"/>
+<rectangle x1="220.345" y1="7.785" x2="221.065" y2="7.795" layer="94"/>
+<rectangle x1="221.485" y1="7.785" x2="221.965" y2="7.795" layer="94"/>
+<rectangle x1="222.205" y1="7.785" x2="222.785" y2="7.795" layer="94"/>
+<rectangle x1="216.325" y1="7.795" x2="216.905" y2="7.805" layer="94"/>
+<rectangle x1="217.135" y1="7.795" x2="218.075" y2="7.805" layer="94"/>
+<rectangle x1="218.735" y1="7.795" x2="218.775" y2="7.805" layer="94"/>
+<rectangle x1="219.195" y1="7.795" x2="219.915" y2="7.805" layer="94"/>
+<rectangle x1="220.345" y1="7.795" x2="221.065" y2="7.805" layer="94"/>
+<rectangle x1="221.485" y1="7.795" x2="221.975" y2="7.805" layer="94"/>
+<rectangle x1="222.205" y1="7.795" x2="222.785" y2="7.805" layer="94"/>
+<rectangle x1="216.325" y1="7.805" x2="216.895" y2="7.815" layer="94"/>
+<rectangle x1="217.125" y1="7.805" x2="218.055" y2="7.815" layer="94"/>
+<rectangle x1="218.765" y1="7.805" x2="218.775" y2="7.815" layer="94"/>
+<rectangle x1="219.195" y1="7.805" x2="219.915" y2="7.815" layer="94"/>
+<rectangle x1="220.345" y1="7.805" x2="221.065" y2="7.815" layer="94"/>
+<rectangle x1="221.485" y1="7.805" x2="221.975" y2="7.815" layer="94"/>
+<rectangle x1="222.205" y1="7.805" x2="222.785" y2="7.815" layer="94"/>
+<rectangle x1="216.315" y1="7.815" x2="216.895" y2="7.825" layer="94"/>
+<rectangle x1="217.125" y1="7.815" x2="218.035" y2="7.825" layer="94"/>
+<rectangle x1="219.195" y1="7.815" x2="219.915" y2="7.825" layer="94"/>
+<rectangle x1="220.345" y1="7.815" x2="221.065" y2="7.825" layer="94"/>
+<rectangle x1="221.485" y1="7.815" x2="221.975" y2="7.825" layer="94"/>
+<rectangle x1="222.215" y1="7.815" x2="222.785" y2="7.825" layer="94"/>
+<rectangle x1="216.315" y1="7.825" x2="216.895" y2="7.835" layer="94"/>
+<rectangle x1="217.125" y1="7.825" x2="218.015" y2="7.835" layer="94"/>
+<rectangle x1="219.195" y1="7.825" x2="219.915" y2="7.835" layer="94"/>
+<rectangle x1="220.345" y1="7.825" x2="221.065" y2="7.835" layer="94"/>
+<rectangle x1="221.485" y1="7.825" x2="221.985" y2="7.835" layer="94"/>
+<rectangle x1="222.215" y1="7.825" x2="222.785" y2="7.835" layer="94"/>
+<rectangle x1="216.305" y1="7.835" x2="216.885" y2="7.845" layer="94"/>
+<rectangle x1="217.115" y1="7.835" x2="217.995" y2="7.845" layer="94"/>
+<rectangle x1="219.195" y1="7.835" x2="219.915" y2="7.845" layer="94"/>
+<rectangle x1="220.345" y1="7.835" x2="221.065" y2="7.845" layer="94"/>
+<rectangle x1="221.485" y1="7.835" x2="221.985" y2="7.845" layer="94"/>
+<rectangle x1="222.215" y1="7.835" x2="222.785" y2="7.845" layer="94"/>
+<rectangle x1="216.295" y1="7.845" x2="216.885" y2="7.855" layer="94"/>
+<rectangle x1="217.115" y1="7.845" x2="217.975" y2="7.855" layer="94"/>
+<rectangle x1="219.195" y1="7.845" x2="219.915" y2="7.855" layer="94"/>
+<rectangle x1="220.345" y1="7.845" x2="221.065" y2="7.855" layer="94"/>
+<rectangle x1="221.485" y1="7.845" x2="221.985" y2="7.855" layer="94"/>
+<rectangle x1="222.225" y1="7.845" x2="222.785" y2="7.855" layer="94"/>
+<rectangle x1="216.295" y1="7.855" x2="216.885" y2="7.865" layer="94"/>
+<rectangle x1="217.115" y1="7.855" x2="217.955" y2="7.865" layer="94"/>
+<rectangle x1="219.195" y1="7.855" x2="219.915" y2="7.865" layer="94"/>
+<rectangle x1="220.345" y1="7.855" x2="221.065" y2="7.865" layer="94"/>
+<rectangle x1="221.485" y1="7.855" x2="221.995" y2="7.865" layer="94"/>
+<rectangle x1="222.225" y1="7.855" x2="222.785" y2="7.865" layer="94"/>
+<rectangle x1="216.285" y1="7.865" x2="216.875" y2="7.875" layer="94"/>
+<rectangle x1="217.105" y1="7.865" x2="217.945" y2="7.875" layer="94"/>
+<rectangle x1="219.195" y1="7.865" x2="219.915" y2="7.875" layer="94"/>
+<rectangle x1="220.345" y1="7.865" x2="221.065" y2="7.875" layer="94"/>
+<rectangle x1="221.485" y1="7.865" x2="221.995" y2="7.875" layer="94"/>
+<rectangle x1="222.225" y1="7.865" x2="222.785" y2="7.875" layer="94"/>
+<rectangle x1="216.285" y1="7.875" x2="216.875" y2="7.885" layer="94"/>
+<rectangle x1="217.105" y1="7.875" x2="217.925" y2="7.885" layer="94"/>
+<rectangle x1="219.195" y1="7.875" x2="219.915" y2="7.885" layer="94"/>
+<rectangle x1="220.345" y1="7.875" x2="221.065" y2="7.885" layer="94"/>
+<rectangle x1="221.485" y1="7.875" x2="221.995" y2="7.885" layer="94"/>
+<rectangle x1="222.235" y1="7.875" x2="222.785" y2="7.885" layer="94"/>
+<rectangle x1="216.275" y1="7.885" x2="216.875" y2="7.895" layer="94"/>
+<rectangle x1="217.105" y1="7.885" x2="217.915" y2="7.895" layer="94"/>
+<rectangle x1="219.195" y1="7.885" x2="219.915" y2="7.895" layer="94"/>
+<rectangle x1="220.345" y1="7.885" x2="221.065" y2="7.895" layer="94"/>
+<rectangle x1="221.485" y1="7.885" x2="222.005" y2="7.895" layer="94"/>
+<rectangle x1="222.235" y1="7.885" x2="222.785" y2="7.895" layer="94"/>
+<rectangle x1="216.265" y1="7.895" x2="216.865" y2="7.905" layer="94"/>
+<rectangle x1="217.095" y1="7.895" x2="217.895" y2="7.905" layer="94"/>
+<rectangle x1="219.195" y1="7.895" x2="219.915" y2="7.905" layer="94"/>
+<rectangle x1="220.345" y1="7.895" x2="221.065" y2="7.905" layer="94"/>
+<rectangle x1="221.485" y1="7.895" x2="222.005" y2="7.905" layer="94"/>
+<rectangle x1="222.235" y1="7.895" x2="222.785" y2="7.905" layer="94"/>
+<rectangle x1="216.265" y1="7.905" x2="216.865" y2="7.915" layer="94"/>
+<rectangle x1="217.095" y1="7.905" x2="217.885" y2="7.915" layer="94"/>
+<rectangle x1="219.195" y1="7.905" x2="219.915" y2="7.915" layer="94"/>
+<rectangle x1="220.345" y1="7.905" x2="221.065" y2="7.915" layer="94"/>
+<rectangle x1="221.485" y1="7.905" x2="222.005" y2="7.915" layer="94"/>
+<rectangle x1="222.235" y1="7.905" x2="222.785" y2="7.915" layer="94"/>
+<rectangle x1="216.255" y1="7.915" x2="216.865" y2="7.925" layer="94"/>
+<rectangle x1="217.095" y1="7.915" x2="217.875" y2="7.925" layer="94"/>
+<rectangle x1="219.195" y1="7.915" x2="219.915" y2="7.925" layer="94"/>
+<rectangle x1="220.345" y1="7.915" x2="221.065" y2="7.925" layer="94"/>
+<rectangle x1="221.485" y1="7.915" x2="222.015" y2="7.925" layer="94"/>
+<rectangle x1="222.245" y1="7.915" x2="222.785" y2="7.925" layer="94"/>
+<rectangle x1="216.255" y1="7.925" x2="216.865" y2="7.935" layer="94"/>
+<rectangle x1="217.085" y1="7.925" x2="217.865" y2="7.935" layer="94"/>
+<rectangle x1="219.195" y1="7.925" x2="219.915" y2="7.935" layer="94"/>
+<rectangle x1="220.345" y1="7.925" x2="221.065" y2="7.935" layer="94"/>
+<rectangle x1="221.485" y1="7.925" x2="222.015" y2="7.935" layer="94"/>
+<rectangle x1="222.245" y1="7.925" x2="222.785" y2="7.935" layer="94"/>
+<rectangle x1="216.245" y1="7.935" x2="216.855" y2="7.945" layer="94"/>
+<rectangle x1="217.085" y1="7.935" x2="217.855" y2="7.945" layer="94"/>
+<rectangle x1="219.195" y1="7.935" x2="219.915" y2="7.945" layer="94"/>
+<rectangle x1="220.345" y1="7.935" x2="221.065" y2="7.945" layer="94"/>
+<rectangle x1="221.485" y1="7.935" x2="222.015" y2="7.945" layer="94"/>
+<rectangle x1="222.245" y1="7.935" x2="222.785" y2="7.945" layer="94"/>
+<rectangle x1="216.235" y1="7.945" x2="216.855" y2="7.955" layer="94"/>
+<rectangle x1="217.085" y1="7.945" x2="217.845" y2="7.955" layer="94"/>
+<rectangle x1="219.195" y1="7.945" x2="219.915" y2="7.955" layer="94"/>
+<rectangle x1="220.345" y1="7.945" x2="221.065" y2="7.955" layer="94"/>
+<rectangle x1="221.485" y1="7.945" x2="222.025" y2="7.955" layer="94"/>
+<rectangle x1="222.245" y1="7.945" x2="222.785" y2="7.955" layer="94"/>
+<rectangle x1="216.235" y1="7.955" x2="216.855" y2="7.965" layer="94"/>
+<rectangle x1="217.085" y1="7.955" x2="217.835" y2="7.965" layer="94"/>
+<rectangle x1="219.195" y1="7.955" x2="219.915" y2="7.965" layer="94"/>
+<rectangle x1="220.345" y1="7.955" x2="221.065" y2="7.965" layer="94"/>
+<rectangle x1="221.485" y1="7.955" x2="222.025" y2="7.965" layer="94"/>
+<rectangle x1="222.255" y1="7.955" x2="222.785" y2="7.965" layer="94"/>
+<rectangle x1="216.225" y1="7.965" x2="216.845" y2="7.975" layer="94"/>
+<rectangle x1="217.075" y1="7.965" x2="217.825" y2="7.975" layer="94"/>
+<rectangle x1="219.195" y1="7.965" x2="219.915" y2="7.975" layer="94"/>
+<rectangle x1="220.345" y1="7.965" x2="221.065" y2="7.975" layer="94"/>
+<rectangle x1="221.485" y1="7.965" x2="222.025" y2="7.975" layer="94"/>
+<rectangle x1="222.255" y1="7.965" x2="222.785" y2="7.975" layer="94"/>
+<rectangle x1="216.215" y1="7.975" x2="216.845" y2="7.985" layer="94"/>
+<rectangle x1="217.075" y1="7.975" x2="217.815" y2="7.985" layer="94"/>
+<rectangle x1="219.195" y1="7.975" x2="219.915" y2="7.985" layer="94"/>
+<rectangle x1="220.345" y1="7.975" x2="221.065" y2="7.985" layer="94"/>
+<rectangle x1="221.485" y1="7.975" x2="222.025" y2="7.985" layer="94"/>
+<rectangle x1="222.255" y1="7.975" x2="222.785" y2="7.985" layer="94"/>
+<rectangle x1="216.215" y1="7.985" x2="216.845" y2="7.995" layer="94"/>
+<rectangle x1="217.075" y1="7.985" x2="217.805" y2="7.995" layer="94"/>
+<rectangle x1="219.195" y1="7.985" x2="219.915" y2="7.995" layer="94"/>
+<rectangle x1="220.345" y1="7.985" x2="221.065" y2="7.995" layer="94"/>
+<rectangle x1="221.485" y1="7.985" x2="222.035" y2="7.995" layer="94"/>
+<rectangle x1="222.265" y1="7.985" x2="222.785" y2="7.995" layer="94"/>
+<rectangle x1="216.205" y1="7.995" x2="216.845" y2="8.005" layer="94"/>
+<rectangle x1="217.065" y1="7.995" x2="217.795" y2="8.005" layer="94"/>
+<rectangle x1="219.195" y1="7.995" x2="219.915" y2="8.005" layer="94"/>
+<rectangle x1="220.345" y1="7.995" x2="221.065" y2="8.005" layer="94"/>
+<rectangle x1="221.485" y1="7.995" x2="222.035" y2="8.005" layer="94"/>
+<rectangle x1="222.265" y1="7.995" x2="222.785" y2="8.005" layer="94"/>
+<rectangle x1="216.205" y1="8.005" x2="216.835" y2="8.015" layer="94"/>
+<rectangle x1="217.065" y1="8.005" x2="217.785" y2="8.015" layer="94"/>
+<rectangle x1="219.195" y1="8.005" x2="219.915" y2="8.015" layer="94"/>
+<rectangle x1="220.345" y1="8.005" x2="221.065" y2="8.015" layer="94"/>
+<rectangle x1="221.485" y1="8.005" x2="222.035" y2="8.015" layer="94"/>
+<rectangle x1="222.265" y1="8.005" x2="222.775" y2="8.015" layer="94"/>
+<rectangle x1="216.195" y1="8.015" x2="216.835" y2="8.025" layer="94"/>
+<rectangle x1="217.065" y1="8.015" x2="217.775" y2="8.025" layer="94"/>
+<rectangle x1="219.195" y1="8.015" x2="219.915" y2="8.025" layer="94"/>
+<rectangle x1="220.345" y1="8.015" x2="221.065" y2="8.025" layer="94"/>
+<rectangle x1="221.485" y1="8.015" x2="222.045" y2="8.025" layer="94"/>
+<rectangle x1="222.265" y1="8.015" x2="222.775" y2="8.025" layer="94"/>
+<rectangle x1="216.185" y1="8.025" x2="216.835" y2="8.035" layer="94"/>
+<rectangle x1="217.065" y1="8.025" x2="217.765" y2="8.035" layer="94"/>
+<rectangle x1="219.195" y1="8.025" x2="219.915" y2="8.035" layer="94"/>
+<rectangle x1="220.345" y1="8.025" x2="221.065" y2="8.035" layer="94"/>
+<rectangle x1="221.485" y1="8.025" x2="222.045" y2="8.035" layer="94"/>
+<rectangle x1="222.275" y1="8.025" x2="222.775" y2="8.035" layer="94"/>
+<rectangle x1="216.185" y1="8.035" x2="216.835" y2="8.045" layer="94"/>
+<rectangle x1="217.055" y1="8.035" x2="217.765" y2="8.045" layer="94"/>
+<rectangle x1="219.195" y1="8.035" x2="219.915" y2="8.045" layer="94"/>
+<rectangle x1="220.345" y1="8.035" x2="221.065" y2="8.045" layer="94"/>
+<rectangle x1="221.485" y1="8.035" x2="222.045" y2="8.045" layer="94"/>
+<rectangle x1="222.275" y1="8.035" x2="222.775" y2="8.045" layer="94"/>
+<rectangle x1="216.175" y1="8.045" x2="216.825" y2="8.055" layer="94"/>
+<rectangle x1="217.055" y1="8.045" x2="217.755" y2="8.055" layer="94"/>
+<rectangle x1="219.195" y1="8.045" x2="219.915" y2="8.055" layer="94"/>
+<rectangle x1="220.345" y1="8.045" x2="221.065" y2="8.055" layer="94"/>
+<rectangle x1="221.485" y1="8.045" x2="222.045" y2="8.055" layer="94"/>
+<rectangle x1="222.275" y1="8.045" x2="222.775" y2="8.055" layer="94"/>
+<rectangle x1="216.175" y1="8.055" x2="216.825" y2="8.065" layer="94"/>
+<rectangle x1="217.055" y1="8.055" x2="217.745" y2="8.065" layer="94"/>
+<rectangle x1="219.195" y1="8.055" x2="219.915" y2="8.065" layer="94"/>
+<rectangle x1="220.345" y1="8.055" x2="221.065" y2="8.065" layer="94"/>
+<rectangle x1="221.485" y1="8.055" x2="222.055" y2="8.065" layer="94"/>
+<rectangle x1="222.275" y1="8.055" x2="222.765" y2="8.065" layer="94"/>
+<rectangle x1="216.165" y1="8.065" x2="216.825" y2="8.075" layer="94"/>
+<rectangle x1="217.055" y1="8.065" x2="217.735" y2="8.075" layer="94"/>
+<rectangle x1="219.195" y1="8.065" x2="219.915" y2="8.075" layer="94"/>
+<rectangle x1="220.345" y1="8.065" x2="221.065" y2="8.075" layer="94"/>
+<rectangle x1="221.485" y1="8.065" x2="222.055" y2="8.075" layer="94"/>
+<rectangle x1="222.275" y1="8.065" x2="222.755" y2="8.075" layer="94"/>
+<rectangle x1="216.155" y1="8.075" x2="216.825" y2="8.085" layer="94"/>
+<rectangle x1="217.045" y1="8.075" x2="217.735" y2="8.085" layer="94"/>
+<rectangle x1="219.195" y1="8.075" x2="219.915" y2="8.085" layer="94"/>
+<rectangle x1="220.345" y1="8.075" x2="221.065" y2="8.085" layer="94"/>
+<rectangle x1="221.485" y1="8.075" x2="222.055" y2="8.085" layer="94"/>
+<rectangle x1="222.285" y1="8.075" x2="222.745" y2="8.085" layer="94"/>
+<rectangle x1="216.155" y1="8.085" x2="216.435" y2="8.095" layer="94"/>
+<rectangle x1="216.465" y1="8.085" x2="216.825" y2="8.095" layer="94"/>
+<rectangle x1="217.045" y1="8.085" x2="217.725" y2="8.095" layer="94"/>
+<rectangle x1="219.195" y1="8.085" x2="219.915" y2="8.095" layer="94"/>
+<rectangle x1="220.345" y1="8.085" x2="221.065" y2="8.095" layer="94"/>
+<rectangle x1="221.485" y1="8.085" x2="222.055" y2="8.095" layer="94"/>
+<rectangle x1="222.285" y1="8.085" x2="222.725" y2="8.095" layer="94"/>
+<rectangle x1="216.145" y1="8.095" x2="216.405" y2="8.105" layer="94"/>
+<rectangle x1="216.475" y1="8.095" x2="216.815" y2="8.105" layer="94"/>
+<rectangle x1="217.045" y1="8.095" x2="217.725" y2="8.105" layer="94"/>
+<rectangle x1="219.195" y1="8.095" x2="219.915" y2="8.105" layer="94"/>
+<rectangle x1="220.345" y1="8.095" x2="221.065" y2="8.105" layer="94"/>
+<rectangle x1="221.485" y1="8.095" x2="222.065" y2="8.105" layer="94"/>
+<rectangle x1="222.285" y1="8.095" x2="222.715" y2="8.105" layer="94"/>
+<rectangle x1="216.145" y1="8.105" x2="216.375" y2="8.115" layer="94"/>
+<rectangle x1="216.485" y1="8.105" x2="216.815" y2="8.115" layer="94"/>
+<rectangle x1="217.045" y1="8.105" x2="217.715" y2="8.115" layer="94"/>
+<rectangle x1="219.195" y1="8.105" x2="219.915" y2="8.115" layer="94"/>
+<rectangle x1="220.345" y1="8.105" x2="221.065" y2="8.115" layer="94"/>
+<rectangle x1="221.485" y1="8.105" x2="222.065" y2="8.115" layer="94"/>
+<rectangle x1="222.285" y1="8.105" x2="222.705" y2="8.115" layer="94"/>
+<rectangle x1="216.135" y1="8.115" x2="216.335" y2="8.125" layer="94"/>
+<rectangle x1="216.495" y1="8.115" x2="216.815" y2="8.125" layer="94"/>
+<rectangle x1="217.035" y1="8.115" x2="217.705" y2="8.125" layer="94"/>
+<rectangle x1="219.195" y1="8.115" x2="219.915" y2="8.125" layer="94"/>
+<rectangle x1="220.345" y1="8.115" x2="221.065" y2="8.125" layer="94"/>
+<rectangle x1="221.485" y1="8.115" x2="222.065" y2="8.125" layer="94"/>
+<rectangle x1="222.295" y1="8.115" x2="222.685" y2="8.125" layer="94"/>
+<rectangle x1="216.125" y1="8.125" x2="216.305" y2="8.135" layer="94"/>
+<rectangle x1="216.505" y1="8.125" x2="216.815" y2="8.135" layer="94"/>
+<rectangle x1="217.035" y1="8.125" x2="217.705" y2="8.135" layer="94"/>
+<rectangle x1="218.315" y1="8.125" x2="218.505" y2="8.135" layer="94"/>
+<rectangle x1="219.195" y1="8.125" x2="219.915" y2="8.135" layer="94"/>
+<rectangle x1="220.345" y1="8.125" x2="221.065" y2="8.135" layer="94"/>
+<rectangle x1="221.485" y1="8.125" x2="222.065" y2="8.135" layer="94"/>
+<rectangle x1="222.295" y1="8.125" x2="222.675" y2="8.135" layer="94"/>
+<rectangle x1="216.125" y1="8.135" x2="216.275" y2="8.145" layer="94"/>
+<rectangle x1="216.515" y1="8.135" x2="216.805" y2="8.145" layer="94"/>
+<rectangle x1="217.035" y1="8.135" x2="217.695" y2="8.145" layer="94"/>
+<rectangle x1="218.275" y1="8.135" x2="218.535" y2="8.145" layer="94"/>
+<rectangle x1="219.195" y1="8.135" x2="219.915" y2="8.145" layer="94"/>
+<rectangle x1="220.345" y1="8.135" x2="221.065" y2="8.145" layer="94"/>
+<rectangle x1="221.485" y1="8.135" x2="222.075" y2="8.145" layer="94"/>
+<rectangle x1="222.295" y1="8.135" x2="222.665" y2="8.145" layer="94"/>
+<rectangle x1="216.115" y1="8.145" x2="216.235" y2="8.155" layer="94"/>
+<rectangle x1="216.525" y1="8.145" x2="216.805" y2="8.155" layer="94"/>
+<rectangle x1="217.035" y1="8.145" x2="217.695" y2="8.155" layer="94"/>
+<rectangle x1="218.245" y1="8.145" x2="218.565" y2="8.155" layer="94"/>
+<rectangle x1="219.195" y1="8.145" x2="219.915" y2="8.155" layer="94"/>
+<rectangle x1="220.345" y1="8.145" x2="221.065" y2="8.155" layer="94"/>
+<rectangle x1="221.485" y1="8.145" x2="222.075" y2="8.155" layer="94"/>
+<rectangle x1="222.295" y1="8.145" x2="222.645" y2="8.155" layer="94"/>
+<rectangle x1="216.115" y1="8.155" x2="216.205" y2="8.165" layer="94"/>
+<rectangle x1="216.535" y1="8.155" x2="216.805" y2="8.165" layer="94"/>
+<rectangle x1="217.025" y1="8.155" x2="217.695" y2="8.165" layer="94"/>
+<rectangle x1="218.235" y1="8.155" x2="218.585" y2="8.165" layer="94"/>
+<rectangle x1="219.195" y1="8.155" x2="219.915" y2="8.165" layer="94"/>
+<rectangle x1="220.345" y1="8.155" x2="221.065" y2="8.165" layer="94"/>
+<rectangle x1="221.485" y1="8.155" x2="222.075" y2="8.165" layer="94"/>
+<rectangle x1="222.295" y1="8.155" x2="222.635" y2="8.165" layer="94"/>
+<rectangle x1="216.105" y1="8.165" x2="216.175" y2="8.175" layer="94"/>
+<rectangle x1="216.545" y1="8.165" x2="216.805" y2="8.175" layer="94"/>
+<rectangle x1="217.025" y1="8.165" x2="217.685" y2="8.175" layer="94"/>
+<rectangle x1="218.215" y1="8.165" x2="218.605" y2="8.175" layer="94"/>
+<rectangle x1="219.195" y1="8.165" x2="219.915" y2="8.175" layer="94"/>
+<rectangle x1="220.345" y1="8.165" x2="221.065" y2="8.175" layer="94"/>
+<rectangle x1="221.485" y1="8.165" x2="222.075" y2="8.175" layer="94"/>
+<rectangle x1="222.305" y1="8.165" x2="222.625" y2="8.175" layer="94"/>
+<rectangle x1="216.095" y1="8.175" x2="216.145" y2="8.185" layer="94"/>
+<rectangle x1="216.555" y1="8.175" x2="216.805" y2="8.185" layer="94"/>
+<rectangle x1="217.025" y1="8.175" x2="217.685" y2="8.185" layer="94"/>
+<rectangle x1="218.195" y1="8.175" x2="218.625" y2="8.185" layer="94"/>
+<rectangle x1="219.195" y1="8.175" x2="219.915" y2="8.185" layer="94"/>
+<rectangle x1="220.345" y1="8.175" x2="221.065" y2="8.185" layer="94"/>
+<rectangle x1="221.485" y1="8.175" x2="222.075" y2="8.185" layer="94"/>
+<rectangle x1="222.305" y1="8.175" x2="222.605" y2="8.185" layer="94"/>
+<rectangle x1="216.095" y1="8.185" x2="216.105" y2="8.195" layer="94"/>
+<rectangle x1="216.565" y1="8.185" x2="216.805" y2="8.195" layer="94"/>
+<rectangle x1="217.025" y1="8.185" x2="217.675" y2="8.195" layer="94"/>
+<rectangle x1="218.185" y1="8.185" x2="218.635" y2="8.195" layer="94"/>
+<rectangle x1="219.195" y1="8.185" x2="219.915" y2="8.195" layer="94"/>
+<rectangle x1="220.345" y1="8.185" x2="221.065" y2="8.195" layer="94"/>
+<rectangle x1="221.485" y1="8.185" x2="222.085" y2="8.195" layer="94"/>
+<rectangle x1="222.305" y1="8.185" x2="222.595" y2="8.195" layer="94"/>
+<rectangle x1="216.575" y1="8.195" x2="216.795" y2="8.205" layer="94"/>
+<rectangle x1="217.025" y1="8.195" x2="217.675" y2="8.205" layer="94"/>
+<rectangle x1="218.175" y1="8.195" x2="218.645" y2="8.205" layer="94"/>
+<rectangle x1="219.195" y1="8.195" x2="219.915" y2="8.205" layer="94"/>
+<rectangle x1="220.345" y1="8.195" x2="221.065" y2="8.205" layer="94"/>
+<rectangle x1="221.485" y1="8.195" x2="222.085" y2="8.205" layer="94"/>
+<rectangle x1="222.305" y1="8.195" x2="222.575" y2="8.205" layer="94"/>
+<rectangle x1="216.585" y1="8.205" x2="216.795" y2="8.215" layer="94"/>
+<rectangle x1="217.025" y1="8.205" x2="217.675" y2="8.215" layer="94"/>
+<rectangle x1="218.165" y1="8.205" x2="218.655" y2="8.215" layer="94"/>
+<rectangle x1="219.195" y1="8.205" x2="219.915" y2="8.215" layer="94"/>
+<rectangle x1="220.345" y1="8.205" x2="221.065" y2="8.215" layer="94"/>
+<rectangle x1="221.485" y1="8.205" x2="222.085" y2="8.215" layer="94"/>
+<rectangle x1="222.305" y1="8.205" x2="222.565" y2="8.215" layer="94"/>
+<rectangle x1="216.595" y1="8.215" x2="216.795" y2="8.225" layer="94"/>
+<rectangle x1="217.015" y1="8.215" x2="217.665" y2="8.225" layer="94"/>
+<rectangle x1="218.155" y1="8.215" x2="218.665" y2="8.225" layer="94"/>
+<rectangle x1="219.195" y1="8.215" x2="219.915" y2="8.225" layer="94"/>
+<rectangle x1="220.345" y1="8.215" x2="221.065" y2="8.225" layer="94"/>
+<rectangle x1="221.485" y1="8.215" x2="222.085" y2="8.225" layer="94"/>
+<rectangle x1="222.305" y1="8.215" x2="222.555" y2="8.225" layer="94"/>
+<rectangle x1="216.605" y1="8.225" x2="216.795" y2="8.235" layer="94"/>
+<rectangle x1="217.015" y1="8.225" x2="217.665" y2="8.235" layer="94"/>
+<rectangle x1="218.145" y1="8.225" x2="218.675" y2="8.235" layer="94"/>
+<rectangle x1="219.195" y1="8.225" x2="219.915" y2="8.235" layer="94"/>
+<rectangle x1="220.345" y1="8.225" x2="221.065" y2="8.235" layer="94"/>
+<rectangle x1="221.485" y1="8.225" x2="222.085" y2="8.235" layer="94"/>
+<rectangle x1="222.315" y1="8.225" x2="222.535" y2="8.235" layer="94"/>
+<rectangle x1="216.605" y1="8.235" x2="216.795" y2="8.245" layer="94"/>
+<rectangle x1="217.015" y1="8.235" x2="217.665" y2="8.245" layer="94"/>
+<rectangle x1="218.135" y1="8.235" x2="218.685" y2="8.245" layer="94"/>
+<rectangle x1="219.195" y1="8.235" x2="219.915" y2="8.245" layer="94"/>
+<rectangle x1="220.345" y1="8.235" x2="221.065" y2="8.245" layer="94"/>
+<rectangle x1="221.485" y1="8.235" x2="222.085" y2="8.245" layer="94"/>
+<rectangle x1="222.315" y1="8.235" x2="222.525" y2="8.245" layer="94"/>
+<rectangle x1="216.605" y1="8.245" x2="216.785" y2="8.255" layer="94"/>
+<rectangle x1="217.015" y1="8.245" x2="217.655" y2="8.255" layer="94"/>
+<rectangle x1="218.125" y1="8.245" x2="218.685" y2="8.255" layer="94"/>
+<rectangle x1="219.195" y1="8.245" x2="219.915" y2="8.255" layer="94"/>
+<rectangle x1="220.345" y1="8.245" x2="221.065" y2="8.255" layer="94"/>
+<rectangle x1="221.485" y1="8.245" x2="222.095" y2="8.255" layer="94"/>
+<rectangle x1="222.315" y1="8.245" x2="222.515" y2="8.255" layer="94"/>
+<rectangle x1="216.605" y1="8.255" x2="216.785" y2="8.265" layer="94"/>
+<rectangle x1="217.015" y1="8.255" x2="217.655" y2="8.265" layer="94"/>
+<rectangle x1="218.125" y1="8.255" x2="218.695" y2="8.265" layer="94"/>
+<rectangle x1="219.195" y1="8.255" x2="219.915" y2="8.265" layer="94"/>
+<rectangle x1="220.345" y1="8.255" x2="221.065" y2="8.265" layer="94"/>
+<rectangle x1="221.485" y1="8.255" x2="222.095" y2="8.265" layer="94"/>
+<rectangle x1="222.315" y1="8.255" x2="222.505" y2="8.265" layer="94"/>
+<rectangle x1="216.605" y1="8.265" x2="216.785" y2="8.275" layer="94"/>
+<rectangle x1="217.005" y1="8.265" x2="217.655" y2="8.275" layer="94"/>
+<rectangle x1="218.115" y1="8.265" x2="218.695" y2="8.275" layer="94"/>
+<rectangle x1="219.195" y1="8.265" x2="219.915" y2="8.275" layer="94"/>
+<rectangle x1="220.345" y1="8.265" x2="221.065" y2="8.275" layer="94"/>
+<rectangle x1="221.485" y1="8.265" x2="222.095" y2="8.275" layer="94"/>
+<rectangle x1="222.315" y1="8.265" x2="222.505" y2="8.275" layer="94"/>
+<rectangle x1="216.605" y1="8.275" x2="216.785" y2="8.285" layer="94"/>
+<rectangle x1="217.005" y1="8.275" x2="217.655" y2="8.285" layer="94"/>
+<rectangle x1="218.115" y1="8.275" x2="218.705" y2="8.285" layer="94"/>
+<rectangle x1="219.195" y1="8.275" x2="219.915" y2="8.285" layer="94"/>
+<rectangle x1="220.345" y1="8.275" x2="221.065" y2="8.285" layer="94"/>
+<rectangle x1="221.485" y1="8.275" x2="222.095" y2="8.285" layer="94"/>
+<rectangle x1="222.315" y1="8.275" x2="222.505" y2="8.285" layer="94"/>
+<rectangle x1="223.005" y1="8.275" x2="223.025" y2="8.285" layer="94"/>
+<rectangle x1="216.595" y1="8.285" x2="216.785" y2="8.295" layer="94"/>
+<rectangle x1="217.005" y1="8.285" x2="217.645" y2="8.295" layer="94"/>
+<rectangle x1="218.105" y1="8.285" x2="218.715" y2="8.295" layer="94"/>
+<rectangle x1="219.195" y1="8.285" x2="219.915" y2="8.295" layer="94"/>
+<rectangle x1="220.345" y1="8.285" x2="221.065" y2="8.295" layer="94"/>
+<rectangle x1="221.485" y1="8.285" x2="222.095" y2="8.295" layer="94"/>
+<rectangle x1="222.325" y1="8.285" x2="222.505" y2="8.295" layer="94"/>
+<rectangle x1="222.995" y1="8.285" x2="223.015" y2="8.295" layer="94"/>
+<rectangle x1="216.595" y1="8.295" x2="216.785" y2="8.305" layer="94"/>
+<rectangle x1="217.005" y1="8.295" x2="217.645" y2="8.305" layer="94"/>
+<rectangle x1="218.095" y1="8.295" x2="218.715" y2="8.305" layer="94"/>
+<rectangle x1="219.195" y1="8.295" x2="219.915" y2="8.305" layer="94"/>
+<rectangle x1="220.345" y1="8.295" x2="221.065" y2="8.305" layer="94"/>
+<rectangle x1="221.485" y1="8.295" x2="222.105" y2="8.305" layer="94"/>
+<rectangle x1="222.325" y1="8.295" x2="222.505" y2="8.305" layer="94"/>
+<rectangle x1="222.975" y1="8.295" x2="223.015" y2="8.305" layer="94"/>
+<rectangle x1="216.595" y1="8.305" x2="216.785" y2="8.315" layer="94"/>
+<rectangle x1="217.005" y1="8.305" x2="217.645" y2="8.315" layer="94"/>
+<rectangle x1="218.095" y1="8.305" x2="218.725" y2="8.315" layer="94"/>
+<rectangle x1="219.195" y1="8.305" x2="219.915" y2="8.315" layer="94"/>
+<rectangle x1="220.345" y1="8.305" x2="221.065" y2="8.315" layer="94"/>
+<rectangle x1="221.485" y1="8.305" x2="222.105" y2="8.315" layer="94"/>
+<rectangle x1="222.325" y1="8.305" x2="222.505" y2="8.315" layer="94"/>
+<rectangle x1="222.955" y1="8.305" x2="223.015" y2="8.315" layer="94"/>
+<rectangle x1="216.575" y1="8.315" x2="216.785" y2="8.325" layer="94"/>
+<rectangle x1="217.005" y1="8.315" x2="217.645" y2="8.325" layer="94"/>
+<rectangle x1="218.095" y1="8.315" x2="218.725" y2="8.325" layer="94"/>
+<rectangle x1="219.195" y1="8.315" x2="219.915" y2="8.325" layer="94"/>
+<rectangle x1="220.345" y1="8.315" x2="221.065" y2="8.325" layer="94"/>
+<rectangle x1="221.485" y1="8.315" x2="222.105" y2="8.325" layer="94"/>
+<rectangle x1="222.325" y1="8.315" x2="222.505" y2="8.325" layer="94"/>
+<rectangle x1="222.945" y1="8.315" x2="223.005" y2="8.325" layer="94"/>
+<rectangle x1="216.555" y1="8.325" x2="216.775" y2="8.335" layer="94"/>
+<rectangle x1="217.005" y1="8.325" x2="217.645" y2="8.335" layer="94"/>
+<rectangle x1="218.085" y1="8.325" x2="218.725" y2="8.335" layer="94"/>
+<rectangle x1="219.195" y1="8.325" x2="219.915" y2="8.335" layer="94"/>
+<rectangle x1="220.345" y1="8.325" x2="221.065" y2="8.335" layer="94"/>
+<rectangle x1="221.485" y1="8.325" x2="222.105" y2="8.335" layer="94"/>
+<rectangle x1="222.325" y1="8.325" x2="222.515" y2="8.335" layer="94"/>
+<rectangle x1="222.925" y1="8.325" x2="223.005" y2="8.335" layer="94"/>
+<rectangle x1="216.525" y1="8.335" x2="216.775" y2="8.345" layer="94"/>
+<rectangle x1="216.995" y1="8.335" x2="217.635" y2="8.345" layer="94"/>
+<rectangle x1="218.085" y1="8.335" x2="218.735" y2="8.345" layer="94"/>
+<rectangle x1="219.195" y1="8.335" x2="219.915" y2="8.345" layer="94"/>
+<rectangle x1="220.345" y1="8.335" x2="221.065" y2="8.345" layer="94"/>
+<rectangle x1="221.485" y1="8.335" x2="222.105" y2="8.345" layer="94"/>
+<rectangle x1="222.325" y1="8.335" x2="222.515" y2="8.345" layer="94"/>
+<rectangle x1="222.905" y1="8.335" x2="223.005" y2="8.345" layer="94"/>
+<rectangle x1="216.505" y1="8.345" x2="216.775" y2="8.355" layer="94"/>
+<rectangle x1="216.995" y1="8.345" x2="217.635" y2="8.355" layer="94"/>
+<rectangle x1="218.085" y1="8.345" x2="218.735" y2="8.355" layer="94"/>
+<rectangle x1="219.195" y1="8.345" x2="219.915" y2="8.355" layer="94"/>
+<rectangle x1="220.345" y1="8.345" x2="221.065" y2="8.355" layer="94"/>
+<rectangle x1="221.485" y1="8.345" x2="222.105" y2="8.355" layer="94"/>
+<rectangle x1="222.325" y1="8.345" x2="222.515" y2="8.355" layer="94"/>
+<rectangle x1="222.895" y1="8.345" x2="223.005" y2="8.355" layer="94"/>
+<rectangle x1="216.475" y1="8.355" x2="216.775" y2="8.365" layer="94"/>
+<rectangle x1="216.995" y1="8.355" x2="217.635" y2="8.365" layer="94"/>
+<rectangle x1="218.075" y1="8.355" x2="218.735" y2="8.365" layer="94"/>
+<rectangle x1="219.195" y1="8.355" x2="219.915" y2="8.365" layer="94"/>
+<rectangle x1="220.345" y1="8.355" x2="221.065" y2="8.365" layer="94"/>
+<rectangle x1="221.485" y1="8.355" x2="222.105" y2="8.365" layer="94"/>
+<rectangle x1="222.325" y1="8.355" x2="222.515" y2="8.365" layer="94"/>
+<rectangle x1="222.875" y1="8.355" x2="222.995" y2="8.365" layer="94"/>
+<rectangle x1="216.445" y1="8.365" x2="216.775" y2="8.375" layer="94"/>
+<rectangle x1="216.995" y1="8.365" x2="217.635" y2="8.375" layer="94"/>
+<rectangle x1="218.075" y1="8.365" x2="218.745" y2="8.375" layer="94"/>
+<rectangle x1="219.195" y1="8.365" x2="219.915" y2="8.375" layer="94"/>
+<rectangle x1="220.345" y1="8.365" x2="221.065" y2="8.375" layer="94"/>
+<rectangle x1="221.485" y1="8.365" x2="222.105" y2="8.375" layer="94"/>
+<rectangle x1="222.335" y1="8.365" x2="222.515" y2="8.375" layer="94"/>
+<rectangle x1="222.865" y1="8.365" x2="222.995" y2="8.375" layer="94"/>
+<rectangle x1="216.425" y1="8.375" x2="216.775" y2="8.385" layer="94"/>
+<rectangle x1="216.995" y1="8.375" x2="217.635" y2="8.385" layer="94"/>
+<rectangle x1="218.075" y1="8.375" x2="218.745" y2="8.385" layer="94"/>
+<rectangle x1="219.195" y1="8.375" x2="219.915" y2="8.385" layer="94"/>
+<rectangle x1="220.345" y1="8.375" x2="221.065" y2="8.385" layer="94"/>
+<rectangle x1="221.485" y1="8.375" x2="222.115" y2="8.385" layer="94"/>
+<rectangle x1="222.335" y1="8.375" x2="222.535" y2="8.385" layer="94"/>
+<rectangle x1="222.845" y1="8.375" x2="222.995" y2="8.385" layer="94"/>
+<rectangle x1="216.395" y1="8.385" x2="216.775" y2="8.395" layer="94"/>
+<rectangle x1="216.995" y1="8.385" x2="217.635" y2="8.395" layer="94"/>
+<rectangle x1="218.065" y1="8.385" x2="218.745" y2="8.395" layer="94"/>
+<rectangle x1="219.195" y1="8.385" x2="219.915" y2="8.395" layer="94"/>
+<rectangle x1="220.345" y1="8.385" x2="221.065" y2="8.395" layer="94"/>
+<rectangle x1="221.485" y1="8.385" x2="222.115" y2="8.395" layer="94"/>
+<rectangle x1="222.335" y1="8.385" x2="222.555" y2="8.395" layer="94"/>
+<rectangle x1="222.825" y1="8.385" x2="222.985" y2="8.395" layer="94"/>
+<rectangle x1="216.375" y1="8.395" x2="216.775" y2="8.405" layer="94"/>
+<rectangle x1="216.995" y1="8.395" x2="217.635" y2="8.405" layer="94"/>
+<rectangle x1="218.065" y1="8.395" x2="218.745" y2="8.405" layer="94"/>
+<rectangle x1="219.195" y1="8.395" x2="219.915" y2="8.405" layer="94"/>
+<rectangle x1="220.345" y1="8.395" x2="221.065" y2="8.405" layer="94"/>
+<rectangle x1="221.485" y1="8.395" x2="222.115" y2="8.405" layer="94"/>
+<rectangle x1="222.335" y1="8.395" x2="222.565" y2="8.405" layer="94"/>
+<rectangle x1="222.815" y1="8.395" x2="222.985" y2="8.405" layer="94"/>
+<rectangle x1="216.345" y1="8.405" x2="216.765" y2="8.415" layer="94"/>
+<rectangle x1="216.995" y1="8.405" x2="217.635" y2="8.415" layer="94"/>
+<rectangle x1="218.065" y1="8.405" x2="218.755" y2="8.415" layer="94"/>
+<rectangle x1="219.195" y1="8.405" x2="219.915" y2="8.415" layer="94"/>
+<rectangle x1="220.345" y1="8.405" x2="221.065" y2="8.415" layer="94"/>
+<rectangle x1="221.485" y1="8.405" x2="222.115" y2="8.415" layer="94"/>
+<rectangle x1="222.335" y1="8.405" x2="222.585" y2="8.415" layer="94"/>
+<rectangle x1="222.795" y1="8.405" x2="222.985" y2="8.415" layer="94"/>
+<rectangle x1="216.325" y1="8.415" x2="216.765" y2="8.425" layer="94"/>
+<rectangle x1="216.985" y1="8.415" x2="217.635" y2="8.425" layer="94"/>
+<rectangle x1="218.065" y1="8.415" x2="218.755" y2="8.425" layer="94"/>
+<rectangle x1="219.195" y1="8.415" x2="219.915" y2="8.425" layer="94"/>
+<rectangle x1="220.345" y1="8.415" x2="221.065" y2="8.425" layer="94"/>
+<rectangle x1="221.485" y1="8.415" x2="222.115" y2="8.425" layer="94"/>
+<rectangle x1="222.335" y1="8.415" x2="222.605" y2="8.425" layer="94"/>
+<rectangle x1="222.785" y1="8.415" x2="222.985" y2="8.425" layer="94"/>
+<rectangle x1="216.295" y1="8.425" x2="216.765" y2="8.435" layer="94"/>
+<rectangle x1="216.985" y1="8.425" x2="217.635" y2="8.435" layer="94"/>
+<rectangle x1="218.065" y1="8.425" x2="218.755" y2="8.435" layer="94"/>
+<rectangle x1="219.195" y1="8.425" x2="219.915" y2="8.435" layer="94"/>
+<rectangle x1="220.345" y1="8.425" x2="221.065" y2="8.435" layer="94"/>
+<rectangle x1="221.485" y1="8.425" x2="222.115" y2="8.435" layer="94"/>
+<rectangle x1="222.335" y1="8.425" x2="222.625" y2="8.435" layer="94"/>
+<rectangle x1="222.765" y1="8.425" x2="222.975" y2="8.435" layer="94"/>
+<rectangle x1="216.275" y1="8.435" x2="216.765" y2="8.445" layer="94"/>
+<rectangle x1="216.985" y1="8.435" x2="217.625" y2="8.445" layer="94"/>
+<rectangle x1="218.055" y1="8.435" x2="218.755" y2="8.445" layer="94"/>
+<rectangle x1="219.195" y1="8.435" x2="219.915" y2="8.445" layer="94"/>
+<rectangle x1="220.345" y1="8.435" x2="221.065" y2="8.445" layer="94"/>
+<rectangle x1="221.485" y1="8.435" x2="222.115" y2="8.445" layer="94"/>
+<rectangle x1="222.335" y1="8.435" x2="222.645" y2="8.445" layer="94"/>
+<rectangle x1="222.745" y1="8.435" x2="222.975" y2="8.445" layer="94"/>
+<rectangle x1="216.275" y1="8.445" x2="216.765" y2="8.455" layer="94"/>
+<rectangle x1="216.985" y1="8.445" x2="217.625" y2="8.455" layer="94"/>
+<rectangle x1="218.055" y1="8.445" x2="218.755" y2="8.455" layer="94"/>
+<rectangle x1="219.195" y1="8.445" x2="219.915" y2="8.455" layer="94"/>
+<rectangle x1="220.345" y1="8.445" x2="221.065" y2="8.455" layer="94"/>
+<rectangle x1="221.485" y1="8.445" x2="222.115" y2="8.455" layer="94"/>
+<rectangle x1="222.335" y1="8.445" x2="222.655" y2="8.455" layer="94"/>
+<rectangle x1="222.735" y1="8.445" x2="222.975" y2="8.455" layer="94"/>
+<rectangle x1="216.265" y1="8.455" x2="216.765" y2="8.465" layer="94"/>
+<rectangle x1="216.985" y1="8.455" x2="217.625" y2="8.465" layer="94"/>
+<rectangle x1="218.055" y1="8.455" x2="218.755" y2="8.465" layer="94"/>
+<rectangle x1="219.195" y1="8.455" x2="219.915" y2="8.465" layer="94"/>
+<rectangle x1="220.345" y1="8.455" x2="221.065" y2="8.465" layer="94"/>
+<rectangle x1="221.485" y1="8.455" x2="222.115" y2="8.465" layer="94"/>
+<rectangle x1="222.335" y1="8.455" x2="222.675" y2="8.465" layer="94"/>
+<rectangle x1="222.715" y1="8.455" x2="222.965" y2="8.465" layer="94"/>
+<rectangle x1="216.265" y1="8.465" x2="216.765" y2="8.475" layer="94"/>
+<rectangle x1="216.985" y1="8.465" x2="217.625" y2="8.475" layer="94"/>
+<rectangle x1="218.055" y1="8.465" x2="218.765" y2="8.475" layer="94"/>
+<rectangle x1="219.195" y1="8.465" x2="219.915" y2="8.475" layer="94"/>
+<rectangle x1="220.345" y1="8.465" x2="221.065" y2="8.475" layer="94"/>
+<rectangle x1="221.485" y1="8.465" x2="222.115" y2="8.475" layer="94"/>
+<rectangle x1="222.345" y1="8.465" x2="222.965" y2="8.475" layer="94"/>
+<rectangle x1="216.265" y1="8.475" x2="216.765" y2="8.485" layer="94"/>
+<rectangle x1="216.985" y1="8.475" x2="217.625" y2="8.485" layer="94"/>
+<rectangle x1="218.055" y1="8.475" x2="218.765" y2="8.485" layer="94"/>
+<rectangle x1="219.195" y1="8.475" x2="219.915" y2="8.485" layer="94"/>
+<rectangle x1="220.345" y1="8.475" x2="221.065" y2="8.485" layer="94"/>
+<rectangle x1="221.485" y1="8.475" x2="222.125" y2="8.485" layer="94"/>
+<rectangle x1="222.345" y1="8.475" x2="222.965" y2="8.485" layer="94"/>
+<rectangle x1="216.255" y1="8.485" x2="216.765" y2="8.495" layer="94"/>
+<rectangle x1="216.985" y1="8.485" x2="217.625" y2="8.495" layer="94"/>
+<rectangle x1="218.055" y1="8.485" x2="218.765" y2="8.495" layer="94"/>
+<rectangle x1="219.195" y1="8.485" x2="219.915" y2="8.495" layer="94"/>
+<rectangle x1="220.345" y1="8.485" x2="221.065" y2="8.495" layer="94"/>
+<rectangle x1="221.485" y1="8.485" x2="222.125" y2="8.495" layer="94"/>
+<rectangle x1="222.345" y1="8.485" x2="222.955" y2="8.495" layer="94"/>
+<rectangle x1="216.255" y1="8.495" x2="216.765" y2="8.505" layer="94"/>
+<rectangle x1="216.985" y1="8.495" x2="217.625" y2="8.505" layer="94"/>
+<rectangle x1="218.055" y1="8.495" x2="218.765" y2="8.505" layer="94"/>
+<rectangle x1="219.195" y1="8.495" x2="219.915" y2="8.505" layer="94"/>
+<rectangle x1="220.345" y1="8.495" x2="221.065" y2="8.505" layer="94"/>
+<rectangle x1="221.485" y1="8.495" x2="222.125" y2="8.505" layer="94"/>
+<rectangle x1="222.345" y1="8.495" x2="222.955" y2="8.505" layer="94"/>
+<rectangle x1="216.255" y1="8.505" x2="216.765" y2="8.515" layer="94"/>
+<rectangle x1="216.985" y1="8.505" x2="217.625" y2="8.515" layer="94"/>
+<rectangle x1="218.055" y1="8.505" x2="218.765" y2="8.515" layer="94"/>
+<rectangle x1="219.195" y1="8.505" x2="219.915" y2="8.515" layer="94"/>
+<rectangle x1="220.345" y1="8.505" x2="221.065" y2="8.515" layer="94"/>
+<rectangle x1="221.485" y1="8.505" x2="222.125" y2="8.515" layer="94"/>
+<rectangle x1="222.345" y1="8.505" x2="222.955" y2="8.515" layer="94"/>
+<rectangle x1="216.245" y1="8.515" x2="216.765" y2="8.525" layer="94"/>
+<rectangle x1="216.985" y1="8.515" x2="217.625" y2="8.525" layer="94"/>
+<rectangle x1="218.055" y1="8.515" x2="218.765" y2="8.525" layer="94"/>
+<rectangle x1="219.195" y1="8.515" x2="219.915" y2="8.525" layer="94"/>
+<rectangle x1="220.345" y1="8.515" x2="221.065" y2="8.525" layer="94"/>
+<rectangle x1="221.485" y1="8.515" x2="222.125" y2="8.525" layer="94"/>
+<rectangle x1="222.345" y1="8.515" x2="222.955" y2="8.525" layer="94"/>
+<rectangle x1="216.245" y1="8.525" x2="216.755" y2="8.535" layer="94"/>
+<rectangle x1="216.985" y1="8.525" x2="217.625" y2="8.535" layer="94"/>
+<rectangle x1="218.055" y1="8.525" x2="218.765" y2="8.535" layer="94"/>
+<rectangle x1="219.195" y1="8.525" x2="219.915" y2="8.535" layer="94"/>
+<rectangle x1="220.345" y1="8.525" x2="221.065" y2="8.535" layer="94"/>
+<rectangle x1="221.485" y1="8.525" x2="222.125" y2="8.535" layer="94"/>
+<rectangle x1="222.345" y1="8.525" x2="222.945" y2="8.535" layer="94"/>
+<rectangle x1="216.245" y1="8.535" x2="216.755" y2="8.545" layer="94"/>
+<rectangle x1="216.975" y1="8.535" x2="217.625" y2="8.545" layer="94"/>
+<rectangle x1="218.055" y1="8.535" x2="218.765" y2="8.545" layer="94"/>
+<rectangle x1="219.195" y1="8.535" x2="219.915" y2="8.545" layer="94"/>
+<rectangle x1="220.345" y1="8.535" x2="221.065" y2="8.545" layer="94"/>
+<rectangle x1="221.485" y1="8.535" x2="222.125" y2="8.545" layer="94"/>
+<rectangle x1="222.345" y1="8.535" x2="222.945" y2="8.545" layer="94"/>
+<rectangle x1="216.245" y1="8.545" x2="216.755" y2="8.555" layer="94"/>
+<rectangle x1="216.975" y1="8.545" x2="217.625" y2="8.555" layer="94"/>
+<rectangle x1="218.055" y1="8.545" x2="218.765" y2="8.555" layer="94"/>
+<rectangle x1="219.195" y1="8.545" x2="219.915" y2="8.555" layer="94"/>
+<rectangle x1="220.345" y1="8.545" x2="221.065" y2="8.555" layer="94"/>
+<rectangle x1="221.485" y1="8.545" x2="222.125" y2="8.555" layer="94"/>
+<rectangle x1="222.345" y1="8.545" x2="222.945" y2="8.555" layer="94"/>
+<rectangle x1="216.235" y1="8.555" x2="216.755" y2="8.565" layer="94"/>
+<rectangle x1="216.975" y1="8.555" x2="217.625" y2="8.565" layer="94"/>
+<rectangle x1="218.045" y1="8.555" x2="218.765" y2="8.565" layer="94"/>
+<rectangle x1="219.195" y1="8.555" x2="219.915" y2="8.565" layer="94"/>
+<rectangle x1="220.345" y1="8.555" x2="221.065" y2="8.565" layer="94"/>
+<rectangle x1="221.485" y1="8.555" x2="222.125" y2="8.565" layer="94"/>
+<rectangle x1="222.345" y1="8.555" x2="222.935" y2="8.565" layer="94"/>
+<rectangle x1="216.235" y1="8.565" x2="216.755" y2="8.575" layer="94"/>
+<rectangle x1="216.975" y1="8.565" x2="217.625" y2="8.575" layer="94"/>
+<rectangle x1="218.045" y1="8.565" x2="218.765" y2="8.575" layer="94"/>
+<rectangle x1="219.195" y1="8.565" x2="219.915" y2="8.575" layer="94"/>
+<rectangle x1="220.345" y1="8.565" x2="221.065" y2="8.575" layer="94"/>
+<rectangle x1="221.485" y1="8.565" x2="222.125" y2="8.575" layer="94"/>
+<rectangle x1="222.345" y1="8.565" x2="222.935" y2="8.575" layer="94"/>
+<rectangle x1="216.235" y1="8.575" x2="216.755" y2="8.585" layer="94"/>
+<rectangle x1="216.975" y1="8.575" x2="217.625" y2="8.585" layer="94"/>
+<rectangle x1="218.045" y1="8.575" x2="218.765" y2="8.585" layer="94"/>
+<rectangle x1="219.195" y1="8.575" x2="219.915" y2="8.585" layer="94"/>
+<rectangle x1="220.345" y1="8.575" x2="221.065" y2="8.585" layer="94"/>
+<rectangle x1="221.485" y1="8.575" x2="222.125" y2="8.585" layer="94"/>
+<rectangle x1="222.345" y1="8.575" x2="222.935" y2="8.585" layer="94"/>
+<rectangle x1="216.225" y1="8.585" x2="216.755" y2="8.595" layer="94"/>
+<rectangle x1="216.975" y1="8.585" x2="217.625" y2="8.595" layer="94"/>
+<rectangle x1="218.045" y1="8.585" x2="218.765" y2="8.595" layer="94"/>
+<rectangle x1="219.195" y1="8.585" x2="219.915" y2="8.595" layer="94"/>
+<rectangle x1="220.345" y1="8.585" x2="221.065" y2="8.595" layer="94"/>
+<rectangle x1="221.485" y1="8.585" x2="222.125" y2="8.595" layer="94"/>
+<rectangle x1="222.345" y1="8.585" x2="222.935" y2="8.595" layer="94"/>
+<rectangle x1="216.225" y1="8.595" x2="216.755" y2="8.605" layer="94"/>
+<rectangle x1="216.975" y1="8.595" x2="217.625" y2="8.605" layer="94"/>
+<rectangle x1="218.045" y1="8.595" x2="218.765" y2="8.605" layer="94"/>
+<rectangle x1="219.195" y1="8.595" x2="219.915" y2="8.605" layer="94"/>
+<rectangle x1="220.345" y1="8.595" x2="221.065" y2="8.605" layer="94"/>
+<rectangle x1="221.485" y1="8.595" x2="222.125" y2="8.605" layer="94"/>
+<rectangle x1="222.345" y1="8.595" x2="222.925" y2="8.605" layer="94"/>
+<rectangle x1="216.225" y1="8.605" x2="216.755" y2="8.615" layer="94"/>
+<rectangle x1="216.975" y1="8.605" x2="217.625" y2="8.615" layer="94"/>
+<rectangle x1="218.045" y1="8.605" x2="218.765" y2="8.615" layer="94"/>
+<rectangle x1="219.195" y1="8.605" x2="219.915" y2="8.615" layer="94"/>
+<rectangle x1="220.345" y1="8.605" x2="221.065" y2="8.615" layer="94"/>
+<rectangle x1="221.485" y1="8.605" x2="222.125" y2="8.615" layer="94"/>
+<rectangle x1="222.345" y1="8.605" x2="222.925" y2="8.615" layer="94"/>
+<rectangle x1="216.225" y1="8.615" x2="216.755" y2="8.625" layer="94"/>
+<rectangle x1="216.975" y1="8.615" x2="217.625" y2="8.625" layer="94"/>
+<rectangle x1="218.045" y1="8.615" x2="218.765" y2="8.625" layer="94"/>
+<rectangle x1="219.195" y1="8.615" x2="219.915" y2="8.625" layer="94"/>
+<rectangle x1="220.345" y1="8.615" x2="221.065" y2="8.625" layer="94"/>
+<rectangle x1="221.485" y1="8.615" x2="222.125" y2="8.625" layer="94"/>
+<rectangle x1="222.345" y1="8.615" x2="222.925" y2="8.625" layer="94"/>
+<rectangle x1="216.215" y1="8.625" x2="216.755" y2="8.635" layer="94"/>
+<rectangle x1="216.975" y1="8.625" x2="217.625" y2="8.635" layer="94"/>
+<rectangle x1="218.045" y1="8.625" x2="218.765" y2="8.635" layer="94"/>
+<rectangle x1="219.195" y1="8.625" x2="219.915" y2="8.635" layer="94"/>
+<rectangle x1="220.345" y1="8.625" x2="221.065" y2="8.635" layer="94"/>
+<rectangle x1="221.485" y1="8.625" x2="222.125" y2="8.635" layer="94"/>
+<rectangle x1="222.345" y1="8.625" x2="222.915" y2="8.635" layer="94"/>
+<rectangle x1="216.215" y1="8.635" x2="216.755" y2="8.645" layer="94"/>
+<rectangle x1="216.975" y1="8.635" x2="217.625" y2="8.645" layer="94"/>
+<rectangle x1="218.045" y1="8.635" x2="218.765" y2="8.645" layer="94"/>
+<rectangle x1="219.195" y1="8.635" x2="219.915" y2="8.645" layer="94"/>
+<rectangle x1="220.345" y1="8.635" x2="221.065" y2="8.645" layer="94"/>
+<rectangle x1="221.485" y1="8.635" x2="222.125" y2="8.645" layer="94"/>
+<rectangle x1="222.345" y1="8.635" x2="222.915" y2="8.645" layer="94"/>
+<rectangle x1="216.215" y1="8.645" x2="216.755" y2="8.655" layer="94"/>
+<rectangle x1="216.975" y1="8.645" x2="217.625" y2="8.655" layer="94"/>
+<rectangle x1="218.045" y1="8.645" x2="218.765" y2="8.655" layer="94"/>
+<rectangle x1="219.195" y1="8.645" x2="219.915" y2="8.655" layer="94"/>
+<rectangle x1="220.345" y1="8.645" x2="221.065" y2="8.655" layer="94"/>
+<rectangle x1="221.485" y1="8.645" x2="222.125" y2="8.655" layer="94"/>
+<rectangle x1="222.345" y1="8.645" x2="222.915" y2="8.655" layer="94"/>
+<rectangle x1="216.205" y1="8.655" x2="216.755" y2="8.665" layer="94"/>
+<rectangle x1="216.975" y1="8.655" x2="217.625" y2="8.665" layer="94"/>
+<rectangle x1="218.045" y1="8.655" x2="218.765" y2="8.665" layer="94"/>
+<rectangle x1="219.195" y1="8.655" x2="219.915" y2="8.665" layer="94"/>
+<rectangle x1="220.345" y1="8.655" x2="221.065" y2="8.665" layer="94"/>
+<rectangle x1="221.485" y1="8.655" x2="222.125" y2="8.665" layer="94"/>
+<rectangle x1="222.345" y1="8.655" x2="222.905" y2="8.665" layer="94"/>
+<rectangle x1="216.205" y1="8.665" x2="216.755" y2="8.675" layer="94"/>
+<rectangle x1="216.975" y1="8.665" x2="217.625" y2="8.675" layer="94"/>
+<rectangle x1="218.045" y1="8.665" x2="218.765" y2="8.675" layer="94"/>
+<rectangle x1="219.195" y1="8.665" x2="219.915" y2="8.675" layer="94"/>
+<rectangle x1="220.345" y1="8.665" x2="221.065" y2="8.675" layer="94"/>
+<rectangle x1="221.485" y1="8.665" x2="222.125" y2="8.675" layer="94"/>
+<rectangle x1="222.345" y1="8.665" x2="222.905" y2="8.675" layer="94"/>
+<rectangle x1="216.205" y1="8.675" x2="216.755" y2="8.685" layer="94"/>
+<rectangle x1="216.975" y1="8.675" x2="217.625" y2="8.685" layer="94"/>
+<rectangle x1="218.045" y1="8.675" x2="218.765" y2="8.685" layer="94"/>
+<rectangle x1="219.195" y1="8.675" x2="219.915" y2="8.685" layer="94"/>
+<rectangle x1="220.345" y1="8.675" x2="221.065" y2="8.685" layer="94"/>
+<rectangle x1="221.485" y1="8.675" x2="222.125" y2="8.685" layer="94"/>
+<rectangle x1="222.345" y1="8.675" x2="222.905" y2="8.685" layer="94"/>
+<rectangle x1="216.195" y1="8.685" x2="216.755" y2="8.695" layer="94"/>
+<rectangle x1="216.975" y1="8.685" x2="217.625" y2="8.695" layer="94"/>
+<rectangle x1="218.045" y1="8.685" x2="218.765" y2="8.695" layer="94"/>
+<rectangle x1="219.195" y1="8.685" x2="219.915" y2="8.695" layer="94"/>
+<rectangle x1="220.345" y1="8.685" x2="221.065" y2="8.695" layer="94"/>
+<rectangle x1="221.485" y1="8.685" x2="222.125" y2="8.695" layer="94"/>
+<rectangle x1="222.345" y1="8.685" x2="222.905" y2="8.695" layer="94"/>
+<rectangle x1="216.195" y1="8.695" x2="216.755" y2="8.705" layer="94"/>
+<rectangle x1="216.975" y1="8.695" x2="217.625" y2="8.705" layer="94"/>
+<rectangle x1="218.045" y1="8.695" x2="218.765" y2="8.705" layer="94"/>
+<rectangle x1="219.195" y1="8.695" x2="219.915" y2="8.705" layer="94"/>
+<rectangle x1="220.345" y1="8.695" x2="221.065" y2="8.705" layer="94"/>
+<rectangle x1="221.485" y1="8.695" x2="222.125" y2="8.705" layer="94"/>
+<rectangle x1="222.345" y1="8.695" x2="222.895" y2="8.705" layer="94"/>
+<rectangle x1="216.195" y1="8.705" x2="216.755" y2="8.715" layer="94"/>
+<rectangle x1="216.975" y1="8.705" x2="217.625" y2="8.715" layer="94"/>
+<rectangle x1="218.045" y1="8.705" x2="218.765" y2="8.715" layer="94"/>
+<rectangle x1="219.195" y1="8.705" x2="219.915" y2="8.715" layer="94"/>
+<rectangle x1="220.345" y1="8.705" x2="221.065" y2="8.715" layer="94"/>
+<rectangle x1="221.485" y1="8.705" x2="222.125" y2="8.715" layer="94"/>
+<rectangle x1="222.345" y1="8.705" x2="222.895" y2="8.715" layer="94"/>
+<rectangle x1="216.195" y1="8.715" x2="216.755" y2="8.725" layer="94"/>
+<rectangle x1="216.975" y1="8.715" x2="217.625" y2="8.725" layer="94"/>
+<rectangle x1="218.045" y1="8.715" x2="218.765" y2="8.725" layer="94"/>
+<rectangle x1="219.195" y1="8.715" x2="219.915" y2="8.725" layer="94"/>
+<rectangle x1="220.345" y1="8.715" x2="221.065" y2="8.725" layer="94"/>
+<rectangle x1="221.485" y1="8.715" x2="222.125" y2="8.725" layer="94"/>
+<rectangle x1="222.345" y1="8.715" x2="222.895" y2="8.725" layer="94"/>
+<rectangle x1="216.185" y1="8.725" x2="216.755" y2="8.735" layer="94"/>
+<rectangle x1="216.975" y1="8.725" x2="217.625" y2="8.735" layer="94"/>
+<rectangle x1="218.045" y1="8.725" x2="218.765" y2="8.735" layer="94"/>
+<rectangle x1="219.195" y1="8.725" x2="219.915" y2="8.735" layer="94"/>
+<rectangle x1="220.345" y1="8.725" x2="221.065" y2="8.735" layer="94"/>
+<rectangle x1="221.485" y1="8.725" x2="222.125" y2="8.735" layer="94"/>
+<rectangle x1="222.345" y1="8.725" x2="222.885" y2="8.735" layer="94"/>
+<rectangle x1="216.185" y1="8.735" x2="216.755" y2="8.745" layer="94"/>
+<rectangle x1="216.975" y1="8.735" x2="217.625" y2="8.745" layer="94"/>
+<rectangle x1="218.045" y1="8.735" x2="218.765" y2="8.745" layer="94"/>
+<rectangle x1="219.195" y1="8.735" x2="219.915" y2="8.745" layer="94"/>
+<rectangle x1="220.345" y1="8.735" x2="221.065" y2="8.745" layer="94"/>
+<rectangle x1="221.485" y1="8.735" x2="222.125" y2="8.745" layer="94"/>
+<rectangle x1="222.345" y1="8.735" x2="222.885" y2="8.745" layer="94"/>
+<rectangle x1="216.185" y1="8.745" x2="216.755" y2="8.755" layer="94"/>
+<rectangle x1="216.975" y1="8.745" x2="217.625" y2="8.755" layer="94"/>
+<rectangle x1="218.045" y1="8.745" x2="218.765" y2="8.755" layer="94"/>
+<rectangle x1="219.195" y1="8.745" x2="219.915" y2="8.755" layer="94"/>
+<rectangle x1="220.345" y1="8.745" x2="221.065" y2="8.755" layer="94"/>
+<rectangle x1="221.485" y1="8.745" x2="222.125" y2="8.755" layer="94"/>
+<rectangle x1="222.345" y1="8.745" x2="222.885" y2="8.755" layer="94"/>
+<rectangle x1="216.175" y1="8.755" x2="216.755" y2="8.765" layer="94"/>
+<rectangle x1="216.975" y1="8.755" x2="217.625" y2="8.765" layer="94"/>
+<rectangle x1="218.045" y1="8.755" x2="218.765" y2="8.765" layer="94"/>
+<rectangle x1="219.195" y1="8.755" x2="219.915" y2="8.765" layer="94"/>
+<rectangle x1="220.345" y1="8.755" x2="221.065" y2="8.765" layer="94"/>
+<rectangle x1="221.485" y1="8.755" x2="222.125" y2="8.765" layer="94"/>
+<rectangle x1="222.345" y1="8.755" x2="222.875" y2="8.765" layer="94"/>
+<rectangle x1="216.175" y1="8.765" x2="216.755" y2="8.775" layer="94"/>
+<rectangle x1="216.975" y1="8.765" x2="217.625" y2="8.775" layer="94"/>
+<rectangle x1="218.045" y1="8.765" x2="218.765" y2="8.775" layer="94"/>
+<rectangle x1="219.195" y1="8.765" x2="219.915" y2="8.775" layer="94"/>
+<rectangle x1="220.345" y1="8.765" x2="221.065" y2="8.775" layer="94"/>
+<rectangle x1="221.485" y1="8.765" x2="222.125" y2="8.775" layer="94"/>
+<rectangle x1="222.345" y1="8.765" x2="222.875" y2="8.775" layer="94"/>
+<rectangle x1="216.175" y1="8.775" x2="216.755" y2="8.785" layer="94"/>
+<rectangle x1="216.975" y1="8.775" x2="217.625" y2="8.785" layer="94"/>
+<rectangle x1="218.045" y1="8.775" x2="218.765" y2="8.785" layer="94"/>
+<rectangle x1="219.195" y1="8.775" x2="219.915" y2="8.785" layer="94"/>
+<rectangle x1="220.345" y1="8.775" x2="221.065" y2="8.785" layer="94"/>
+<rectangle x1="221.485" y1="8.775" x2="222.125" y2="8.785" layer="94"/>
+<rectangle x1="222.345" y1="8.775" x2="222.875" y2="8.785" layer="94"/>
+<rectangle x1="216.175" y1="8.785" x2="216.755" y2="8.795" layer="94"/>
+<rectangle x1="216.975" y1="8.785" x2="217.625" y2="8.795" layer="94"/>
+<rectangle x1="218.045" y1="8.785" x2="218.765" y2="8.795" layer="94"/>
+<rectangle x1="219.195" y1="8.785" x2="219.915" y2="8.795" layer="94"/>
+<rectangle x1="220.345" y1="8.785" x2="221.065" y2="8.795" layer="94"/>
+<rectangle x1="221.485" y1="8.785" x2="222.125" y2="8.795" layer="94"/>
+<rectangle x1="222.345" y1="8.785" x2="222.875" y2="8.795" layer="94"/>
+<rectangle x1="216.165" y1="8.795" x2="216.755" y2="8.805" layer="94"/>
+<rectangle x1="216.975" y1="8.795" x2="217.625" y2="8.805" layer="94"/>
+<rectangle x1="218.045" y1="8.795" x2="218.765" y2="8.805" layer="94"/>
+<rectangle x1="219.195" y1="8.795" x2="219.915" y2="8.805" layer="94"/>
+<rectangle x1="220.345" y1="8.795" x2="221.065" y2="8.805" layer="94"/>
+<rectangle x1="221.485" y1="8.795" x2="222.125" y2="8.805" layer="94"/>
+<rectangle x1="222.345" y1="8.795" x2="222.865" y2="8.805" layer="94"/>
+<rectangle x1="216.165" y1="8.805" x2="216.755" y2="8.815" layer="94"/>
+<rectangle x1="216.975" y1="8.805" x2="217.625" y2="8.815" layer="94"/>
+<rectangle x1="218.045" y1="8.805" x2="218.765" y2="8.815" layer="94"/>
+<rectangle x1="219.195" y1="8.805" x2="219.915" y2="8.815" layer="94"/>
+<rectangle x1="220.345" y1="8.805" x2="221.065" y2="8.815" layer="94"/>
+<rectangle x1="221.485" y1="8.805" x2="222.125" y2="8.815" layer="94"/>
+<rectangle x1="222.345" y1="8.805" x2="222.865" y2="8.815" layer="94"/>
+<rectangle x1="216.165" y1="8.815" x2="216.755" y2="8.825" layer="94"/>
+<rectangle x1="216.975" y1="8.815" x2="217.625" y2="8.825" layer="94"/>
+<rectangle x1="218.045" y1="8.815" x2="218.765" y2="8.825" layer="94"/>
+<rectangle x1="219.195" y1="8.815" x2="219.915" y2="8.825" layer="94"/>
+<rectangle x1="220.345" y1="8.815" x2="221.055" y2="8.825" layer="94"/>
+<rectangle x1="221.485" y1="8.815" x2="222.125" y2="8.825" layer="94"/>
+<rectangle x1="222.345" y1="8.815" x2="222.865" y2="8.825" layer="94"/>
+<rectangle x1="216.155" y1="8.825" x2="216.755" y2="8.835" layer="94"/>
+<rectangle x1="216.975" y1="8.825" x2="217.625" y2="8.835" layer="94"/>
+<rectangle x1="218.045" y1="8.825" x2="218.765" y2="8.835" layer="94"/>
+<rectangle x1="219.195" y1="8.825" x2="219.915" y2="8.835" layer="94"/>
+<rectangle x1="220.345" y1="8.825" x2="221.055" y2="8.835" layer="94"/>
+<rectangle x1="221.485" y1="8.825" x2="222.125" y2="8.835" layer="94"/>
+<rectangle x1="222.345" y1="8.825" x2="222.855" y2="8.835" layer="94"/>
+<rectangle x1="216.155" y1="8.835" x2="216.755" y2="8.845" layer="94"/>
+<rectangle x1="216.975" y1="8.835" x2="217.625" y2="8.845" layer="94"/>
+<rectangle x1="218.045" y1="8.835" x2="218.765" y2="8.845" layer="94"/>
+<rectangle x1="219.195" y1="8.835" x2="219.915" y2="8.845" layer="94"/>
+<rectangle x1="220.345" y1="8.835" x2="221.055" y2="8.845" layer="94"/>
+<rectangle x1="221.485" y1="8.835" x2="222.125" y2="8.845" layer="94"/>
+<rectangle x1="222.345" y1="8.835" x2="222.855" y2="8.845" layer="94"/>
+<rectangle x1="216.155" y1="8.845" x2="216.755" y2="8.855" layer="94"/>
+<rectangle x1="216.985" y1="8.845" x2="217.625" y2="8.855" layer="94"/>
+<rectangle x1="218.045" y1="8.845" x2="218.765" y2="8.855" layer="94"/>
+<rectangle x1="219.195" y1="8.845" x2="219.915" y2="8.855" layer="94"/>
+<rectangle x1="220.345" y1="8.845" x2="221.055" y2="8.855" layer="94"/>
+<rectangle x1="221.485" y1="8.845" x2="222.125" y2="8.855" layer="94"/>
+<rectangle x1="222.345" y1="8.845" x2="222.855" y2="8.855" layer="94"/>
+<rectangle x1="216.145" y1="8.855" x2="216.765" y2="8.865" layer="94"/>
+<rectangle x1="216.985" y1="8.855" x2="217.625" y2="8.865" layer="94"/>
+<rectangle x1="218.045" y1="8.855" x2="218.765" y2="8.865" layer="94"/>
+<rectangle x1="219.195" y1="8.855" x2="219.915" y2="8.865" layer="94"/>
+<rectangle x1="220.345" y1="8.855" x2="221.055" y2="8.865" layer="94"/>
+<rectangle x1="221.485" y1="8.855" x2="222.125" y2="8.865" layer="94"/>
+<rectangle x1="222.345" y1="8.855" x2="222.855" y2="8.865" layer="94"/>
+<rectangle x1="216.145" y1="8.865" x2="216.765" y2="8.875" layer="94"/>
+<rectangle x1="216.985" y1="8.865" x2="217.625" y2="8.875" layer="94"/>
+<rectangle x1="218.045" y1="8.865" x2="218.765" y2="8.875" layer="94"/>
+<rectangle x1="219.195" y1="8.865" x2="219.905" y2="8.875" layer="94"/>
+<rectangle x1="220.345" y1="8.865" x2="221.055" y2="8.875" layer="94"/>
+<rectangle x1="221.485" y1="8.865" x2="222.125" y2="8.875" layer="94"/>
+<rectangle x1="222.345" y1="8.865" x2="222.845" y2="8.875" layer="94"/>
+<rectangle x1="216.145" y1="8.875" x2="216.765" y2="8.885" layer="94"/>
+<rectangle x1="216.985" y1="8.875" x2="217.625" y2="8.885" layer="94"/>
+<rectangle x1="218.045" y1="8.875" x2="218.765" y2="8.885" layer="94"/>
+<rectangle x1="219.195" y1="8.875" x2="219.905" y2="8.885" layer="94"/>
+<rectangle x1="220.345" y1="8.875" x2="221.055" y2="8.885" layer="94"/>
+<rectangle x1="221.485" y1="8.875" x2="222.125" y2="8.885" layer="94"/>
+<rectangle x1="222.345" y1="8.875" x2="222.845" y2="8.885" layer="94"/>
+<rectangle x1="216.145" y1="8.885" x2="216.765" y2="8.895" layer="94"/>
+<rectangle x1="216.985" y1="8.885" x2="217.625" y2="8.895" layer="94"/>
+<rectangle x1="218.045" y1="8.885" x2="218.765" y2="8.895" layer="94"/>
+<rectangle x1="219.205" y1="8.885" x2="219.905" y2="8.895" layer="94"/>
+<rectangle x1="220.345" y1="8.885" x2="221.055" y2="8.895" layer="94"/>
+<rectangle x1="221.485" y1="8.885" x2="222.125" y2="8.895" layer="94"/>
+<rectangle x1="222.345" y1="8.885" x2="222.845" y2="8.895" layer="94"/>
+<rectangle x1="216.135" y1="8.895" x2="216.405" y2="8.905" layer="94"/>
+<rectangle x1="216.415" y1="8.895" x2="216.765" y2="8.905" layer="94"/>
+<rectangle x1="216.985" y1="8.895" x2="217.625" y2="8.905" layer="94"/>
+<rectangle x1="218.045" y1="8.895" x2="218.765" y2="8.905" layer="94"/>
+<rectangle x1="219.205" y1="8.895" x2="219.905" y2="8.905" layer="94"/>
+<rectangle x1="220.345" y1="8.895" x2="221.055" y2="8.905" layer="94"/>
+<rectangle x1="221.485" y1="8.895" x2="222.125" y2="8.905" layer="94"/>
+<rectangle x1="222.345" y1="8.895" x2="222.835" y2="8.905" layer="94"/>
+<rectangle x1="216.135" y1="8.905" x2="216.385" y2="8.915" layer="94"/>
+<rectangle x1="216.425" y1="8.905" x2="216.765" y2="8.915" layer="94"/>
+<rectangle x1="216.985" y1="8.905" x2="217.625" y2="8.915" layer="94"/>
+<rectangle x1="218.045" y1="8.905" x2="218.765" y2="8.915" layer="94"/>
+<rectangle x1="219.205" y1="8.905" x2="219.905" y2="8.915" layer="94"/>
+<rectangle x1="220.355" y1="8.905" x2="221.055" y2="8.915" layer="94"/>
+<rectangle x1="221.485" y1="8.905" x2="222.115" y2="8.915" layer="94"/>
+<rectangle x1="222.345" y1="8.905" x2="222.835" y2="8.915" layer="94"/>
+<rectangle x1="216.135" y1="8.915" x2="216.365" y2="8.925" layer="94"/>
+<rectangle x1="216.445" y1="8.915" x2="216.765" y2="8.925" layer="94"/>
+<rectangle x1="216.985" y1="8.915" x2="217.625" y2="8.925" layer="94"/>
+<rectangle x1="218.045" y1="8.915" x2="218.765" y2="8.925" layer="94"/>
+<rectangle x1="219.205" y1="8.915" x2="219.905" y2="8.925" layer="94"/>
+<rectangle x1="220.355" y1="8.915" x2="221.055" y2="8.925" layer="94"/>
+<rectangle x1="221.485" y1="8.915" x2="222.115" y2="8.925" layer="94"/>
+<rectangle x1="222.335" y1="8.915" x2="222.835" y2="8.925" layer="94"/>
+<rectangle x1="216.125" y1="8.925" x2="216.355" y2="8.935" layer="94"/>
+<rectangle x1="216.465" y1="8.925" x2="216.765" y2="8.935" layer="94"/>
+<rectangle x1="216.985" y1="8.925" x2="217.625" y2="8.935" layer="94"/>
+<rectangle x1="218.045" y1="8.925" x2="218.765" y2="8.935" layer="94"/>
+<rectangle x1="219.205" y1="8.925" x2="219.905" y2="8.935" layer="94"/>
+<rectangle x1="220.355" y1="8.925" x2="221.045" y2="8.935" layer="94"/>
+<rectangle x1="221.485" y1="8.925" x2="222.115" y2="8.935" layer="94"/>
+<rectangle x1="222.335" y1="8.925" x2="222.815" y2="8.935" layer="94"/>
+<rectangle x1="216.125" y1="8.935" x2="216.335" y2="8.945" layer="94"/>
+<rectangle x1="216.485" y1="8.935" x2="216.765" y2="8.945" layer="94"/>
+<rectangle x1="216.985" y1="8.935" x2="217.625" y2="8.945" layer="94"/>
+<rectangle x1="218.045" y1="8.935" x2="218.765" y2="8.945" layer="94"/>
+<rectangle x1="219.205" y1="8.935" x2="219.905" y2="8.945" layer="94"/>
+<rectangle x1="220.355" y1="8.935" x2="221.045" y2="8.945" layer="94"/>
+<rectangle x1="221.475" y1="8.935" x2="222.115" y2="8.945" layer="94"/>
+<rectangle x1="222.335" y1="8.935" x2="222.795" y2="8.945" layer="94"/>
+<rectangle x1="216.125" y1="8.945" x2="216.325" y2="8.955" layer="94"/>
+<rectangle x1="216.505" y1="8.945" x2="216.765" y2="8.955" layer="94"/>
+<rectangle x1="216.985" y1="8.945" x2="217.625" y2="8.955" layer="94"/>
+<rectangle x1="218.045" y1="8.945" x2="218.765" y2="8.955" layer="94"/>
+<rectangle x1="219.205" y1="8.945" x2="219.895" y2="8.955" layer="94"/>
+<rectangle x1="220.355" y1="8.945" x2="221.045" y2="8.955" layer="94"/>
+<rectangle x1="221.475" y1="8.945" x2="222.115" y2="8.955" layer="94"/>
+<rectangle x1="222.335" y1="8.945" x2="222.765" y2="8.955" layer="94"/>
+<rectangle x1="216.125" y1="8.955" x2="216.305" y2="8.965" layer="94"/>
+<rectangle x1="216.515" y1="8.955" x2="216.765" y2="8.965" layer="94"/>
+<rectangle x1="216.985" y1="8.955" x2="217.625" y2="8.965" layer="94"/>
+<rectangle x1="218.045" y1="8.955" x2="218.765" y2="8.965" layer="94"/>
+<rectangle x1="219.215" y1="8.955" x2="219.895" y2="8.965" layer="94"/>
+<rectangle x1="220.355" y1="8.955" x2="221.045" y2="8.965" layer="94"/>
+<rectangle x1="221.475" y1="8.955" x2="222.115" y2="8.965" layer="94"/>
+<rectangle x1="222.335" y1="8.955" x2="222.745" y2="8.965" layer="94"/>
+<rectangle x1="216.115" y1="8.965" x2="216.285" y2="8.975" layer="94"/>
+<rectangle x1="216.535" y1="8.965" x2="216.765" y2="8.975" layer="94"/>
+<rectangle x1="216.995" y1="8.965" x2="217.625" y2="8.975" layer="94"/>
+<rectangle x1="218.045" y1="8.965" x2="218.765" y2="8.975" layer="94"/>
+<rectangle x1="219.215" y1="8.965" x2="219.895" y2="8.975" layer="94"/>
+<rectangle x1="220.365" y1="8.965" x2="221.045" y2="8.975" layer="94"/>
+<rectangle x1="221.475" y1="8.965" x2="222.115" y2="8.975" layer="94"/>
+<rectangle x1="222.335" y1="8.965" x2="222.715" y2="8.975" layer="94"/>
+<rectangle x1="216.115" y1="8.975" x2="216.275" y2="8.985" layer="94"/>
+<rectangle x1="216.555" y1="8.975" x2="216.775" y2="8.985" layer="94"/>
+<rectangle x1="216.995" y1="8.975" x2="217.625" y2="8.985" layer="94"/>
+<rectangle x1="218.045" y1="8.975" x2="218.765" y2="8.985" layer="94"/>
+<rectangle x1="219.215" y1="8.975" x2="219.895" y2="8.985" layer="94"/>
+<rectangle x1="220.365" y1="8.975" x2="221.045" y2="8.985" layer="94"/>
+<rectangle x1="221.475" y1="8.975" x2="222.115" y2="8.985" layer="94"/>
+<rectangle x1="222.335" y1="8.975" x2="222.685" y2="8.985" layer="94"/>
+<rectangle x1="216.115" y1="8.985" x2="216.255" y2="8.995" layer="94"/>
+<rectangle x1="216.575" y1="8.985" x2="216.775" y2="8.995" layer="94"/>
+<rectangle x1="216.995" y1="8.985" x2="217.625" y2="8.995" layer="94"/>
+<rectangle x1="218.045" y1="8.985" x2="218.765" y2="8.995" layer="94"/>
+<rectangle x1="219.215" y1="8.985" x2="219.895" y2="8.995" layer="94"/>
+<rectangle x1="220.365" y1="8.985" x2="221.035" y2="8.995" layer="94"/>
+<rectangle x1="221.475" y1="8.985" x2="222.115" y2="8.995" layer="94"/>
+<rectangle x1="222.335" y1="8.985" x2="222.665" y2="8.995" layer="94"/>
+<rectangle x1="216.105" y1="8.995" x2="216.235" y2="9.005" layer="94"/>
+<rectangle x1="216.585" y1="8.995" x2="216.775" y2="9.005" layer="94"/>
+<rectangle x1="216.995" y1="8.995" x2="217.625" y2="9.005" layer="94"/>
+<rectangle x1="218.045" y1="8.995" x2="218.765" y2="9.005" layer="94"/>
+<rectangle x1="219.225" y1="8.995" x2="219.885" y2="9.005" layer="94"/>
+<rectangle x1="220.365" y1="8.995" x2="221.035" y2="9.005" layer="94"/>
+<rectangle x1="221.475" y1="8.995" x2="222.115" y2="9.005" layer="94"/>
+<rectangle x1="222.335" y1="8.995" x2="222.635" y2="9.005" layer="94"/>
+<rectangle x1="216.105" y1="9.005" x2="216.225" y2="9.015" layer="94"/>
+<rectangle x1="216.585" y1="9.005" x2="216.775" y2="9.015" layer="94"/>
+<rectangle x1="216.995" y1="9.005" x2="217.625" y2="9.015" layer="94"/>
+<rectangle x1="218.045" y1="9.005" x2="218.765" y2="9.015" layer="94"/>
+<rectangle x1="219.225" y1="9.005" x2="219.885" y2="9.015" layer="94"/>
+<rectangle x1="220.375" y1="9.005" x2="221.035" y2="9.015" layer="94"/>
+<rectangle x1="221.475" y1="9.005" x2="222.105" y2="9.015" layer="94"/>
+<rectangle x1="222.335" y1="9.005" x2="222.615" y2="9.015" layer="94"/>
+<rectangle x1="216.105" y1="9.015" x2="216.205" y2="9.025" layer="94"/>
+<rectangle x1="216.585" y1="9.015" x2="216.775" y2="9.025" layer="94"/>
+<rectangle x1="216.995" y1="9.015" x2="217.625" y2="9.025" layer="94"/>
+<rectangle x1="218.045" y1="9.015" x2="218.765" y2="9.025" layer="94"/>
+<rectangle x1="219.225" y1="9.015" x2="219.885" y2="9.025" layer="94"/>
+<rectangle x1="220.375" y1="9.015" x2="221.025" y2="9.025" layer="94"/>
+<rectangle x1="221.475" y1="9.015" x2="222.105" y2="9.025" layer="94"/>
+<rectangle x1="222.325" y1="9.015" x2="222.585" y2="9.025" layer="94"/>
+<rectangle x1="216.095" y1="9.025" x2="216.185" y2="9.035" layer="94"/>
+<rectangle x1="216.585" y1="9.025" x2="216.775" y2="9.035" layer="94"/>
+<rectangle x1="216.995" y1="9.025" x2="217.625" y2="9.035" layer="94"/>
+<rectangle x1="218.045" y1="9.025" x2="218.765" y2="9.035" layer="94"/>
+<rectangle x1="219.235" y1="9.025" x2="219.875" y2="9.035" layer="94"/>
+<rectangle x1="220.375" y1="9.025" x2="221.025" y2="9.035" layer="94"/>
+<rectangle x1="221.465" y1="9.025" x2="222.105" y2="9.035" layer="94"/>
+<rectangle x1="222.325" y1="9.025" x2="222.555" y2="9.035" layer="94"/>
+<rectangle x1="216.095" y1="9.035" x2="216.175" y2="9.045" layer="94"/>
+<rectangle x1="216.585" y1="9.035" x2="216.775" y2="9.045" layer="94"/>
+<rectangle x1="216.995" y1="9.035" x2="217.625" y2="9.045" layer="94"/>
+<rectangle x1="218.045" y1="9.035" x2="218.765" y2="9.045" layer="94"/>
+<rectangle x1="219.235" y1="9.035" x2="219.875" y2="9.045" layer="94"/>
+<rectangle x1="220.385" y1="9.035" x2="221.025" y2="9.045" layer="94"/>
+<rectangle x1="221.465" y1="9.035" x2="222.105" y2="9.045" layer="94"/>
+<rectangle x1="222.325" y1="9.035" x2="222.535" y2="9.045" layer="94"/>
+<rectangle x1="216.095" y1="9.045" x2="216.155" y2="9.055" layer="94"/>
+<rectangle x1="216.585" y1="9.045" x2="216.775" y2="9.055" layer="94"/>
+<rectangle x1="217.005" y1="9.045" x2="217.625" y2="9.055" layer="94"/>
+<rectangle x1="218.045" y1="9.045" x2="218.765" y2="9.055" layer="94"/>
+<rectangle x1="219.235" y1="9.045" x2="219.875" y2="9.055" layer="94"/>
+<rectangle x1="220.385" y1="9.045" x2="221.015" y2="9.055" layer="94"/>
+<rectangle x1="221.465" y1="9.045" x2="222.105" y2="9.055" layer="94"/>
+<rectangle x1="222.325" y1="9.045" x2="222.515" y2="9.055" layer="94"/>
+<rectangle x1="216.095" y1="9.055" x2="216.145" y2="9.065" layer="94"/>
+<rectangle x1="216.585" y1="9.055" x2="216.785" y2="9.065" layer="94"/>
+<rectangle x1="217.005" y1="9.055" x2="217.625" y2="9.065" layer="94"/>
+<rectangle x1="218.045" y1="9.055" x2="218.765" y2="9.065" layer="94"/>
+<rectangle x1="219.245" y1="9.055" x2="219.865" y2="9.065" layer="94"/>
+<rectangle x1="220.385" y1="9.055" x2="221.015" y2="9.065" layer="94"/>
+<rectangle x1="221.465" y1="9.055" x2="222.105" y2="9.065" layer="94"/>
+<rectangle x1="222.325" y1="9.055" x2="222.515" y2="9.065" layer="94"/>
+<rectangle x1="216.085" y1="9.065" x2="216.125" y2="9.075" layer="94"/>
+<rectangle x1="216.595" y1="9.065" x2="216.785" y2="9.075" layer="94"/>
+<rectangle x1="217.005" y1="9.065" x2="217.625" y2="9.075" layer="94"/>
+<rectangle x1="218.045" y1="9.065" x2="218.765" y2="9.075" layer="94"/>
+<rectangle x1="219.245" y1="9.065" x2="219.865" y2="9.075" layer="94"/>
+<rectangle x1="220.395" y1="9.065" x2="221.015" y2="9.075" layer="94"/>
+<rectangle x1="221.465" y1="9.065" x2="222.105" y2="9.075" layer="94"/>
+<rectangle x1="222.325" y1="9.065" x2="222.515" y2="9.075" layer="94"/>
+<rectangle x1="216.085" y1="9.075" x2="216.105" y2="9.085" layer="94"/>
+<rectangle x1="216.595" y1="9.075" x2="216.785" y2="9.085" layer="94"/>
+<rectangle x1="217.005" y1="9.075" x2="217.625" y2="9.085" layer="94"/>
+<rectangle x1="218.045" y1="9.075" x2="218.765" y2="9.085" layer="94"/>
+<rectangle x1="219.255" y1="9.075" x2="219.855" y2="9.085" layer="94"/>
+<rectangle x1="220.395" y1="9.075" x2="221.005" y2="9.085" layer="94"/>
+<rectangle x1="221.465" y1="9.075" x2="222.095" y2="9.085" layer="94"/>
+<rectangle x1="222.325" y1="9.075" x2="222.505" y2="9.085" layer="94"/>
+<rectangle x1="216.085" y1="9.085" x2="216.095" y2="9.095" layer="94"/>
+<rectangle x1="216.595" y1="9.085" x2="216.785" y2="9.095" layer="94"/>
+<rectangle x1="217.005" y1="9.085" x2="217.625" y2="9.095" layer="94"/>
+<rectangle x1="218.045" y1="9.085" x2="218.765" y2="9.095" layer="94"/>
+<rectangle x1="219.255" y1="9.085" x2="219.855" y2="9.095" layer="94"/>
+<rectangle x1="220.405" y1="9.085" x2="220.995" y2="9.095" layer="94"/>
+<rectangle x1="221.455" y1="9.085" x2="222.095" y2="9.095" layer="94"/>
+<rectangle x1="222.325" y1="9.085" x2="222.505" y2="9.095" layer="94"/>
+<rectangle x1="216.595" y1="9.095" x2="216.785" y2="9.105" layer="94"/>
+<rectangle x1="217.005" y1="9.095" x2="217.625" y2="9.105" layer="94"/>
+<rectangle x1="218.045" y1="9.095" x2="218.765" y2="9.105" layer="94"/>
+<rectangle x1="219.265" y1="9.095" x2="219.845" y2="9.105" layer="94"/>
+<rectangle x1="220.415" y1="9.095" x2="220.995" y2="9.105" layer="94"/>
+<rectangle x1="221.455" y1="9.095" x2="222.095" y2="9.105" layer="94"/>
+<rectangle x1="222.315" y1="9.095" x2="222.505" y2="9.105" layer="94"/>
+<rectangle x1="216.595" y1="9.105" x2="216.785" y2="9.115" layer="94"/>
+<rectangle x1="217.005" y1="9.105" x2="217.625" y2="9.115" layer="94"/>
+<rectangle x1="218.045" y1="9.105" x2="218.765" y2="9.115" layer="94"/>
+<rectangle x1="219.265" y1="9.105" x2="219.845" y2="9.115" layer="94"/>
+<rectangle x1="220.415" y1="9.105" x2="220.985" y2="9.115" layer="94"/>
+<rectangle x1="221.455" y1="9.105" x2="222.095" y2="9.115" layer="94"/>
+<rectangle x1="222.315" y1="9.105" x2="222.505" y2="9.115" layer="94"/>
+<rectangle x1="216.585" y1="9.115" x2="216.785" y2="9.125" layer="94"/>
+<rectangle x1="217.015" y1="9.115" x2="217.625" y2="9.125" layer="94"/>
+<rectangle x1="218.045" y1="9.115" x2="218.765" y2="9.125" layer="94"/>
+<rectangle x1="219.275" y1="9.115" x2="219.835" y2="9.125" layer="94"/>
+<rectangle x1="220.425" y1="9.115" x2="220.985" y2="9.125" layer="94"/>
+<rectangle x1="221.455" y1="9.115" x2="222.095" y2="9.125" layer="94"/>
+<rectangle x1="222.315" y1="9.115" x2="222.505" y2="9.125" layer="94"/>
+<rectangle x1="216.565" y1="9.125" x2="216.785" y2="9.135" layer="94"/>
+<rectangle x1="217.015" y1="9.125" x2="217.625" y2="9.135" layer="94"/>
+<rectangle x1="218.045" y1="9.125" x2="218.765" y2="9.135" layer="94"/>
+<rectangle x1="219.285" y1="9.125" x2="219.825" y2="9.135" layer="94"/>
+<rectangle x1="220.435" y1="9.125" x2="220.975" y2="9.135" layer="94"/>
+<rectangle x1="221.445" y1="9.125" x2="222.095" y2="9.135" layer="94"/>
+<rectangle x1="222.315" y1="9.125" x2="222.505" y2="9.135" layer="94"/>
+<rectangle x1="216.555" y1="9.135" x2="216.795" y2="9.145" layer="94"/>
+<rectangle x1="217.015" y1="9.135" x2="217.625" y2="9.145" layer="94"/>
+<rectangle x1="218.045" y1="9.135" x2="218.765" y2="9.145" layer="94"/>
+<rectangle x1="219.285" y1="9.135" x2="219.825" y2="9.145" layer="94"/>
+<rectangle x1="220.435" y1="9.135" x2="220.965" y2="9.145" layer="94"/>
+<rectangle x1="221.445" y1="9.135" x2="222.085" y2="9.145" layer="94"/>
+<rectangle x1="222.315" y1="9.135" x2="222.505" y2="9.145" layer="94"/>
+<rectangle x1="216.545" y1="9.145" x2="216.795" y2="9.155" layer="94"/>
+<rectangle x1="217.015" y1="9.145" x2="217.625" y2="9.155" layer="94"/>
+<rectangle x1="218.045" y1="9.145" x2="218.765" y2="9.155" layer="94"/>
+<rectangle x1="219.295" y1="9.145" x2="219.815" y2="9.155" layer="94"/>
+<rectangle x1="220.445" y1="9.145" x2="220.955" y2="9.155" layer="94"/>
+<rectangle x1="221.445" y1="9.145" x2="222.085" y2="9.155" layer="94"/>
+<rectangle x1="222.315" y1="9.145" x2="222.505" y2="9.155" layer="94"/>
+<rectangle x1="216.525" y1="9.155" x2="216.795" y2="9.165" layer="94"/>
+<rectangle x1="217.015" y1="9.155" x2="217.625" y2="9.165" layer="94"/>
+<rectangle x1="218.045" y1="9.155" x2="218.765" y2="9.165" layer="94"/>
+<rectangle x1="219.305" y1="9.155" x2="219.805" y2="9.165" layer="94"/>
+<rectangle x1="220.455" y1="9.155" x2="220.945" y2="9.165" layer="94"/>
+<rectangle x1="221.435" y1="9.155" x2="222.085" y2="9.165" layer="94"/>
+<rectangle x1="222.305" y1="9.155" x2="222.515" y2="9.165" layer="94"/>
+<rectangle x1="216.515" y1="9.165" x2="216.795" y2="9.175" layer="94"/>
+<rectangle x1="217.025" y1="9.165" x2="217.625" y2="9.175" layer="94"/>
+<rectangle x1="218.045" y1="9.165" x2="218.765" y2="9.175" layer="94"/>
+<rectangle x1="219.315" y1="9.165" x2="219.785" y2="9.175" layer="94"/>
+<rectangle x1="220.465" y1="9.165" x2="220.935" y2="9.175" layer="94"/>
+<rectangle x1="221.435" y1="9.165" x2="222.085" y2="9.175" layer="94"/>
+<rectangle x1="222.305" y1="9.165" x2="222.525" y2="9.175" layer="94"/>
+<rectangle x1="216.505" y1="9.175" x2="216.795" y2="9.185" layer="94"/>
+<rectangle x1="217.025" y1="9.175" x2="217.625" y2="9.185" layer="94"/>
+<rectangle x1="218.045" y1="9.175" x2="218.765" y2="9.185" layer="94"/>
+<rectangle x1="219.325" y1="9.175" x2="219.775" y2="9.185" layer="94"/>
+<rectangle x1="220.475" y1="9.175" x2="220.925" y2="9.185" layer="94"/>
+<rectangle x1="221.435" y1="9.175" x2="222.085" y2="9.185" layer="94"/>
+<rectangle x1="222.305" y1="9.175" x2="222.545" y2="9.185" layer="94"/>
+<rectangle x1="222.985" y1="9.175" x2="223.005" y2="9.185" layer="94"/>
+<rectangle x1="216.485" y1="9.185" x2="216.805" y2="9.195" layer="94"/>
+<rectangle x1="217.025" y1="9.185" x2="217.625" y2="9.195" layer="94"/>
+<rectangle x1="218.045" y1="9.185" x2="218.765" y2="9.195" layer="94"/>
+<rectangle x1="219.345" y1="9.185" x2="219.765" y2="9.195" layer="94"/>
+<rectangle x1="220.495" y1="9.185" x2="220.915" y2="9.195" layer="94"/>
+<rectangle x1="221.425" y1="9.185" x2="222.085" y2="9.195" layer="94"/>
+<rectangle x1="222.305" y1="9.185" x2="222.555" y2="9.195" layer="94"/>
+<rectangle x1="222.945" y1="9.185" x2="223.005" y2="9.195" layer="94"/>
+<rectangle x1="216.475" y1="9.195" x2="216.805" y2="9.205" layer="94"/>
+<rectangle x1="217.025" y1="9.195" x2="217.625" y2="9.205" layer="94"/>
+<rectangle x1="218.045" y1="9.195" x2="218.765" y2="9.205" layer="94"/>
+<rectangle x1="219.355" y1="9.195" x2="219.745" y2="9.205" layer="94"/>
+<rectangle x1="220.515" y1="9.195" x2="220.895" y2="9.205" layer="94"/>
+<rectangle x1="221.425" y1="9.195" x2="222.075" y2="9.205" layer="94"/>
+<rectangle x1="222.305" y1="9.195" x2="222.565" y2="9.205" layer="94"/>
+<rectangle x1="222.915" y1="9.195" x2="222.995" y2="9.205" layer="94"/>
+<rectangle x1="216.465" y1="9.205" x2="216.805" y2="9.215" layer="94"/>
+<rectangle x1="217.025" y1="9.205" x2="217.625" y2="9.215" layer="94"/>
+<rectangle x1="218.045" y1="9.205" x2="218.765" y2="9.215" layer="94"/>
+<rectangle x1="219.375" y1="9.205" x2="219.735" y2="9.215" layer="94"/>
+<rectangle x1="220.525" y1="9.205" x2="220.875" y2="9.215" layer="94"/>
+<rectangle x1="221.415" y1="9.205" x2="222.075" y2="9.215" layer="94"/>
+<rectangle x1="222.305" y1="9.205" x2="222.575" y2="9.215" layer="94"/>
+<rectangle x1="222.885" y1="9.205" x2="222.995" y2="9.215" layer="94"/>
+<rectangle x1="216.445" y1="9.215" x2="216.805" y2="9.225" layer="94"/>
+<rectangle x1="217.035" y1="9.215" x2="217.625" y2="9.225" layer="94"/>
+<rectangle x1="218.045" y1="9.215" x2="218.765" y2="9.225" layer="94"/>
+<rectangle x1="219.395" y1="9.215" x2="219.715" y2="9.225" layer="94"/>
+<rectangle x1="220.545" y1="9.215" x2="220.855" y2="9.225" layer="94"/>
+<rectangle x1="221.415" y1="9.215" x2="222.075" y2="9.225" layer="94"/>
+<rectangle x1="222.295" y1="9.215" x2="222.585" y2="9.225" layer="94"/>
+<rectangle x1="222.845" y1="9.215" x2="222.985" y2="9.225" layer="94"/>
+<rectangle x1="216.435" y1="9.225" x2="216.805" y2="9.235" layer="94"/>
+<rectangle x1="217.035" y1="9.225" x2="217.625" y2="9.235" layer="94"/>
+<rectangle x1="218.045" y1="9.225" x2="218.765" y2="9.235" layer="94"/>
+<rectangle x1="219.425" y1="9.225" x2="219.685" y2="9.235" layer="94"/>
+<rectangle x1="220.585" y1="9.225" x2="220.825" y2="9.235" layer="94"/>
+<rectangle x1="221.405" y1="9.225" x2="222.075" y2="9.235" layer="94"/>
+<rectangle x1="222.295" y1="9.225" x2="222.595" y2="9.235" layer="94"/>
+<rectangle x1="222.815" y1="9.225" x2="222.975" y2="9.235" layer="94"/>
+<rectangle x1="216.425" y1="9.235" x2="216.805" y2="9.245" layer="94"/>
+<rectangle x1="217.035" y1="9.235" x2="217.625" y2="9.245" layer="94"/>
+<rectangle x1="218.045" y1="9.235" x2="218.765" y2="9.245" layer="94"/>
+<rectangle x1="219.455" y1="9.235" x2="219.645" y2="9.245" layer="94"/>
+<rectangle x1="220.615" y1="9.235" x2="220.785" y2="9.245" layer="94"/>
+<rectangle x1="221.405" y1="9.235" x2="222.065" y2="9.245" layer="94"/>
+<rectangle x1="222.295" y1="9.235" x2="222.605" y2="9.245" layer="94"/>
+<rectangle x1="222.785" y1="9.235" x2="222.975" y2="9.245" layer="94"/>
+<rectangle x1="216.405" y1="9.245" x2="216.815" y2="9.255" layer="94"/>
+<rectangle x1="217.035" y1="9.245" x2="217.625" y2="9.255" layer="94"/>
+<rectangle x1="218.045" y1="9.245" x2="218.765" y2="9.255" layer="94"/>
+<rectangle x1="221.405" y1="9.245" x2="222.065" y2="9.255" layer="94"/>
+<rectangle x1="222.295" y1="9.245" x2="222.615" y2="9.255" layer="94"/>
+<rectangle x1="222.745" y1="9.245" x2="222.965" y2="9.255" layer="94"/>
+<rectangle x1="216.395" y1="9.255" x2="216.815" y2="9.265" layer="94"/>
+<rectangle x1="217.035" y1="9.255" x2="217.625" y2="9.265" layer="94"/>
+<rectangle x1="218.045" y1="9.255" x2="218.765" y2="9.265" layer="94"/>
+<rectangle x1="221.395" y1="9.255" x2="222.065" y2="9.265" layer="94"/>
+<rectangle x1="222.295" y1="9.255" x2="222.625" y2="9.265" layer="94"/>
+<rectangle x1="222.715" y1="9.255" x2="222.965" y2="9.265" layer="94"/>
+<rectangle x1="216.385" y1="9.265" x2="216.815" y2="9.275" layer="94"/>
+<rectangle x1="217.045" y1="9.265" x2="217.625" y2="9.275" layer="94"/>
+<rectangle x1="218.045" y1="9.265" x2="218.765" y2="9.275" layer="94"/>
+<rectangle x1="221.385" y1="9.265" x2="222.065" y2="9.275" layer="94"/>
+<rectangle x1="222.285" y1="9.265" x2="222.635" y2="9.275" layer="94"/>
+<rectangle x1="222.685" y1="9.265" x2="222.955" y2="9.275" layer="94"/>
+<rectangle x1="216.365" y1="9.275" x2="216.815" y2="9.285" layer="94"/>
+<rectangle x1="217.045" y1="9.275" x2="217.625" y2="9.285" layer="94"/>
+<rectangle x1="218.045" y1="9.275" x2="218.765" y2="9.285" layer="94"/>
+<rectangle x1="221.385" y1="9.275" x2="222.065" y2="9.285" layer="94"/>
+<rectangle x1="222.285" y1="9.275" x2="222.945" y2="9.285" layer="94"/>
+<rectangle x1="216.355" y1="9.285" x2="216.825" y2="9.295" layer="94"/>
+<rectangle x1="217.045" y1="9.285" x2="217.625" y2="9.295" layer="94"/>
+<rectangle x1="218.045" y1="9.285" x2="218.765" y2="9.295" layer="94"/>
+<rectangle x1="221.375" y1="9.285" x2="222.055" y2="9.295" layer="94"/>
+<rectangle x1="222.285" y1="9.285" x2="222.945" y2="9.295" layer="94"/>
+<rectangle x1="216.345" y1="9.295" x2="216.825" y2="9.305" layer="94"/>
+<rectangle x1="217.045" y1="9.295" x2="217.625" y2="9.305" layer="94"/>
+<rectangle x1="218.045" y1="9.295" x2="218.765" y2="9.305" layer="94"/>
+<rectangle x1="221.365" y1="9.295" x2="222.055" y2="9.305" layer="94"/>
+<rectangle x1="222.285" y1="9.295" x2="222.935" y2="9.305" layer="94"/>
+<rectangle x1="216.325" y1="9.305" x2="216.825" y2="9.315" layer="94"/>
+<rectangle x1="217.055" y1="9.305" x2="217.625" y2="9.315" layer="94"/>
+<rectangle x1="218.045" y1="9.305" x2="218.765" y2="9.315" layer="94"/>
+<rectangle x1="221.365" y1="9.305" x2="222.055" y2="9.315" layer="94"/>
+<rectangle x1="222.275" y1="9.305" x2="222.925" y2="9.315" layer="94"/>
+<rectangle x1="216.325" y1="9.315" x2="216.825" y2="9.325" layer="94"/>
+<rectangle x1="217.055" y1="9.315" x2="217.625" y2="9.325" layer="94"/>
+<rectangle x1="218.045" y1="9.315" x2="218.765" y2="9.325" layer="94"/>
+<rectangle x1="221.355" y1="9.315" x2="222.055" y2="9.325" layer="94"/>
+<rectangle x1="222.275" y1="9.315" x2="222.925" y2="9.325" layer="94"/>
+<rectangle x1="216.325" y1="9.325" x2="216.825" y2="9.335" layer="94"/>
+<rectangle x1="217.055" y1="9.325" x2="217.625" y2="9.335" layer="94"/>
+<rectangle x1="218.045" y1="9.325" x2="218.765" y2="9.335" layer="94"/>
+<rectangle x1="221.345" y1="9.325" x2="222.045" y2="9.335" layer="94"/>
+<rectangle x1="222.275" y1="9.325" x2="222.915" y2="9.335" layer="94"/>
+<rectangle x1="216.325" y1="9.335" x2="216.835" y2="9.345" layer="94"/>
+<rectangle x1="217.055" y1="9.335" x2="217.625" y2="9.345" layer="94"/>
+<rectangle x1="218.045" y1="9.335" x2="218.765" y2="9.345" layer="94"/>
+<rectangle x1="221.335" y1="9.335" x2="222.045" y2="9.345" layer="94"/>
+<rectangle x1="222.275" y1="9.335" x2="222.915" y2="9.345" layer="94"/>
+<rectangle x1="216.325" y1="9.345" x2="216.835" y2="9.355" layer="94"/>
+<rectangle x1="217.065" y1="9.345" x2="217.625" y2="9.355" layer="94"/>
+<rectangle x1="218.045" y1="9.345" x2="218.765" y2="9.355" layer="94"/>
+<rectangle x1="221.335" y1="9.345" x2="222.045" y2="9.355" layer="94"/>
+<rectangle x1="222.275" y1="9.345" x2="222.905" y2="9.355" layer="94"/>
+<rectangle x1="216.325" y1="9.355" x2="216.835" y2="9.365" layer="94"/>
+<rectangle x1="217.065" y1="9.355" x2="217.625" y2="9.365" layer="94"/>
+<rectangle x1="218.045" y1="9.355" x2="218.765" y2="9.365" layer="94"/>
+<rectangle x1="221.325" y1="9.355" x2="222.045" y2="9.365" layer="94"/>
+<rectangle x1="222.265" y1="9.355" x2="222.895" y2="9.365" layer="94"/>
+<rectangle x1="216.325" y1="9.365" x2="216.835" y2="9.375" layer="94"/>
+<rectangle x1="217.065" y1="9.365" x2="217.625" y2="9.375" layer="94"/>
+<rectangle x1="218.045" y1="9.365" x2="218.765" y2="9.375" layer="94"/>
+<rectangle x1="221.315" y1="9.365" x2="222.035" y2="9.375" layer="94"/>
+<rectangle x1="222.265" y1="9.365" x2="222.895" y2="9.375" layer="94"/>
+<rectangle x1="216.325" y1="9.375" x2="216.845" y2="9.385" layer="94"/>
+<rectangle x1="217.065" y1="9.375" x2="217.625" y2="9.385" layer="94"/>
+<rectangle x1="218.045" y1="9.375" x2="218.765" y2="9.385" layer="94"/>
+<rectangle x1="221.305" y1="9.375" x2="222.035" y2="9.385" layer="94"/>
+<rectangle x1="222.265" y1="9.375" x2="222.885" y2="9.385" layer="94"/>
+<rectangle x1="216.325" y1="9.385" x2="216.845" y2="9.395" layer="94"/>
+<rectangle x1="217.075" y1="9.385" x2="217.625" y2="9.395" layer="94"/>
+<rectangle x1="218.045" y1="9.385" x2="218.765" y2="9.395" layer="94"/>
+<rectangle x1="221.295" y1="9.385" x2="222.035" y2="9.395" layer="94"/>
+<rectangle x1="222.265" y1="9.385" x2="222.885" y2="9.395" layer="94"/>
+<rectangle x1="216.325" y1="9.395" x2="216.845" y2="9.405" layer="94"/>
+<rectangle x1="217.075" y1="9.395" x2="217.625" y2="9.405" layer="94"/>
+<rectangle x1="218.045" y1="9.395" x2="218.765" y2="9.405" layer="94"/>
+<rectangle x1="221.285" y1="9.395" x2="222.025" y2="9.405" layer="94"/>
+<rectangle x1="222.255" y1="9.395" x2="222.875" y2="9.405" layer="94"/>
+<rectangle x1="216.325" y1="9.405" x2="216.845" y2="9.415" layer="94"/>
+<rectangle x1="217.075" y1="9.405" x2="217.625" y2="9.415" layer="94"/>
+<rectangle x1="218.045" y1="9.405" x2="218.765" y2="9.415" layer="94"/>
+<rectangle x1="221.275" y1="9.405" x2="222.025" y2="9.415" layer="94"/>
+<rectangle x1="222.255" y1="9.405" x2="222.865" y2="9.415" layer="94"/>
+<rectangle x1="216.325" y1="9.415" x2="216.855" y2="9.425" layer="94"/>
+<rectangle x1="217.085" y1="9.415" x2="217.625" y2="9.425" layer="94"/>
+<rectangle x1="218.045" y1="9.415" x2="218.765" y2="9.425" layer="94"/>
+<rectangle x1="220.125" y1="9.415" x2="220.135" y2="9.425" layer="94"/>
+<rectangle x1="221.265" y1="9.415" x2="222.025" y2="9.425" layer="94"/>
+<rectangle x1="222.255" y1="9.415" x2="222.865" y2="9.425" layer="94"/>
+<rectangle x1="216.325" y1="9.425" x2="216.855" y2="9.435" layer="94"/>
+<rectangle x1="217.085" y1="9.425" x2="217.625" y2="9.435" layer="94"/>
+<rectangle x1="218.045" y1="9.425" x2="218.765" y2="9.435" layer="94"/>
+<rectangle x1="220.115" y1="9.425" x2="220.145" y2="9.435" layer="94"/>
+<rectangle x1="221.255" y1="9.425" x2="222.025" y2="9.435" layer="94"/>
+<rectangle x1="222.245" y1="9.425" x2="222.855" y2="9.435" layer="94"/>
+<rectangle x1="216.325" y1="9.435" x2="216.855" y2="9.445" layer="94"/>
+<rectangle x1="217.085" y1="9.435" x2="217.625" y2="9.445" layer="94"/>
+<rectangle x1="218.045" y1="9.435" x2="218.765" y2="9.445" layer="94"/>
+<rectangle x1="220.105" y1="9.435" x2="220.155" y2="9.445" layer="94"/>
+<rectangle x1="221.245" y1="9.435" x2="222.015" y2="9.445" layer="94"/>
+<rectangle x1="222.245" y1="9.435" x2="222.855" y2="9.445" layer="94"/>
+<rectangle x1="216.325" y1="9.445" x2="216.865" y2="9.455" layer="94"/>
+<rectangle x1="217.085" y1="9.445" x2="217.625" y2="9.455" layer="94"/>
+<rectangle x1="218.045" y1="9.445" x2="218.765" y2="9.455" layer="94"/>
+<rectangle x1="220.085" y1="9.445" x2="220.165" y2="9.455" layer="94"/>
+<rectangle x1="221.235" y1="9.445" x2="222.015" y2="9.455" layer="94"/>
+<rectangle x1="222.245" y1="9.445" x2="222.845" y2="9.455" layer="94"/>
+<rectangle x1="216.325" y1="9.455" x2="216.865" y2="9.465" layer="94"/>
+<rectangle x1="217.095" y1="9.455" x2="217.625" y2="9.465" layer="94"/>
+<rectangle x1="218.045" y1="9.455" x2="218.765" y2="9.465" layer="94"/>
+<rectangle x1="220.075" y1="9.455" x2="220.185" y2="9.465" layer="94"/>
+<rectangle x1="221.215" y1="9.455" x2="222.015" y2="9.465" layer="94"/>
+<rectangle x1="222.245" y1="9.455" x2="222.835" y2="9.465" layer="94"/>
+<rectangle x1="216.315" y1="9.465" x2="216.865" y2="9.475" layer="94"/>
+<rectangle x1="217.095" y1="9.465" x2="217.625" y2="9.475" layer="94"/>
+<rectangle x1="218.045" y1="9.465" x2="218.765" y2="9.475" layer="94"/>
+<rectangle x1="220.065" y1="9.465" x2="220.195" y2="9.475" layer="94"/>
+<rectangle x1="221.205" y1="9.465" x2="222.005" y2="9.475" layer="94"/>
+<rectangle x1="222.235" y1="9.465" x2="222.835" y2="9.475" layer="94"/>
+<rectangle x1="216.315" y1="9.475" x2="216.865" y2="9.485" layer="94"/>
+<rectangle x1="217.095" y1="9.475" x2="217.625" y2="9.485" layer="94"/>
+<rectangle x1="218.045" y1="9.475" x2="218.765" y2="9.485" layer="94"/>
+<rectangle x1="220.045" y1="9.475" x2="220.205" y2="9.485" layer="94"/>
+<rectangle x1="221.195" y1="9.475" x2="222.005" y2="9.485" layer="94"/>
+<rectangle x1="222.235" y1="9.475" x2="222.825" y2="9.485" layer="94"/>
+<rectangle x1="216.315" y1="9.485" x2="216.875" y2="9.495" layer="94"/>
+<rectangle x1="217.105" y1="9.485" x2="217.625" y2="9.495" layer="94"/>
+<rectangle x1="218.045" y1="9.485" x2="218.765" y2="9.495" layer="94"/>
+<rectangle x1="220.035" y1="9.485" x2="220.225" y2="9.495" layer="94"/>
+<rectangle x1="221.175" y1="9.485" x2="222.005" y2="9.495" layer="94"/>
+<rectangle x1="222.235" y1="9.485" x2="222.825" y2="9.495" layer="94"/>
+<rectangle x1="216.315" y1="9.495" x2="216.875" y2="9.505" layer="94"/>
+<rectangle x1="217.105" y1="9.495" x2="217.625" y2="9.505" layer="94"/>
+<rectangle x1="218.045" y1="9.495" x2="218.765" y2="9.505" layer="94"/>
+<rectangle x1="220.025" y1="9.495" x2="220.235" y2="9.505" layer="94"/>
+<rectangle x1="221.165" y1="9.495" x2="221.995" y2="9.505" layer="94"/>
+<rectangle x1="222.225" y1="9.495" x2="222.815" y2="9.505" layer="94"/>
+<rectangle x1="216.315" y1="9.505" x2="216.875" y2="9.515" layer="94"/>
+<rectangle x1="217.105" y1="9.505" x2="217.625" y2="9.515" layer="94"/>
+<rectangle x1="218.045" y1="9.505" x2="218.765" y2="9.515" layer="94"/>
+<rectangle x1="220.005" y1="9.505" x2="220.255" y2="9.515" layer="94"/>
+<rectangle x1="221.145" y1="9.505" x2="221.995" y2="9.515" layer="94"/>
+<rectangle x1="222.225" y1="9.505" x2="222.805" y2="9.515" layer="94"/>
+<rectangle x1="216.315" y1="9.515" x2="216.885" y2="9.525" layer="94"/>
+<rectangle x1="217.115" y1="9.515" x2="217.625" y2="9.525" layer="94"/>
+<rectangle x1="218.045" y1="9.515" x2="218.765" y2="9.525" layer="94"/>
+<rectangle x1="219.985" y1="9.515" x2="220.265" y2="9.525" layer="94"/>
+<rectangle x1="221.135" y1="9.515" x2="221.995" y2="9.525" layer="94"/>
+<rectangle x1="222.225" y1="9.515" x2="222.805" y2="9.525" layer="94"/>
+<rectangle x1="216.315" y1="9.525" x2="216.885" y2="9.535" layer="94"/>
+<rectangle x1="217.115" y1="9.525" x2="217.625" y2="9.535" layer="94"/>
+<rectangle x1="218.045" y1="9.525" x2="218.765" y2="9.535" layer="94"/>
+<rectangle x1="219.975" y1="9.525" x2="220.285" y2="9.535" layer="94"/>
+<rectangle x1="221.115" y1="9.525" x2="221.985" y2="9.535" layer="94"/>
+<rectangle x1="222.225" y1="9.525" x2="222.795" y2="9.535" layer="94"/>
+<rectangle x1="216.315" y1="9.535" x2="216.885" y2="9.545" layer="94"/>
+<rectangle x1="217.115" y1="9.535" x2="217.625" y2="9.545" layer="94"/>
+<rectangle x1="218.045" y1="9.535" x2="218.765" y2="9.545" layer="94"/>
+<rectangle x1="219.955" y1="9.535" x2="220.305" y2="9.545" layer="94"/>
+<rectangle x1="221.095" y1="9.535" x2="221.985" y2="9.545" layer="94"/>
+<rectangle x1="222.215" y1="9.535" x2="222.795" y2="9.545" layer="94"/>
+<rectangle x1="216.315" y1="9.545" x2="216.895" y2="9.555" layer="94"/>
+<rectangle x1="217.125" y1="9.545" x2="217.625" y2="9.555" layer="94"/>
+<rectangle x1="218.045" y1="9.545" x2="218.765" y2="9.555" layer="94"/>
+<rectangle x1="219.935" y1="9.545" x2="220.325" y2="9.555" layer="94"/>
+<rectangle x1="221.075" y1="9.545" x2="221.985" y2="9.555" layer="94"/>
+<rectangle x1="222.215" y1="9.545" x2="222.785" y2="9.555" layer="94"/>
+<rectangle x1="216.315" y1="9.555" x2="216.895" y2="9.565" layer="94"/>
+<rectangle x1="217.125" y1="9.555" x2="217.625" y2="9.565" layer="94"/>
+<rectangle x1="218.045" y1="9.555" x2="218.765" y2="9.565" layer="94"/>
+<rectangle x1="219.905" y1="9.555" x2="220.355" y2="9.565" layer="94"/>
+<rectangle x1="221.055" y1="9.555" x2="221.975" y2="9.565" layer="94"/>
+<rectangle x1="222.215" y1="9.555" x2="222.775" y2="9.565" layer="94"/>
+<rectangle x1="216.315" y1="9.565" x2="216.895" y2="9.575" layer="94"/>
+<rectangle x1="217.125" y1="9.565" x2="217.625" y2="9.575" layer="94"/>
+<rectangle x1="218.045" y1="9.565" x2="218.765" y2="9.575" layer="94"/>
+<rectangle x1="219.195" y1="9.565" x2="219.225" y2="9.575" layer="94"/>
+<rectangle x1="219.885" y1="9.565" x2="220.375" y2="9.575" layer="94"/>
+<rectangle x1="221.025" y1="9.565" x2="221.975" y2="9.575" layer="94"/>
+<rectangle x1="222.205" y1="9.565" x2="222.775" y2="9.575" layer="94"/>
+<rectangle x1="216.315" y1="9.575" x2="216.905" y2="9.585" layer="94"/>
+<rectangle x1="217.135" y1="9.575" x2="217.625" y2="9.585" layer="94"/>
+<rectangle x1="218.045" y1="9.575" x2="218.765" y2="9.585" layer="94"/>
+<rectangle x1="219.195" y1="9.575" x2="219.245" y2="9.585" layer="94"/>
+<rectangle x1="219.855" y1="9.575" x2="220.405" y2="9.585" layer="94"/>
+<rectangle x1="221.005" y1="9.575" x2="221.975" y2="9.585" layer="94"/>
+<rectangle x1="222.205" y1="9.575" x2="222.765" y2="9.585" layer="94"/>
+<rectangle x1="216.315" y1="9.585" x2="216.905" y2="9.595" layer="94"/>
+<rectangle x1="217.135" y1="9.585" x2="217.625" y2="9.595" layer="94"/>
+<rectangle x1="218.045" y1="9.585" x2="218.765" y2="9.595" layer="94"/>
+<rectangle x1="219.195" y1="9.585" x2="219.285" y2="9.595" layer="94"/>
+<rectangle x1="219.825" y1="9.585" x2="220.435" y2="9.595" layer="94"/>
+<rectangle x1="220.965" y1="9.585" x2="221.965" y2="9.595" layer="94"/>
+<rectangle x1="222.205" y1="9.585" x2="222.765" y2="9.595" layer="94"/>
+<rectangle x1="216.315" y1="9.595" x2="216.905" y2="9.605" layer="94"/>
+<rectangle x1="217.145" y1="9.595" x2="217.625" y2="9.605" layer="94"/>
+<rectangle x1="218.045" y1="9.595" x2="218.765" y2="9.605" layer="94"/>
+<rectangle x1="219.195" y1="9.595" x2="219.315" y2="9.605" layer="94"/>
+<rectangle x1="219.795" y1="9.595" x2="220.475" y2="9.605" layer="94"/>
+<rectangle x1="220.935" y1="9.595" x2="221.965" y2="9.605" layer="94"/>
+<rectangle x1="222.195" y1="9.595" x2="222.755" y2="9.605" layer="94"/>
+<rectangle x1="216.315" y1="9.605" x2="216.915" y2="9.615" layer="94"/>
+<rectangle x1="217.145" y1="9.605" x2="217.625" y2="9.615" layer="94"/>
+<rectangle x1="218.045" y1="9.605" x2="218.765" y2="9.615" layer="94"/>
+<rectangle x1="219.195" y1="9.605" x2="219.365" y2="9.615" layer="94"/>
+<rectangle x1="219.745" y1="9.605" x2="220.525" y2="9.615" layer="94"/>
+<rectangle x1="220.885" y1="9.605" x2="221.955" y2="9.615" layer="94"/>
+<rectangle x1="222.195" y1="9.605" x2="222.745" y2="9.615" layer="94"/>
+<rectangle x1="216.315" y1="9.615" x2="216.915" y2="9.625" layer="94"/>
+<rectangle x1="217.145" y1="9.615" x2="217.625" y2="9.625" layer="94"/>
+<rectangle x1="218.045" y1="9.615" x2="218.765" y2="9.625" layer="94"/>
+<rectangle x1="219.195" y1="9.615" x2="219.425" y2="9.625" layer="94"/>
+<rectangle x1="219.685" y1="9.615" x2="220.595" y2="9.625" layer="94"/>
+<rectangle x1="220.805" y1="9.615" x2="221.955" y2="9.625" layer="94"/>
+<rectangle x1="222.195" y1="9.615" x2="222.745" y2="9.625" layer="94"/>
+<rectangle x1="216.315" y1="9.625" x2="216.915" y2="9.635" layer="94"/>
+<rectangle x1="217.155" y1="9.625" x2="221.955" y2="9.635" layer="94"/>
+<rectangle x1="222.185" y1="9.625" x2="222.735" y2="9.635" layer="94"/>
+<rectangle x1="216.315" y1="9.635" x2="216.925" y2="9.645" layer="94"/>
+<rectangle x1="217.155" y1="9.635" x2="221.945" y2="9.645" layer="94"/>
+<rectangle x1="222.185" y1="9.635" x2="222.725" y2="9.645" layer="94"/>
+<rectangle x1="216.315" y1="9.645" x2="216.925" y2="9.655" layer="94"/>
+<rectangle x1="217.165" y1="9.645" x2="221.945" y2="9.655" layer="94"/>
+<rectangle x1="222.185" y1="9.645" x2="222.725" y2="9.655" layer="94"/>
+<rectangle x1="216.315" y1="9.655" x2="216.925" y2="9.665" layer="94"/>
+<rectangle x1="217.165" y1="9.655" x2="221.945" y2="9.665" layer="94"/>
+<rectangle x1="222.175" y1="9.655" x2="222.715" y2="9.665" layer="94"/>
+<rectangle x1="216.315" y1="9.665" x2="216.935" y2="9.675" layer="94"/>
+<rectangle x1="217.165" y1="9.665" x2="221.935" y2="9.675" layer="94"/>
+<rectangle x1="222.175" y1="9.665" x2="222.715" y2="9.675" layer="94"/>
+<rectangle x1="216.315" y1="9.675" x2="216.935" y2="9.685" layer="94"/>
+<rectangle x1="217.175" y1="9.675" x2="221.935" y2="9.685" layer="94"/>
+<rectangle x1="222.165" y1="9.675" x2="222.705" y2="9.685" layer="94"/>
+<rectangle x1="216.315" y1="9.685" x2="216.935" y2="9.695" layer="94"/>
+<rectangle x1="217.175" y1="9.685" x2="221.925" y2="9.695" layer="94"/>
+<rectangle x1="222.165" y1="9.685" x2="222.695" y2="9.695" layer="94"/>
+<rectangle x1="216.315" y1="9.695" x2="216.945" y2="9.705" layer="94"/>
+<rectangle x1="217.185" y1="9.695" x2="221.925" y2="9.705" layer="94"/>
+<rectangle x1="222.165" y1="9.695" x2="222.695" y2="9.705" layer="94"/>
+<rectangle x1="216.315" y1="9.705" x2="216.945" y2="9.715" layer="94"/>
+<rectangle x1="217.185" y1="9.705" x2="221.915" y2="9.715" layer="94"/>
+<rectangle x1="222.155" y1="9.705" x2="222.685" y2="9.715" layer="94"/>
+<rectangle x1="216.315" y1="9.715" x2="216.575" y2="9.725" layer="94"/>
+<rectangle x1="216.585" y1="9.715" x2="216.955" y2="9.725" layer="94"/>
+<rectangle x1="217.185" y1="9.715" x2="221.915" y2="9.725" layer="94"/>
+<rectangle x1="222.155" y1="9.715" x2="222.685" y2="9.725" layer="94"/>
+<rectangle x1="216.315" y1="9.725" x2="216.565" y2="9.735" layer="94"/>
+<rectangle x1="216.625" y1="9.725" x2="216.955" y2="9.735" layer="94"/>
+<rectangle x1="217.195" y1="9.725" x2="221.915" y2="9.735" layer="94"/>
+<rectangle x1="222.145" y1="9.725" x2="222.675" y2="9.735" layer="94"/>
+<rectangle x1="216.315" y1="9.735" x2="216.555" y2="9.745" layer="94"/>
+<rectangle x1="216.665" y1="9.735" x2="216.955" y2="9.745" layer="94"/>
+<rectangle x1="217.195" y1="9.735" x2="221.905" y2="9.745" layer="94"/>
+<rectangle x1="222.145" y1="9.735" x2="222.665" y2="9.745" layer="94"/>
+<rectangle x1="216.315" y1="9.745" x2="216.545" y2="9.755" layer="94"/>
+<rectangle x1="216.705" y1="9.745" x2="216.965" y2="9.755" layer="94"/>
+<rectangle x1="217.205" y1="9.745" x2="221.905" y2="9.755" layer="94"/>
+<rectangle x1="222.145" y1="9.745" x2="222.665" y2="9.755" layer="94"/>
+<rectangle x1="216.315" y1="9.755" x2="216.535" y2="9.765" layer="94"/>
+<rectangle x1="216.745" y1="9.755" x2="216.965" y2="9.765" layer="94"/>
+<rectangle x1="217.205" y1="9.755" x2="221.895" y2="9.765" layer="94"/>
+<rectangle x1="222.135" y1="9.755" x2="222.625" y2="9.765" layer="94"/>
+<rectangle x1="216.315" y1="9.765" x2="216.525" y2="9.775" layer="94"/>
+<rectangle x1="216.765" y1="9.765" x2="216.975" y2="9.775" layer="94"/>
+<rectangle x1="217.215" y1="9.765" x2="221.895" y2="9.775" layer="94"/>
+<rectangle x1="222.135" y1="9.765" x2="222.545" y2="9.775" layer="94"/>
+<rectangle x1="216.315" y1="9.775" x2="216.515" y2="9.785" layer="94"/>
+<rectangle x1="216.765" y1="9.775" x2="216.975" y2="9.785" layer="94"/>
+<rectangle x1="217.215" y1="9.775" x2="221.885" y2="9.785" layer="94"/>
+<rectangle x1="222.125" y1="9.775" x2="222.455" y2="9.785" layer="94"/>
+<rectangle x1="216.315" y1="9.785" x2="216.505" y2="9.795" layer="94"/>
+<rectangle x1="216.775" y1="9.785" x2="216.975" y2="9.795" layer="94"/>
+<rectangle x1="217.225" y1="9.785" x2="221.885" y2="9.795" layer="94"/>
+<rectangle x1="222.125" y1="9.785" x2="222.375" y2="9.795" layer="94"/>
+<rectangle x1="216.315" y1="9.795" x2="216.495" y2="9.805" layer="94"/>
+<rectangle x1="216.775" y1="9.795" x2="216.985" y2="9.805" layer="94"/>
+<rectangle x1="217.225" y1="9.795" x2="221.875" y2="9.805" layer="94"/>
+<rectangle x1="222.125" y1="9.795" x2="222.325" y2="9.805" layer="94"/>
+<rectangle x1="216.315" y1="9.805" x2="216.485" y2="9.815" layer="94"/>
+<rectangle x1="216.785" y1="9.805" x2="216.985" y2="9.815" layer="94"/>
+<rectangle x1="217.235" y1="9.805" x2="221.875" y2="9.815" layer="94"/>
+<rectangle x1="222.115" y1="9.805" x2="222.325" y2="9.815" layer="94"/>
+<rectangle x1="216.315" y1="9.815" x2="216.475" y2="9.825" layer="94"/>
+<rectangle x1="216.785" y1="9.815" x2="216.995" y2="9.825" layer="94"/>
+<rectangle x1="217.235" y1="9.815" x2="221.865" y2="9.825" layer="94"/>
+<rectangle x1="222.115" y1="9.815" x2="222.315" y2="9.825" layer="94"/>
+<rectangle x1="216.315" y1="9.825" x2="216.465" y2="9.835" layer="94"/>
+<rectangle x1="216.785" y1="9.825" x2="216.995" y2="9.835" layer="94"/>
+<rectangle x1="217.245" y1="9.825" x2="221.865" y2="9.835" layer="94"/>
+<rectangle x1="222.105" y1="9.825" x2="222.315" y2="9.835" layer="94"/>
+<rectangle x1="216.315" y1="9.835" x2="216.455" y2="9.845" layer="94"/>
+<rectangle x1="216.795" y1="9.835" x2="217.005" y2="9.845" layer="94"/>
+<rectangle x1="217.245" y1="9.835" x2="221.855" y2="9.845" layer="94"/>
+<rectangle x1="222.105" y1="9.835" x2="222.305" y2="9.845" layer="94"/>
+<rectangle x1="216.315" y1="9.845" x2="216.445" y2="9.855" layer="94"/>
+<rectangle x1="216.785" y1="9.845" x2="217.005" y2="9.855" layer="94"/>
+<rectangle x1="217.255" y1="9.845" x2="221.855" y2="9.855" layer="94"/>
+<rectangle x1="222.095" y1="9.845" x2="222.305" y2="9.855" layer="94"/>
+<rectangle x1="216.315" y1="9.855" x2="216.435" y2="9.865" layer="94"/>
+<rectangle x1="216.775" y1="9.855" x2="217.015" y2="9.865" layer="94"/>
+<rectangle x1="217.255" y1="9.855" x2="221.845" y2="9.865" layer="94"/>
+<rectangle x1="222.095" y1="9.855" x2="222.305" y2="9.865" layer="94"/>
+<rectangle x1="216.315" y1="9.865" x2="216.425" y2="9.875" layer="94"/>
+<rectangle x1="216.775" y1="9.865" x2="217.015" y2="9.875" layer="94"/>
+<rectangle x1="217.265" y1="9.865" x2="221.845" y2="9.875" layer="94"/>
+<rectangle x1="222.085" y1="9.865" x2="222.295" y2="9.875" layer="94"/>
+<rectangle x1="216.315" y1="9.875" x2="216.425" y2="9.885" layer="94"/>
+<rectangle x1="216.765" y1="9.875" x2="217.025" y2="9.885" layer="94"/>
+<rectangle x1="217.265" y1="9.875" x2="221.835" y2="9.885" layer="94"/>
+<rectangle x1="222.085" y1="9.875" x2="222.295" y2="9.885" layer="94"/>
+<rectangle x1="216.315" y1="9.885" x2="216.415" y2="9.895" layer="94"/>
+<rectangle x1="216.755" y1="9.885" x2="217.025" y2="9.895" layer="94"/>
+<rectangle x1="217.275" y1="9.885" x2="221.835" y2="9.895" layer="94"/>
+<rectangle x1="222.075" y1="9.885" x2="222.285" y2="9.895" layer="94"/>
+<rectangle x1="216.315" y1="9.895" x2="216.405" y2="9.905" layer="94"/>
+<rectangle x1="216.745" y1="9.895" x2="217.025" y2="9.905" layer="94"/>
+<rectangle x1="217.275" y1="9.895" x2="221.825" y2="9.905" layer="94"/>
+<rectangle x1="222.075" y1="9.895" x2="222.285" y2="9.905" layer="94"/>
+<rectangle x1="216.315" y1="9.905" x2="216.395" y2="9.915" layer="94"/>
+<rectangle x1="216.735" y1="9.905" x2="217.035" y2="9.915" layer="94"/>
+<rectangle x1="217.285" y1="9.905" x2="221.825" y2="9.915" layer="94"/>
+<rectangle x1="222.075" y1="9.905" x2="222.285" y2="9.915" layer="94"/>
+<rectangle x1="216.315" y1="9.915" x2="216.385" y2="9.925" layer="94"/>
+<rectangle x1="216.735" y1="9.915" x2="217.035" y2="9.925" layer="94"/>
+<rectangle x1="217.285" y1="9.915" x2="221.815" y2="9.925" layer="94"/>
+<rectangle x1="222.065" y1="9.915" x2="222.285" y2="9.925" layer="94"/>
+<rectangle x1="216.315" y1="9.925" x2="216.375" y2="9.935" layer="94"/>
+<rectangle x1="216.725" y1="9.925" x2="217.045" y2="9.935" layer="94"/>
+<rectangle x1="217.295" y1="9.925" x2="221.815" y2="9.935" layer="94"/>
+<rectangle x1="222.055" y1="9.925" x2="222.295" y2="9.935" layer="94"/>
+<rectangle x1="216.315" y1="9.935" x2="216.365" y2="9.945" layer="94"/>
+<rectangle x1="216.715" y1="9.935" x2="217.045" y2="9.945" layer="94"/>
+<rectangle x1="217.295" y1="9.935" x2="221.805" y2="9.945" layer="94"/>
+<rectangle x1="222.055" y1="9.935" x2="222.295" y2="9.945" layer="94"/>
+<rectangle x1="216.315" y1="9.945" x2="216.355" y2="9.955" layer="94"/>
+<rectangle x1="216.705" y1="9.945" x2="217.055" y2="9.955" layer="94"/>
+<rectangle x1="217.305" y1="9.945" x2="221.805" y2="9.955" layer="94"/>
+<rectangle x1="222.045" y1="9.945" x2="222.305" y2="9.955" layer="94"/>
+<rectangle x1="216.305" y1="9.955" x2="216.345" y2="9.965" layer="94"/>
+<rectangle x1="216.695" y1="9.955" x2="217.065" y2="9.965" layer="94"/>
+<rectangle x1="217.305" y1="9.955" x2="221.795" y2="9.965" layer="94"/>
+<rectangle x1="222.045" y1="9.955" x2="222.315" y2="9.965" layer="94"/>
+<rectangle x1="216.305" y1="9.965" x2="216.335" y2="9.975" layer="94"/>
+<rectangle x1="216.695" y1="9.965" x2="217.065" y2="9.975" layer="94"/>
+<rectangle x1="217.315" y1="9.965" x2="221.785" y2="9.975" layer="94"/>
+<rectangle x1="222.035" y1="9.965" x2="222.315" y2="9.975" layer="94"/>
+<rectangle x1="216.305" y1="9.975" x2="216.325" y2="9.985" layer="94"/>
+<rectangle x1="216.685" y1="9.975" x2="217.075" y2="9.985" layer="94"/>
+<rectangle x1="217.325" y1="9.975" x2="221.785" y2="9.985" layer="94"/>
+<rectangle x1="222.035" y1="9.975" x2="222.325" y2="9.985" layer="94"/>
+<rectangle x1="216.305" y1="9.985" x2="216.315" y2="9.995" layer="94"/>
+<rectangle x1="216.675" y1="9.985" x2="217.075" y2="9.995" layer="94"/>
+<rectangle x1="217.325" y1="9.985" x2="221.775" y2="9.995" layer="94"/>
+<rectangle x1="222.025" y1="9.985" x2="222.325" y2="9.995" layer="94"/>
+<rectangle x1="216.665" y1="9.995" x2="217.085" y2="10.005" layer="94"/>
+<rectangle x1="217.335" y1="9.995" x2="221.775" y2="10.005" layer="94"/>
+<rectangle x1="222.025" y1="9.995" x2="222.335" y2="10.005" layer="94"/>
+<rectangle x1="216.655" y1="10.005" x2="217.085" y2="10.015" layer="94"/>
+<rectangle x1="217.335" y1="10.005" x2="221.765" y2="10.015" layer="94"/>
+<rectangle x1="222.015" y1="10.005" x2="222.345" y2="10.015" layer="94"/>
+<rectangle x1="216.655" y1="10.015" x2="217.095" y2="10.025" layer="94"/>
+<rectangle x1="217.345" y1="10.015" x2="221.765" y2="10.025" layer="94"/>
+<rectangle x1="222.015" y1="10.015" x2="222.345" y2="10.025" layer="94"/>
+<rectangle x1="216.645" y1="10.025" x2="217.095" y2="10.035" layer="94"/>
+<rectangle x1="217.355" y1="10.025" x2="221.755" y2="10.035" layer="94"/>
+<rectangle x1="222.005" y1="10.025" x2="222.355" y2="10.035" layer="94"/>
+<rectangle x1="216.635" y1="10.035" x2="217.105" y2="10.045" layer="94"/>
+<rectangle x1="217.355" y1="10.035" x2="221.745" y2="10.045" layer="94"/>
+<rectangle x1="222.005" y1="10.035" x2="222.355" y2="10.045" layer="94"/>
+<rectangle x1="216.625" y1="10.045" x2="217.105" y2="10.055" layer="94"/>
+<rectangle x1="217.365" y1="10.045" x2="221.745" y2="10.055" layer="94"/>
+<rectangle x1="221.995" y1="10.045" x2="222.365" y2="10.055" layer="94"/>
+<rectangle x1="216.615" y1="10.055" x2="217.115" y2="10.065" layer="94"/>
+<rectangle x1="217.365" y1="10.055" x2="221.735" y2="10.065" layer="94"/>
+<rectangle x1="221.995" y1="10.055" x2="222.375" y2="10.065" layer="94"/>
+<rectangle x1="216.615" y1="10.065" x2="217.115" y2="10.075" layer="94"/>
+<rectangle x1="217.375" y1="10.065" x2="221.725" y2="10.075" layer="94"/>
+<rectangle x1="221.985" y1="10.065" x2="222.375" y2="10.075" layer="94"/>
+<rectangle x1="222.625" y1="10.065" x2="222.755" y2="10.075" layer="94"/>
+<rectangle x1="216.605" y1="10.075" x2="217.125" y2="10.085" layer="94"/>
+<rectangle x1="217.385" y1="10.075" x2="221.725" y2="10.085" layer="94"/>
+<rectangle x1="221.975" y1="10.075" x2="222.755" y2="10.085" layer="94"/>
+<rectangle x1="216.595" y1="10.085" x2="217.135" y2="10.095" layer="94"/>
+<rectangle x1="217.385" y1="10.085" x2="221.715" y2="10.095" layer="94"/>
+<rectangle x1="221.975" y1="10.085" x2="222.735" y2="10.095" layer="94"/>
+<rectangle x1="216.585" y1="10.095" x2="217.135" y2="10.105" layer="94"/>
+<rectangle x1="217.395" y1="10.095" x2="221.705" y2="10.105" layer="94"/>
+<rectangle x1="221.965" y1="10.095" x2="222.725" y2="10.105" layer="94"/>
+<rectangle x1="216.585" y1="10.105" x2="217.145" y2="10.115" layer="94"/>
+<rectangle x1="217.405" y1="10.105" x2="221.705" y2="10.115" layer="94"/>
+<rectangle x1="221.965" y1="10.105" x2="222.715" y2="10.115" layer="94"/>
+<rectangle x1="216.585" y1="10.115" x2="217.145" y2="10.125" layer="94"/>
+<rectangle x1="217.405" y1="10.115" x2="221.695" y2="10.125" layer="94"/>
+<rectangle x1="221.955" y1="10.115" x2="222.705" y2="10.125" layer="94"/>
+<rectangle x1="216.595" y1="10.125" x2="217.155" y2="10.135" layer="94"/>
+<rectangle x1="217.415" y1="10.125" x2="221.695" y2="10.135" layer="94"/>
+<rectangle x1="221.955" y1="10.125" x2="222.695" y2="10.135" layer="94"/>
+<rectangle x1="216.595" y1="10.135" x2="217.155" y2="10.145" layer="94"/>
+<rectangle x1="217.425" y1="10.135" x2="221.685" y2="10.145" layer="94"/>
+<rectangle x1="221.945" y1="10.135" x2="222.685" y2="10.145" layer="94"/>
+<rectangle x1="216.595" y1="10.145" x2="217.165" y2="10.155" layer="94"/>
+<rectangle x1="217.425" y1="10.145" x2="221.675" y2="10.155" layer="94"/>
+<rectangle x1="221.935" y1="10.145" x2="222.675" y2="10.155" layer="94"/>
+<rectangle x1="216.595" y1="10.155" x2="217.175" y2="10.165" layer="94"/>
+<rectangle x1="217.435" y1="10.155" x2="221.665" y2="10.165" layer="94"/>
+<rectangle x1="221.935" y1="10.155" x2="222.665" y2="10.165" layer="94"/>
+<rectangle x1="216.605" y1="10.165" x2="217.175" y2="10.175" layer="94"/>
+<rectangle x1="217.445" y1="10.165" x2="221.665" y2="10.175" layer="94"/>
+<rectangle x1="221.925" y1="10.165" x2="222.655" y2="10.175" layer="94"/>
+<rectangle x1="216.605" y1="10.175" x2="217.185" y2="10.185" layer="94"/>
+<rectangle x1="217.445" y1="10.175" x2="221.655" y2="10.185" layer="94"/>
+<rectangle x1="221.915" y1="10.175" x2="222.645" y2="10.185" layer="94"/>
+<rectangle x1="216.605" y1="10.185" x2="217.195" y2="10.195" layer="94"/>
+<rectangle x1="217.455" y1="10.185" x2="221.645" y2="10.195" layer="94"/>
+<rectangle x1="221.915" y1="10.185" x2="222.635" y2="10.195" layer="94"/>
+<rectangle x1="216.605" y1="10.195" x2="217.195" y2="10.205" layer="94"/>
+<rectangle x1="217.465" y1="10.195" x2="221.645" y2="10.205" layer="94"/>
+<rectangle x1="221.905" y1="10.195" x2="222.625" y2="10.205" layer="94"/>
+<rectangle x1="216.615" y1="10.205" x2="217.205" y2="10.215" layer="94"/>
+<rectangle x1="217.475" y1="10.205" x2="221.635" y2="10.215" layer="94"/>
+<rectangle x1="221.905" y1="10.205" x2="222.615" y2="10.215" layer="94"/>
+<rectangle x1="216.615" y1="10.215" x2="217.215" y2="10.225" layer="94"/>
+<rectangle x1="217.475" y1="10.215" x2="221.625" y2="10.225" layer="94"/>
+<rectangle x1="221.895" y1="10.215" x2="222.605" y2="10.225" layer="94"/>
+<rectangle x1="216.615" y1="10.225" x2="217.215" y2="10.235" layer="94"/>
+<rectangle x1="217.485" y1="10.225" x2="221.615" y2="10.235" layer="94"/>
+<rectangle x1="221.885" y1="10.225" x2="222.595" y2="10.235" layer="94"/>
+<rectangle x1="216.615" y1="10.235" x2="217.225" y2="10.245" layer="94"/>
+<rectangle x1="217.495" y1="10.235" x2="221.615" y2="10.245" layer="94"/>
+<rectangle x1="221.885" y1="10.235" x2="222.585" y2="10.245" layer="94"/>
+<rectangle x1="216.615" y1="10.245" x2="217.225" y2="10.255" layer="94"/>
+<rectangle x1="217.505" y1="10.245" x2="221.605" y2="10.255" layer="94"/>
+<rectangle x1="221.875" y1="10.245" x2="222.575" y2="10.255" layer="94"/>
+<rectangle x1="216.625" y1="10.255" x2="217.235" y2="10.265" layer="94"/>
+<rectangle x1="217.505" y1="10.255" x2="221.595" y2="10.265" layer="94"/>
+<rectangle x1="221.865" y1="10.255" x2="222.565" y2="10.265" layer="94"/>
+<rectangle x1="216.625" y1="10.265" x2="217.245" y2="10.275" layer="94"/>
+<rectangle x1="217.515" y1="10.265" x2="221.585" y2="10.275" layer="94"/>
+<rectangle x1="221.865" y1="10.265" x2="222.545" y2="10.275" layer="94"/>
+<rectangle x1="216.625" y1="10.275" x2="217.255" y2="10.285" layer="94"/>
+<rectangle x1="217.525" y1="10.275" x2="221.585" y2="10.285" layer="94"/>
+<rectangle x1="221.855" y1="10.275" x2="222.535" y2="10.285" layer="94"/>
+<rectangle x1="216.625" y1="10.285" x2="217.255" y2="10.295" layer="94"/>
+<rectangle x1="217.535" y1="10.285" x2="221.575" y2="10.295" layer="94"/>
+<rectangle x1="221.845" y1="10.285" x2="222.525" y2="10.295" layer="94"/>
+<rectangle x1="216.635" y1="10.295" x2="217.265" y2="10.305" layer="94"/>
+<rectangle x1="217.535" y1="10.295" x2="221.565" y2="10.305" layer="94"/>
+<rectangle x1="221.835" y1="10.295" x2="222.515" y2="10.305" layer="94"/>
+<rectangle x1="216.635" y1="10.305" x2="217.275" y2="10.315" layer="94"/>
+<rectangle x1="217.545" y1="10.305" x2="221.555" y2="10.315" layer="94"/>
+<rectangle x1="221.835" y1="10.305" x2="222.505" y2="10.315" layer="94"/>
+<rectangle x1="216.635" y1="10.315" x2="217.275" y2="10.325" layer="94"/>
+<rectangle x1="217.555" y1="10.315" x2="221.545" y2="10.325" layer="94"/>
+<rectangle x1="221.825" y1="10.315" x2="222.495" y2="10.325" layer="94"/>
+<rectangle x1="216.635" y1="10.325" x2="217.285" y2="10.335" layer="94"/>
+<rectangle x1="217.565" y1="10.325" x2="221.545" y2="10.335" layer="94"/>
+<rectangle x1="221.815" y1="10.325" x2="222.485" y2="10.335" layer="94"/>
+<rectangle x1="216.645" y1="10.335" x2="217.295" y2="10.345" layer="94"/>
+<rectangle x1="217.575" y1="10.335" x2="221.535" y2="10.345" layer="94"/>
+<rectangle x1="221.815" y1="10.335" x2="222.475" y2="10.345" layer="94"/>
+<rectangle x1="216.645" y1="10.345" x2="217.305" y2="10.355" layer="94"/>
+<rectangle x1="217.585" y1="10.345" x2="221.525" y2="10.355" layer="94"/>
+<rectangle x1="221.805" y1="10.345" x2="222.465" y2="10.355" layer="94"/>
+<rectangle x1="216.645" y1="10.355" x2="217.305" y2="10.365" layer="94"/>
+<rectangle x1="217.585" y1="10.355" x2="221.515" y2="10.365" layer="94"/>
+<rectangle x1="221.795" y1="10.355" x2="222.455" y2="10.365" layer="94"/>
+<rectangle x1="216.645" y1="10.365" x2="217.315" y2="10.375" layer="94"/>
+<rectangle x1="217.595" y1="10.365" x2="221.505" y2="10.375" layer="94"/>
+<rectangle x1="221.785" y1="10.365" x2="222.445" y2="10.375" layer="94"/>
+<rectangle x1="216.655" y1="10.375" x2="217.325" y2="10.385" layer="94"/>
+<rectangle x1="217.605" y1="10.375" x2="221.495" y2="10.385" layer="94"/>
+<rectangle x1="221.785" y1="10.375" x2="222.435" y2="10.385" layer="94"/>
+<rectangle x1="216.655" y1="10.385" x2="217.335" y2="10.395" layer="94"/>
+<rectangle x1="217.615" y1="10.385" x2="221.485" y2="10.395" layer="94"/>
+<rectangle x1="221.775" y1="10.385" x2="222.425" y2="10.395" layer="94"/>
+<rectangle x1="216.655" y1="10.395" x2="217.335" y2="10.405" layer="94"/>
+<rectangle x1="217.625" y1="10.395" x2="221.485" y2="10.405" layer="94"/>
+<rectangle x1="221.765" y1="10.395" x2="222.415" y2="10.405" layer="94"/>
+<rectangle x1="216.655" y1="10.405" x2="217.345" y2="10.415" layer="94"/>
+<rectangle x1="217.635" y1="10.405" x2="221.475" y2="10.415" layer="94"/>
+<rectangle x1="221.755" y1="10.405" x2="222.405" y2="10.415" layer="94"/>
+<rectangle x1="216.665" y1="10.415" x2="217.355" y2="10.425" layer="94"/>
+<rectangle x1="217.645" y1="10.415" x2="221.465" y2="10.425" layer="94"/>
+<rectangle x1="221.755" y1="10.415" x2="222.395" y2="10.425" layer="94"/>
+<rectangle x1="216.665" y1="10.425" x2="217.095" y2="10.435" layer="94"/>
+<rectangle x1="217.115" y1="10.425" x2="217.365" y2="10.435" layer="94"/>
+<rectangle x1="217.655" y1="10.425" x2="221.455" y2="10.435" layer="94"/>
+<rectangle x1="221.745" y1="10.425" x2="222.385" y2="10.435" layer="94"/>
+<rectangle x1="216.665" y1="10.435" x2="216.925" y2="10.445" layer="94"/>
+<rectangle x1="217.125" y1="10.435" x2="217.375" y2="10.445" layer="94"/>
+<rectangle x1="217.655" y1="10.435" x2="221.445" y2="10.445" layer="94"/>
+<rectangle x1="221.735" y1="10.435" x2="222.375" y2="10.445" layer="94"/>
+<rectangle x1="216.665" y1="10.445" x2="216.915" y2="10.455" layer="94"/>
+<rectangle x1="217.135" y1="10.445" x2="217.375" y2="10.455" layer="94"/>
+<rectangle x1="217.665" y1="10.445" x2="221.435" y2="10.455" layer="94"/>
+<rectangle x1="221.725" y1="10.445" x2="222.355" y2="10.455" layer="94"/>
+<rectangle x1="216.665" y1="10.455" x2="216.915" y2="10.465" layer="94"/>
+<rectangle x1="217.145" y1="10.455" x2="217.385" y2="10.465" layer="94"/>
+<rectangle x1="217.675" y1="10.455" x2="221.425" y2="10.465" layer="94"/>
+<rectangle x1="221.715" y1="10.455" x2="222.345" y2="10.465" layer="94"/>
+<rectangle x1="216.675" y1="10.465" x2="216.905" y2="10.475" layer="94"/>
+<rectangle x1="217.155" y1="10.465" x2="217.395" y2="10.475" layer="94"/>
+<rectangle x1="217.685" y1="10.465" x2="221.415" y2="10.475" layer="94"/>
+<rectangle x1="221.715" y1="10.465" x2="222.335" y2="10.475" layer="94"/>
+<rectangle x1="216.675" y1="10.475" x2="216.905" y2="10.485" layer="94"/>
+<rectangle x1="217.155" y1="10.475" x2="217.405" y2="10.485" layer="94"/>
+<rectangle x1="217.695" y1="10.475" x2="221.405" y2="10.485" layer="94"/>
+<rectangle x1="221.705" y1="10.475" x2="222.325" y2="10.485" layer="94"/>
+<rectangle x1="216.675" y1="10.485" x2="216.895" y2="10.495" layer="94"/>
+<rectangle x1="217.165" y1="10.485" x2="217.415" y2="10.495" layer="94"/>
+<rectangle x1="217.705" y1="10.485" x2="221.395" y2="10.495" layer="94"/>
+<rectangle x1="221.695" y1="10.485" x2="221.945" y2="10.495" layer="94"/>
+<rectangle x1="221.955" y1="10.485" x2="222.315" y2="10.495" layer="94"/>
+<rectangle x1="216.675" y1="10.495" x2="216.895" y2="10.505" layer="94"/>
+<rectangle x1="217.175" y1="10.495" x2="217.415" y2="10.505" layer="94"/>
+<rectangle x1="217.715" y1="10.495" x2="221.385" y2="10.505" layer="94"/>
+<rectangle x1="221.685" y1="10.495" x2="221.935" y2="10.505" layer="94"/>
+<rectangle x1="222.015" y1="10.495" x2="222.305" y2="10.505" layer="94"/>
+<rectangle x1="216.685" y1="10.505" x2="216.885" y2="10.515" layer="94"/>
+<rectangle x1="217.175" y1="10.505" x2="217.425" y2="10.515" layer="94"/>
+<rectangle x1="217.725" y1="10.505" x2="221.375" y2="10.515" layer="94"/>
+<rectangle x1="221.675" y1="10.505" x2="221.925" y2="10.515" layer="94"/>
+<rectangle x1="222.085" y1="10.505" x2="222.295" y2="10.515" layer="94"/>
+<rectangle x1="216.685" y1="10.515" x2="216.885" y2="10.525" layer="94"/>
+<rectangle x1="217.185" y1="10.515" x2="217.435" y2="10.525" layer="94"/>
+<rectangle x1="217.735" y1="10.515" x2="221.365" y2="10.525" layer="94"/>
+<rectangle x1="221.665" y1="10.515" x2="221.915" y2="10.525" layer="94"/>
+<rectangle x1="222.145" y1="10.515" x2="222.285" y2="10.525" layer="94"/>
+<rectangle x1="216.685" y1="10.525" x2="216.875" y2="10.535" layer="94"/>
+<rectangle x1="217.195" y1="10.525" x2="217.445" y2="10.535" layer="94"/>
+<rectangle x1="217.745" y1="10.525" x2="221.355" y2="10.535" layer="94"/>
+<rectangle x1="221.655" y1="10.525" x2="221.905" y2="10.535" layer="94"/>
+<rectangle x1="222.215" y1="10.525" x2="222.275" y2="10.535" layer="94"/>
+<rectangle x1="216.685" y1="10.535" x2="216.865" y2="10.545" layer="94"/>
+<rectangle x1="217.195" y1="10.535" x2="217.455" y2="10.545" layer="94"/>
+<rectangle x1="217.755" y1="10.535" x2="221.345" y2="10.545" layer="94"/>
+<rectangle x1="221.655" y1="10.535" x2="221.905" y2="10.545" layer="94"/>
+<rectangle x1="216.695" y1="10.545" x2="216.865" y2="10.555" layer="94"/>
+<rectangle x1="217.185" y1="10.545" x2="217.465" y2="10.555" layer="94"/>
+<rectangle x1="217.765" y1="10.545" x2="221.335" y2="10.555" layer="94"/>
+<rectangle x1="221.645" y1="10.545" x2="221.895" y2="10.555" layer="94"/>
+<rectangle x1="216.695" y1="10.555" x2="216.855" y2="10.565" layer="94"/>
+<rectangle x1="217.185" y1="10.555" x2="217.475" y2="10.565" layer="94"/>
+<rectangle x1="217.775" y1="10.555" x2="221.325" y2="10.565" layer="94"/>
+<rectangle x1="221.635" y1="10.555" x2="221.885" y2="10.565" layer="94"/>
+<rectangle x1="216.695" y1="10.565" x2="216.855" y2="10.575" layer="94"/>
+<rectangle x1="217.185" y1="10.565" x2="217.485" y2="10.575" layer="94"/>
+<rectangle x1="217.785" y1="10.565" x2="221.315" y2="10.575" layer="94"/>
+<rectangle x1="221.625" y1="10.565" x2="221.875" y2="10.575" layer="94"/>
+<rectangle x1="216.695" y1="10.575" x2="216.845" y2="10.585" layer="94"/>
+<rectangle x1="217.175" y1="10.575" x2="217.485" y2="10.585" layer="94"/>
+<rectangle x1="217.795" y1="10.575" x2="221.305" y2="10.585" layer="94"/>
+<rectangle x1="221.615" y1="10.575" x2="221.875" y2="10.585" layer="94"/>
+<rectangle x1="216.705" y1="10.585" x2="216.845" y2="10.595" layer="94"/>
+<rectangle x1="217.175" y1="10.585" x2="217.495" y2="10.595" layer="94"/>
+<rectangle x1="217.815" y1="10.585" x2="221.295" y2="10.595" layer="94"/>
+<rectangle x1="221.605" y1="10.585" x2="221.885" y2="10.595" layer="94"/>
+<rectangle x1="216.705" y1="10.595" x2="216.835" y2="10.605" layer="94"/>
+<rectangle x1="217.165" y1="10.595" x2="217.505" y2="10.605" layer="94"/>
+<rectangle x1="217.825" y1="10.595" x2="221.285" y2="10.605" layer="94"/>
+<rectangle x1="221.595" y1="10.595" x2="221.885" y2="10.605" layer="94"/>
+<rectangle x1="216.705" y1="10.605" x2="216.835" y2="10.615" layer="94"/>
+<rectangle x1="217.165" y1="10.605" x2="217.515" y2="10.615" layer="94"/>
+<rectangle x1="217.835" y1="10.605" x2="221.275" y2="10.615" layer="94"/>
+<rectangle x1="221.585" y1="10.605" x2="221.885" y2="10.615" layer="94"/>
+<rectangle x1="216.705" y1="10.615" x2="216.825" y2="10.625" layer="94"/>
+<rectangle x1="217.155" y1="10.615" x2="217.525" y2="10.625" layer="94"/>
+<rectangle x1="217.845" y1="10.615" x2="221.265" y2="10.625" layer="94"/>
+<rectangle x1="221.575" y1="10.615" x2="221.895" y2="10.625" layer="94"/>
+<rectangle x1="216.715" y1="10.625" x2="216.825" y2="10.635" layer="94"/>
+<rectangle x1="217.155" y1="10.625" x2="217.535" y2="10.635" layer="94"/>
+<rectangle x1="217.855" y1="10.625" x2="221.245" y2="10.635" layer="94"/>
+<rectangle x1="221.565" y1="10.625" x2="221.895" y2="10.635" layer="94"/>
+<rectangle x1="216.715" y1="10.635" x2="216.815" y2="10.645" layer="94"/>
+<rectangle x1="217.145" y1="10.635" x2="217.545" y2="10.645" layer="94"/>
+<rectangle x1="217.865" y1="10.635" x2="221.235" y2="10.645" layer="94"/>
+<rectangle x1="221.555" y1="10.635" x2="221.895" y2="10.645" layer="94"/>
+<rectangle x1="216.715" y1="10.645" x2="216.805" y2="10.655" layer="94"/>
+<rectangle x1="217.145" y1="10.645" x2="217.555" y2="10.655" layer="94"/>
+<rectangle x1="217.875" y1="10.645" x2="221.225" y2="10.655" layer="94"/>
+<rectangle x1="221.545" y1="10.645" x2="221.895" y2="10.655" layer="94"/>
+<rectangle x1="216.715" y1="10.655" x2="216.805" y2="10.665" layer="94"/>
+<rectangle x1="217.145" y1="10.655" x2="217.565" y2="10.665" layer="94"/>
+<rectangle x1="217.885" y1="10.655" x2="221.215" y2="10.665" layer="94"/>
+<rectangle x1="221.535" y1="10.655" x2="221.905" y2="10.665" layer="94"/>
+<rectangle x1="216.715" y1="10.665" x2="216.795" y2="10.675" layer="94"/>
+<rectangle x1="217.135" y1="10.665" x2="217.575" y2="10.675" layer="94"/>
+<rectangle x1="217.905" y1="10.665" x2="221.205" y2="10.675" layer="94"/>
+<rectangle x1="221.525" y1="10.665" x2="221.905" y2="10.675" layer="94"/>
+<rectangle x1="216.725" y1="10.675" x2="216.795" y2="10.685" layer="94"/>
+<rectangle x1="217.135" y1="10.675" x2="217.585" y2="10.685" layer="94"/>
+<rectangle x1="217.915" y1="10.675" x2="221.195" y2="10.685" layer="94"/>
+<rectangle x1="221.515" y1="10.675" x2="221.905" y2="10.685" layer="94"/>
+<rectangle x1="216.725" y1="10.685" x2="216.785" y2="10.695" layer="94"/>
+<rectangle x1="217.125" y1="10.685" x2="217.595" y2="10.695" layer="94"/>
+<rectangle x1="217.925" y1="10.685" x2="221.175" y2="10.695" layer="94"/>
+<rectangle x1="221.505" y1="10.685" x2="221.915" y2="10.695" layer="94"/>
+<rectangle x1="216.725" y1="10.695" x2="216.785" y2="10.705" layer="94"/>
+<rectangle x1="217.125" y1="10.695" x2="217.605" y2="10.705" layer="94"/>
+<rectangle x1="217.935" y1="10.695" x2="221.165" y2="10.705" layer="94"/>
+<rectangle x1="221.495" y1="10.695" x2="221.915" y2="10.705" layer="94"/>
+<rectangle x1="216.725" y1="10.705" x2="216.775" y2="10.715" layer="94"/>
+<rectangle x1="217.115" y1="10.705" x2="217.615" y2="10.715" layer="94"/>
+<rectangle x1="217.955" y1="10.705" x2="221.155" y2="10.715" layer="94"/>
+<rectangle x1="221.485" y1="10.705" x2="221.915" y2="10.715" layer="94"/>
+<rectangle x1="216.735" y1="10.715" x2="216.775" y2="10.725" layer="94"/>
+<rectangle x1="217.115" y1="10.715" x2="217.625" y2="10.725" layer="94"/>
+<rectangle x1="217.965" y1="10.715" x2="221.145" y2="10.725" layer="94"/>
+<rectangle x1="221.475" y1="10.715" x2="221.915" y2="10.725" layer="94"/>
+<rectangle x1="216.735" y1="10.725" x2="216.765" y2="10.735" layer="94"/>
+<rectangle x1="217.115" y1="10.725" x2="217.635" y2="10.735" layer="94"/>
+<rectangle x1="217.975" y1="10.725" x2="221.125" y2="10.735" layer="94"/>
+<rectangle x1="221.465" y1="10.725" x2="221.925" y2="10.735" layer="94"/>
+<rectangle x1="216.735" y1="10.735" x2="216.755" y2="10.745" layer="94"/>
+<rectangle x1="217.105" y1="10.735" x2="217.645" y2="10.745" layer="94"/>
+<rectangle x1="217.985" y1="10.735" x2="221.115" y2="10.745" layer="94"/>
+<rectangle x1="221.455" y1="10.735" x2="221.925" y2="10.745" layer="94"/>
+<rectangle x1="216.735" y1="10.745" x2="216.755" y2="10.755" layer="94"/>
+<rectangle x1="217.105" y1="10.745" x2="217.655" y2="10.755" layer="94"/>
+<rectangle x1="218.005" y1="10.745" x2="221.105" y2="10.755" layer="94"/>
+<rectangle x1="221.445" y1="10.745" x2="221.925" y2="10.755" layer="94"/>
+<rectangle x1="217.095" y1="10.755" x2="217.665" y2="10.765" layer="94"/>
+<rectangle x1="218.015" y1="10.755" x2="221.085" y2="10.765" layer="94"/>
+<rectangle x1="221.435" y1="10.755" x2="221.955" y2="10.765" layer="94"/>
+<rectangle x1="217.095" y1="10.765" x2="217.685" y2="10.775" layer="94"/>
+<rectangle x1="218.025" y1="10.765" x2="221.075" y2="10.775" layer="94"/>
+<rectangle x1="221.425" y1="10.765" x2="221.995" y2="10.775" layer="94"/>
+<rectangle x1="217.085" y1="10.775" x2="217.695" y2="10.785" layer="94"/>
+<rectangle x1="218.045" y1="10.775" x2="221.065" y2="10.785" layer="94"/>
+<rectangle x1="221.415" y1="10.775" x2="222.045" y2="10.785" layer="94"/>
+<rectangle x1="217.085" y1="10.785" x2="217.705" y2="10.795" layer="94"/>
+<rectangle x1="218.055" y1="10.785" x2="221.045" y2="10.795" layer="94"/>
+<rectangle x1="221.405" y1="10.785" x2="222.085" y2="10.795" layer="94"/>
+<rectangle x1="217.085" y1="10.795" x2="217.715" y2="10.805" layer="94"/>
+<rectangle x1="218.075" y1="10.795" x2="221.035" y2="10.805" layer="94"/>
+<rectangle x1="221.385" y1="10.795" x2="222.125" y2="10.805" layer="94"/>
+<rectangle x1="217.075" y1="10.805" x2="217.725" y2="10.815" layer="94"/>
+<rectangle x1="218.085" y1="10.805" x2="221.015" y2="10.815" layer="94"/>
+<rectangle x1="221.375" y1="10.805" x2="222.165" y2="10.815" layer="94"/>
+<rectangle x1="217.075" y1="10.815" x2="217.735" y2="10.825" layer="94"/>
+<rectangle x1="218.095" y1="10.815" x2="221.005" y2="10.825" layer="94"/>
+<rectangle x1="221.365" y1="10.815" x2="222.205" y2="10.825" layer="94"/>
+<rectangle x1="217.065" y1="10.825" x2="217.745" y2="10.835" layer="94"/>
+<rectangle x1="218.115" y1="10.825" x2="220.995" y2="10.835" layer="94"/>
+<rectangle x1="221.355" y1="10.825" x2="222.245" y2="10.835" layer="94"/>
+<rectangle x1="217.065" y1="10.835" x2="217.765" y2="10.845" layer="94"/>
+<rectangle x1="218.125" y1="10.835" x2="220.975" y2="10.845" layer="94"/>
+<rectangle x1="221.345" y1="10.835" x2="222.295" y2="10.845" layer="94"/>
+<rectangle x1="217.075" y1="10.845" x2="217.775" y2="10.855" layer="94"/>
+<rectangle x1="218.145" y1="10.845" x2="220.965" y2="10.855" layer="94"/>
+<rectangle x1="221.335" y1="10.845" x2="222.295" y2="10.855" layer="94"/>
+<rectangle x1="217.075" y1="10.855" x2="217.785" y2="10.865" layer="94"/>
+<rectangle x1="218.155" y1="10.855" x2="220.945" y2="10.865" layer="94"/>
+<rectangle x1="221.315" y1="10.855" x2="222.275" y2="10.865" layer="94"/>
+<rectangle x1="217.085" y1="10.865" x2="217.795" y2="10.875" layer="94"/>
+<rectangle x1="218.175" y1="10.865" x2="220.925" y2="10.875" layer="94"/>
+<rectangle x1="221.305" y1="10.865" x2="222.255" y2="10.875" layer="94"/>
+<rectangle x1="217.095" y1="10.875" x2="217.815" y2="10.885" layer="94"/>
+<rectangle x1="218.195" y1="10.875" x2="220.915" y2="10.885" layer="94"/>
+<rectangle x1="221.295" y1="10.875" x2="222.235" y2="10.885" layer="94"/>
+<rectangle x1="217.095" y1="10.885" x2="217.825" y2="10.895" layer="94"/>
+<rectangle x1="218.205" y1="10.885" x2="220.895" y2="10.895" layer="94"/>
+<rectangle x1="221.285" y1="10.885" x2="222.215" y2="10.895" layer="94"/>
+<rectangle x1="217.105" y1="10.895" x2="217.835" y2="10.905" layer="94"/>
+<rectangle x1="218.225" y1="10.895" x2="220.885" y2="10.905" layer="94"/>
+<rectangle x1="221.265" y1="10.895" x2="222.195" y2="10.905" layer="94"/>
+<rectangle x1="217.105" y1="10.905" x2="217.845" y2="10.915" layer="94"/>
+<rectangle x1="218.245" y1="10.905" x2="220.865" y2="10.915" layer="94"/>
+<rectangle x1="221.255" y1="10.905" x2="222.185" y2="10.915" layer="94"/>
+<rectangle x1="217.115" y1="10.915" x2="217.865" y2="10.925" layer="94"/>
+<rectangle x1="218.255" y1="10.915" x2="220.845" y2="10.925" layer="94"/>
+<rectangle x1="221.245" y1="10.915" x2="222.165" y2="10.925" layer="94"/>
+<rectangle x1="217.115" y1="10.925" x2="217.875" y2="10.935" layer="94"/>
+<rectangle x1="218.275" y1="10.925" x2="220.825" y2="10.935" layer="94"/>
+<rectangle x1="221.235" y1="10.925" x2="222.145" y2="10.935" layer="94"/>
+<rectangle x1="217.125" y1="10.935" x2="217.885" y2="10.945" layer="94"/>
+<rectangle x1="218.295" y1="10.935" x2="220.815" y2="10.945" layer="94"/>
+<rectangle x1="221.215" y1="10.935" x2="222.125" y2="10.945" layer="94"/>
+<rectangle x1="217.125" y1="10.945" x2="217.905" y2="10.955" layer="94"/>
+<rectangle x1="218.305" y1="10.945" x2="220.795" y2="10.955" layer="94"/>
+<rectangle x1="221.205" y1="10.945" x2="222.105" y2="10.955" layer="94"/>
+<rectangle x1="217.135" y1="10.955" x2="217.915" y2="10.965" layer="94"/>
+<rectangle x1="218.325" y1="10.955" x2="220.775" y2="10.965" layer="94"/>
+<rectangle x1="221.185" y1="10.955" x2="222.085" y2="10.965" layer="94"/>
+<rectangle x1="217.135" y1="10.965" x2="217.935" y2="10.975" layer="94"/>
+<rectangle x1="218.345" y1="10.965" x2="220.755" y2="10.975" layer="94"/>
+<rectangle x1="221.175" y1="10.965" x2="222.075" y2="10.975" layer="94"/>
+<rectangle x1="217.145" y1="10.975" x2="217.945" y2="10.985" layer="94"/>
+<rectangle x1="218.365" y1="10.975" x2="220.735" y2="10.985" layer="94"/>
+<rectangle x1="221.165" y1="10.975" x2="222.055" y2="10.985" layer="94"/>
+<rectangle x1="217.155" y1="10.985" x2="217.955" y2="10.995" layer="94"/>
+<rectangle x1="218.385" y1="10.985" x2="220.715" y2="10.995" layer="94"/>
+<rectangle x1="221.145" y1="10.985" x2="222.035" y2="10.995" layer="94"/>
+<rectangle x1="217.155" y1="10.995" x2="217.975" y2="11.005" layer="94"/>
+<rectangle x1="218.405" y1="10.995" x2="220.695" y2="11.005" layer="94"/>
+<rectangle x1="221.135" y1="10.995" x2="222.015" y2="11.005" layer="94"/>
+<rectangle x1="217.165" y1="11.005" x2="217.655" y2="11.015" layer="94"/>
+<rectangle x1="217.665" y1="11.005" x2="217.985" y2="11.015" layer="94"/>
+<rectangle x1="218.425" y1="11.005" x2="220.675" y2="11.015" layer="94"/>
+<rectangle x1="221.115" y1="11.005" x2="221.995" y2="11.015" layer="94"/>
+<rectangle x1="217.165" y1="11.015" x2="217.625" y2="11.025" layer="94"/>
+<rectangle x1="217.675" y1="11.015" x2="218.005" y2="11.025" layer="94"/>
+<rectangle x1="218.445" y1="11.015" x2="220.655" y2="11.025" layer="94"/>
+<rectangle x1="221.105" y1="11.015" x2="221.975" y2="11.025" layer="94"/>
+<rectangle x1="217.175" y1="11.025" x2="217.585" y2="11.035" layer="94"/>
+<rectangle x1="217.685" y1="11.025" x2="218.015" y2="11.035" layer="94"/>
+<rectangle x1="218.465" y1="11.025" x2="220.635" y2="11.035" layer="94"/>
+<rectangle x1="221.085" y1="11.025" x2="221.965" y2="11.035" layer="94"/>
+<rectangle x1="217.175" y1="11.035" x2="217.555" y2="11.045" layer="94"/>
+<rectangle x1="217.705" y1="11.035" x2="218.035" y2="11.045" layer="94"/>
+<rectangle x1="218.485" y1="11.035" x2="220.615" y2="11.045" layer="94"/>
+<rectangle x1="221.075" y1="11.035" x2="221.945" y2="11.045" layer="94"/>
+<rectangle x1="217.185" y1="11.045" x2="217.525" y2="11.055" layer="94"/>
+<rectangle x1="217.715" y1="11.045" x2="218.045" y2="11.055" layer="94"/>
+<rectangle x1="218.515" y1="11.045" x2="220.595" y2="11.055" layer="94"/>
+<rectangle x1="221.055" y1="11.045" x2="221.395" y2="11.055" layer="94"/>
+<rectangle x1="221.425" y1="11.045" x2="221.925" y2="11.055" layer="94"/>
+<rectangle x1="217.185" y1="11.055" x2="217.485" y2="11.065" layer="94"/>
+<rectangle x1="217.725" y1="11.055" x2="218.065" y2="11.065" layer="94"/>
+<rectangle x1="218.535" y1="11.055" x2="220.575" y2="11.065" layer="94"/>
+<rectangle x1="221.045" y1="11.055" x2="221.375" y2="11.065" layer="94"/>
+<rectangle x1="221.445" y1="11.055" x2="221.905" y2="11.065" layer="94"/>
+<rectangle x1="217.195" y1="11.065" x2="217.485" y2="11.075" layer="94"/>
+<rectangle x1="217.745" y1="11.065" x2="218.075" y2="11.075" layer="94"/>
+<rectangle x1="218.555" y1="11.065" x2="220.545" y2="11.075" layer="94"/>
+<rectangle x1="221.025" y1="11.065" x2="221.365" y2="11.075" layer="94"/>
+<rectangle x1="221.475" y1="11.065" x2="221.885" y2="11.075" layer="94"/>
+<rectangle x1="217.195" y1="11.075" x2="217.475" y2="11.085" layer="94"/>
+<rectangle x1="217.745" y1="11.075" x2="218.095" y2="11.085" layer="94"/>
+<rectangle x1="218.585" y1="11.075" x2="220.525" y2="11.085" layer="94"/>
+<rectangle x1="221.005" y1="11.075" x2="221.355" y2="11.085" layer="94"/>
+<rectangle x1="221.495" y1="11.075" x2="221.865" y2="11.085" layer="94"/>
+<rectangle x1="217.205" y1="11.085" x2="217.475" y2="11.095" layer="94"/>
+<rectangle x1="217.745" y1="11.085" x2="218.115" y2="11.095" layer="94"/>
+<rectangle x1="218.605" y1="11.085" x2="220.495" y2="11.095" layer="94"/>
+<rectangle x1="220.995" y1="11.085" x2="221.335" y2="11.095" layer="94"/>
+<rectangle x1="221.515" y1="11.085" x2="221.855" y2="11.095" layer="94"/>
+<rectangle x1="217.215" y1="11.095" x2="217.475" y2="11.105" layer="94"/>
+<rectangle x1="217.745" y1="11.095" x2="218.125" y2="11.105" layer="94"/>
+<rectangle x1="218.635" y1="11.095" x2="220.475" y2="11.105" layer="94"/>
+<rectangle x1="220.975" y1="11.095" x2="221.325" y2="11.105" layer="94"/>
+<rectangle x1="221.545" y1="11.095" x2="221.835" y2="11.105" layer="94"/>
+<rectangle x1="217.215" y1="11.105" x2="217.475" y2="11.115" layer="94"/>
+<rectangle x1="217.745" y1="11.105" x2="218.145" y2="11.115" layer="94"/>
+<rectangle x1="218.655" y1="11.105" x2="220.445" y2="11.115" layer="94"/>
+<rectangle x1="220.955" y1="11.105" x2="221.315" y2="11.115" layer="94"/>
+<rectangle x1="221.565" y1="11.105" x2="221.815" y2="11.115" layer="94"/>
+<rectangle x1="217.225" y1="11.115" x2="217.465" y2="11.125" layer="94"/>
+<rectangle x1="217.745" y1="11.115" x2="218.165" y2="11.125" layer="94"/>
+<rectangle x1="218.685" y1="11.115" x2="220.415" y2="11.125" layer="94"/>
+<rectangle x1="220.945" y1="11.115" x2="221.295" y2="11.125" layer="94"/>
+<rectangle x1="221.585" y1="11.115" x2="221.795" y2="11.125" layer="94"/>
+<rectangle x1="217.225" y1="11.125" x2="217.465" y2="11.135" layer="94"/>
+<rectangle x1="217.745" y1="11.125" x2="218.185" y2="11.135" layer="94"/>
+<rectangle x1="218.715" y1="11.125" x2="220.385" y2="11.135" layer="94"/>
+<rectangle x1="220.925" y1="11.125" x2="221.295" y2="11.135" layer="94"/>
+<rectangle x1="221.615" y1="11.125" x2="221.775" y2="11.135" layer="94"/>
+<rectangle x1="217.235" y1="11.135" x2="217.465" y2="11.145" layer="94"/>
+<rectangle x1="217.735" y1="11.135" x2="218.195" y2="11.145" layer="94"/>
+<rectangle x1="218.745" y1="11.135" x2="220.355" y2="11.145" layer="94"/>
+<rectangle x1="220.905" y1="11.135" x2="221.295" y2="11.145" layer="94"/>
+<rectangle x1="221.635" y1="11.135" x2="221.755" y2="11.145" layer="94"/>
+<rectangle x1="217.235" y1="11.145" x2="217.465" y2="11.155" layer="94"/>
+<rectangle x1="217.735" y1="11.145" x2="218.215" y2="11.155" layer="94"/>
+<rectangle x1="218.775" y1="11.145" x2="220.335" y2="11.155" layer="94"/>
+<rectangle x1="220.885" y1="11.145" x2="221.295" y2="11.155" layer="94"/>
+<rectangle x1="221.655" y1="11.145" x2="221.745" y2="11.155" layer="94"/>
+<rectangle x1="217.245" y1="11.155" x2="217.465" y2="11.165" layer="94"/>
+<rectangle x1="217.735" y1="11.155" x2="218.235" y2="11.165" layer="94"/>
+<rectangle x1="218.805" y1="11.155" x2="220.295" y2="11.165" layer="94"/>
+<rectangle x1="220.865" y1="11.155" x2="221.295" y2="11.165" layer="94"/>
+<rectangle x1="221.675" y1="11.155" x2="221.725" y2="11.165" layer="94"/>
+<rectangle x1="217.245" y1="11.165" x2="217.455" y2="11.175" layer="94"/>
+<rectangle x1="217.735" y1="11.165" x2="218.255" y2="11.175" layer="94"/>
+<rectangle x1="218.845" y1="11.165" x2="220.265" y2="11.175" layer="94"/>
+<rectangle x1="220.855" y1="11.165" x2="221.295" y2="11.175" layer="94"/>
+<rectangle x1="217.255" y1="11.175" x2="217.455" y2="11.185" layer="94"/>
+<rectangle x1="217.735" y1="11.175" x2="218.275" y2="11.185" layer="94"/>
+<rectangle x1="218.875" y1="11.175" x2="220.225" y2="11.185" layer="94"/>
+<rectangle x1="220.835" y1="11.175" x2="221.295" y2="11.185" layer="94"/>
+<rectangle x1="217.255" y1="11.185" x2="217.455" y2="11.195" layer="94"/>
+<rectangle x1="217.735" y1="11.185" x2="218.295" y2="11.195" layer="94"/>
+<rectangle x1="218.915" y1="11.185" x2="220.195" y2="11.195" layer="94"/>
+<rectangle x1="220.815" y1="11.185" x2="221.295" y2="11.195" layer="94"/>
+<rectangle x1="217.265" y1="11.195" x2="217.455" y2="11.205" layer="94"/>
+<rectangle x1="217.725" y1="11.195" x2="218.315" y2="11.205" layer="94"/>
+<rectangle x1="218.955" y1="11.195" x2="220.145" y2="11.205" layer="94"/>
+<rectangle x1="220.795" y1="11.195" x2="221.295" y2="11.205" layer="94"/>
+<rectangle x1="217.275" y1="11.205" x2="217.445" y2="11.215" layer="94"/>
+<rectangle x1="217.725" y1="11.205" x2="218.335" y2="11.215" layer="94"/>
+<rectangle x1="219.005" y1="11.205" x2="220.105" y2="11.215" layer="94"/>
+<rectangle x1="220.775" y1="11.205" x2="221.295" y2="11.215" layer="94"/>
+<rectangle x1="217.275" y1="11.215" x2="217.445" y2="11.225" layer="94"/>
+<rectangle x1="217.725" y1="11.215" x2="218.355" y2="11.225" layer="94"/>
+<rectangle x1="219.045" y1="11.215" x2="220.055" y2="11.225" layer="94"/>
+<rectangle x1="220.755" y1="11.215" x2="221.295" y2="11.225" layer="94"/>
+<rectangle x1="217.285" y1="11.225" x2="217.445" y2="11.235" layer="94"/>
+<rectangle x1="217.725" y1="11.225" x2="218.375" y2="11.235" layer="94"/>
+<rectangle x1="219.105" y1="11.225" x2="220.005" y2="11.235" layer="94"/>
+<rectangle x1="220.725" y1="11.225" x2="221.295" y2="11.235" layer="94"/>
+<rectangle x1="217.285" y1="11.235" x2="217.445" y2="11.245" layer="94"/>
+<rectangle x1="217.725" y1="11.235" x2="218.395" y2="11.245" layer="94"/>
+<rectangle x1="219.155" y1="11.235" x2="219.945" y2="11.245" layer="94"/>
+<rectangle x1="220.705" y1="11.235" x2="221.295" y2="11.245" layer="94"/>
+<rectangle x1="217.295" y1="11.245" x2="217.435" y2="11.255" layer="94"/>
+<rectangle x1="217.725" y1="11.245" x2="218.415" y2="11.255" layer="94"/>
+<rectangle x1="219.235" y1="11.245" x2="219.865" y2="11.255" layer="94"/>
+<rectangle x1="220.685" y1="11.245" x2="221.295" y2="11.255" layer="94"/>
+<rectangle x1="217.295" y1="11.255" x2="217.435" y2="11.265" layer="94"/>
+<rectangle x1="217.725" y1="11.255" x2="218.445" y2="11.265" layer="94"/>
+<rectangle x1="219.335" y1="11.255" x2="219.775" y2="11.265" layer="94"/>
+<rectangle x1="220.665" y1="11.255" x2="221.295" y2="11.265" layer="94"/>
+<rectangle x1="217.305" y1="11.265" x2="217.435" y2="11.275" layer="94"/>
+<rectangle x1="217.715" y1="11.265" x2="218.465" y2="11.275" layer="94"/>
+<rectangle x1="219.545" y1="11.265" x2="219.555" y2="11.275" layer="94"/>
+<rectangle x1="220.645" y1="11.265" x2="221.295" y2="11.275" layer="94"/>
+<rectangle x1="217.305" y1="11.275" x2="217.435" y2="11.285" layer="94"/>
+<rectangle x1="217.715" y1="11.275" x2="218.485" y2="11.285" layer="94"/>
+<rectangle x1="220.615" y1="11.275" x2="221.295" y2="11.285" layer="94"/>
+<rectangle x1="217.315" y1="11.285" x2="217.425" y2="11.295" layer="94"/>
+<rectangle x1="217.715" y1="11.285" x2="218.515" y2="11.295" layer="94"/>
+<rectangle x1="220.595" y1="11.285" x2="221.295" y2="11.295" layer="94"/>
+<rectangle x1="217.315" y1="11.295" x2="217.425" y2="11.305" layer="94"/>
+<rectangle x1="217.715" y1="11.295" x2="218.535" y2="11.305" layer="94"/>
+<rectangle x1="220.565" y1="11.295" x2="221.295" y2="11.305" layer="94"/>
+<rectangle x1="217.325" y1="11.305" x2="217.425" y2="11.315" layer="94"/>
+<rectangle x1="217.715" y1="11.305" x2="218.565" y2="11.315" layer="94"/>
+<rectangle x1="220.535" y1="11.305" x2="221.305" y2="11.315" layer="94"/>
+<rectangle x1="217.335" y1="11.315" x2="217.425" y2="11.325" layer="94"/>
+<rectangle x1="217.715" y1="11.315" x2="218.595" y2="11.325" layer="94"/>
+<rectangle x1="220.515" y1="11.315" x2="221.325" y2="11.325" layer="94"/>
+<rectangle x1="217.335" y1="11.325" x2="217.415" y2="11.335" layer="94"/>
+<rectangle x1="217.705" y1="11.325" x2="218.615" y2="11.335" layer="94"/>
+<rectangle x1="220.485" y1="11.325" x2="221.345" y2="11.335" layer="94"/>
+<rectangle x1="217.345" y1="11.335" x2="217.415" y2="11.345" layer="94"/>
+<rectangle x1="217.705" y1="11.335" x2="218.645" y2="11.345" layer="94"/>
+<rectangle x1="220.455" y1="11.335" x2="221.365" y2="11.345" layer="94"/>
+<rectangle x1="217.345" y1="11.345" x2="217.415" y2="11.355" layer="94"/>
+<rectangle x1="217.705" y1="11.345" x2="218.675" y2="11.355" layer="94"/>
+<rectangle x1="220.425" y1="11.345" x2="221.375" y2="11.355" layer="94"/>
+<rectangle x1="217.355" y1="11.355" x2="217.415" y2="11.365" layer="94"/>
+<rectangle x1="217.705" y1="11.355" x2="218.705" y2="11.365" layer="94"/>
+<rectangle x1="220.395" y1="11.355" x2="221.395" y2="11.365" layer="94"/>
+<rectangle x1="217.355" y1="11.365" x2="217.405" y2="11.375" layer="94"/>
+<rectangle x1="217.705" y1="11.365" x2="218.745" y2="11.375" layer="94"/>
+<rectangle x1="220.365" y1="11.365" x2="221.415" y2="11.375" layer="94"/>
+<rectangle x1="217.365" y1="11.375" x2="217.405" y2="11.385" layer="94"/>
+<rectangle x1="217.705" y1="11.375" x2="218.775" y2="11.385" layer="94"/>
+<rectangle x1="220.325" y1="11.375" x2="221.435" y2="11.385" layer="94"/>
+<rectangle x1="217.365" y1="11.385" x2="217.405" y2="11.395" layer="94"/>
+<rectangle x1="217.705" y1="11.385" x2="218.815" y2="11.395" layer="94"/>
+<rectangle x1="220.295" y1="11.385" x2="221.455" y2="11.395" layer="94"/>
+<rectangle x1="217.375" y1="11.395" x2="217.405" y2="11.405" layer="94"/>
+<rectangle x1="217.705" y1="11.395" x2="218.845" y2="11.405" layer="94"/>
+<rectangle x1="220.255" y1="11.395" x2="221.475" y2="11.405" layer="94"/>
+<rectangle x1="217.375" y1="11.405" x2="217.405" y2="11.415" layer="94"/>
+<rectangle x1="217.715" y1="11.405" x2="218.885" y2="11.415" layer="94"/>
+<rectangle x1="220.215" y1="11.405" x2="221.485" y2="11.415" layer="94"/>
+<rectangle x1="217.385" y1="11.415" x2="217.395" y2="11.425" layer="94"/>
+<rectangle x1="217.715" y1="11.415" x2="218.315" y2="11.425" layer="94"/>
+<rectangle x1="218.325" y1="11.415" x2="218.935" y2="11.425" layer="94"/>
+<rectangle x1="220.175" y1="11.415" x2="221.505" y2="11.425" layer="94"/>
+<rectangle x1="217.725" y1="11.425" x2="218.295" y2="11.435" layer="94"/>
+<rectangle x1="218.345" y1="11.425" x2="218.975" y2="11.435" layer="94"/>
+<rectangle x1="220.125" y1="11.425" x2="221.525" y2="11.435" layer="94"/>
+<rectangle x1="217.735" y1="11.435" x2="218.275" y2="11.445" layer="94"/>
+<rectangle x1="218.365" y1="11.435" x2="219.025" y2="11.445" layer="94"/>
+<rectangle x1="220.075" y1="11.435" x2="221.545" y2="11.445" layer="94"/>
+<rectangle x1="217.745" y1="11.445" x2="218.265" y2="11.455" layer="94"/>
+<rectangle x1="218.395" y1="11.445" x2="219.085" y2="11.455" layer="94"/>
+<rectangle x1="220.025" y1="11.445" x2="220.715" y2="11.455" layer="94"/>
+<rectangle x1="220.725" y1="11.445" x2="221.565" y2="11.455" layer="94"/>
+<rectangle x1="217.755" y1="11.455" x2="218.245" y2="11.465" layer="94"/>
+<rectangle x1="218.415" y1="11.455" x2="219.145" y2="11.465" layer="94"/>
+<rectangle x1="219.965" y1="11.455" x2="220.685" y2="11.465" layer="94"/>
+<rectangle x1="220.735" y1="11.455" x2="221.575" y2="11.465" layer="94"/>
+<rectangle x1="217.765" y1="11.465" x2="218.225" y2="11.475" layer="94"/>
+<rectangle x1="218.435" y1="11.465" x2="219.225" y2="11.475" layer="94"/>
+<rectangle x1="219.885" y1="11.465" x2="220.665" y2="11.475" layer="94"/>
+<rectangle x1="220.745" y1="11.465" x2="221.595" y2="11.475" layer="94"/>
+<rectangle x1="217.775" y1="11.475" x2="218.215" y2="11.485" layer="94"/>
+<rectangle x1="218.445" y1="11.475" x2="219.325" y2="11.485" layer="94"/>
+<rectangle x1="219.785" y1="11.475" x2="220.635" y2="11.485" layer="94"/>
+<rectangle x1="220.755" y1="11.475" x2="221.615" y2="11.485" layer="94"/>
+<rectangle x1="217.785" y1="11.485" x2="218.195" y2="11.495" layer="94"/>
+<rectangle x1="218.445" y1="11.485" x2="219.545" y2="11.495" layer="94"/>
+<rectangle x1="219.565" y1="11.485" x2="220.625" y2="11.495" layer="94"/>
+<rectangle x1="220.775" y1="11.485" x2="221.635" y2="11.495" layer="94"/>
+<rectangle x1="217.795" y1="11.495" x2="218.175" y2="11.505" layer="94"/>
+<rectangle x1="218.445" y1="11.495" x2="220.625" y2="11.505" layer="94"/>
+<rectangle x1="220.785" y1="11.495" x2="221.605" y2="11.505" layer="94"/>
+<rectangle x1="217.805" y1="11.505" x2="218.165" y2="11.515" layer="94"/>
+<rectangle x1="218.445" y1="11.505" x2="220.625" y2="11.515" layer="94"/>
+<rectangle x1="220.795" y1="11.505" x2="221.555" y2="11.515" layer="94"/>
+<rectangle x1="217.815" y1="11.515" x2="218.165" y2="11.525" layer="94"/>
+<rectangle x1="218.445" y1="11.515" x2="220.625" y2="11.525" layer="94"/>
+<rectangle x1="220.805" y1="11.515" x2="221.515" y2="11.525" layer="94"/>
+<rectangle x1="217.825" y1="11.525" x2="218.165" y2="11.535" layer="94"/>
+<rectangle x1="218.445" y1="11.525" x2="220.615" y2="11.535" layer="94"/>
+<rectangle x1="220.825" y1="11.525" x2="221.475" y2="11.535" layer="94"/>
+<rectangle x1="217.835" y1="11.535" x2="218.165" y2="11.545" layer="94"/>
+<rectangle x1="218.455" y1="11.535" x2="220.615" y2="11.545" layer="94"/>
+<rectangle x1="220.835" y1="11.535" x2="221.435" y2="11.545" layer="94"/>
+<rectangle x1="217.845" y1="11.545" x2="218.165" y2="11.555" layer="94"/>
+<rectangle x1="218.455" y1="11.545" x2="220.615" y2="11.555" layer="94"/>
+<rectangle x1="220.845" y1="11.545" x2="221.395" y2="11.555" layer="94"/>
+<rectangle x1="217.855" y1="11.555" x2="218.165" y2="11.565" layer="94"/>
+<rectangle x1="218.455" y1="11.555" x2="220.615" y2="11.565" layer="94"/>
+<rectangle x1="220.855" y1="11.555" x2="221.345" y2="11.565" layer="94"/>
+<rectangle x1="217.865" y1="11.565" x2="218.165" y2="11.575" layer="94"/>
+<rectangle x1="218.455" y1="11.565" x2="220.605" y2="11.575" layer="94"/>
+<rectangle x1="220.875" y1="11.565" x2="221.305" y2="11.575" layer="94"/>
+<rectangle x1="217.875" y1="11.575" x2="218.165" y2="11.585" layer="94"/>
+<rectangle x1="218.455" y1="11.575" x2="220.605" y2="11.585" layer="94"/>
+<rectangle x1="220.885" y1="11.575" x2="221.265" y2="11.585" layer="94"/>
+<rectangle x1="217.885" y1="11.585" x2="218.165" y2="11.595" layer="94"/>
+<rectangle x1="218.455" y1="11.585" x2="220.605" y2="11.595" layer="94"/>
+<rectangle x1="220.895" y1="11.585" x2="221.225" y2="11.595" layer="94"/>
+<rectangle x1="217.895" y1="11.595" x2="218.165" y2="11.605" layer="94"/>
+<rectangle x1="218.455" y1="11.595" x2="220.605" y2="11.605" layer="94"/>
+<rectangle x1="220.905" y1="11.595" x2="221.185" y2="11.605" layer="94"/>
+<rectangle x1="217.895" y1="11.605" x2="218.165" y2="11.615" layer="94"/>
+<rectangle x1="218.455" y1="11.605" x2="220.595" y2="11.615" layer="94"/>
+<rectangle x1="220.925" y1="11.605" x2="221.135" y2="11.615" layer="94"/>
+<rectangle x1="217.905" y1="11.615" x2="218.165" y2="11.625" layer="94"/>
+<rectangle x1="218.465" y1="11.615" x2="220.595" y2="11.625" layer="94"/>
+<rectangle x1="220.935" y1="11.615" x2="221.095" y2="11.625" layer="94"/>
+<rectangle x1="217.915" y1="11.625" x2="218.165" y2="11.635" layer="94"/>
+<rectangle x1="218.465" y1="11.625" x2="220.595" y2="11.635" layer="94"/>
+<rectangle x1="220.945" y1="11.625" x2="221.055" y2="11.635" layer="94"/>
+<rectangle x1="217.925" y1="11.635" x2="218.165" y2="11.645" layer="94"/>
+<rectangle x1="218.465" y1="11.635" x2="220.595" y2="11.645" layer="94"/>
+<rectangle x1="220.955" y1="11.635" x2="221.015" y2="11.645" layer="94"/>
+<rectangle x1="217.935" y1="11.645" x2="218.165" y2="11.655" layer="94"/>
+<rectangle x1="218.465" y1="11.645" x2="219.075" y2="11.655" layer="94"/>
+<rectangle x1="219.095" y1="11.645" x2="220.585" y2="11.655" layer="94"/>
+<rectangle x1="217.945" y1="11.655" x2="218.165" y2="11.665" layer="94"/>
+<rectangle x1="218.465" y1="11.655" x2="219.065" y2="11.665" layer="94"/>
+<rectangle x1="219.165" y1="11.655" x2="219.935" y2="11.665" layer="94"/>
+<rectangle x1="219.995" y1="11.655" x2="220.585" y2="11.665" layer="94"/>
+<rectangle x1="217.955" y1="11.665" x2="218.165" y2="11.675" layer="94"/>
+<rectangle x1="218.465" y1="11.665" x2="219.055" y2="11.675" layer="94"/>
+<rectangle x1="219.195" y1="11.665" x2="219.855" y2="11.675" layer="94"/>
+<rectangle x1="220.005" y1="11.665" x2="220.595" y2="11.675" layer="94"/>
+<rectangle x1="217.965" y1="11.675" x2="218.165" y2="11.685" layer="94"/>
+<rectangle x1="218.465" y1="11.675" x2="219.055" y2="11.685" layer="94"/>
+<rectangle x1="219.205" y1="11.675" x2="219.845" y2="11.685" layer="94"/>
+<rectangle x1="220.015" y1="11.675" x2="220.605" y2="11.685" layer="94"/>
+<rectangle x1="217.975" y1="11.685" x2="218.165" y2="11.695" layer="94"/>
+<rectangle x1="218.465" y1="11.685" x2="219.045" y2="11.695" layer="94"/>
+<rectangle x1="219.205" y1="11.685" x2="219.845" y2="11.695" layer="94"/>
+<rectangle x1="220.015" y1="11.685" x2="220.615" y2="11.695" layer="94"/>
+<rectangle x1="217.985" y1="11.695" x2="218.165" y2="11.705" layer="94"/>
+<rectangle x1="218.465" y1="11.695" x2="219.035" y2="11.705" layer="94"/>
+<rectangle x1="219.205" y1="11.695" x2="219.835" y2="11.705" layer="94"/>
+<rectangle x1="220.025" y1="11.695" x2="220.625" y2="11.705" layer="94"/>
+<rectangle x1="217.995" y1="11.705" x2="218.165" y2="11.715" layer="94"/>
+<rectangle x1="218.475" y1="11.705" x2="219.025" y2="11.715" layer="94"/>
+<rectangle x1="219.215" y1="11.705" x2="219.835" y2="11.715" layer="94"/>
+<rectangle x1="220.035" y1="11.705" x2="220.635" y2="11.715" layer="94"/>
+<rectangle x1="218.005" y1="11.715" x2="218.165" y2="11.725" layer="94"/>
+<rectangle x1="218.475" y1="11.715" x2="219.015" y2="11.725" layer="94"/>
+<rectangle x1="219.215" y1="11.715" x2="219.825" y2="11.725" layer="94"/>
+<rectangle x1="220.045" y1="11.715" x2="220.645" y2="11.725" layer="94"/>
+<rectangle x1="218.015" y1="11.725" x2="218.165" y2="11.735" layer="94"/>
+<rectangle x1="218.475" y1="11.725" x2="219.005" y2="11.735" layer="94"/>
+<rectangle x1="219.225" y1="11.725" x2="219.825" y2="11.735" layer="94"/>
+<rectangle x1="220.045" y1="11.725" x2="220.665" y2="11.735" layer="94"/>
+<rectangle x1="218.025" y1="11.735" x2="218.165" y2="11.745" layer="94"/>
+<rectangle x1="218.475" y1="11.735" x2="218.995" y2="11.745" layer="94"/>
+<rectangle x1="219.225" y1="11.735" x2="219.815" y2="11.745" layer="94"/>
+<rectangle x1="220.055" y1="11.735" x2="220.675" y2="11.745" layer="94"/>
+<rectangle x1="218.035" y1="11.745" x2="218.165" y2="11.755" layer="94"/>
+<rectangle x1="218.475" y1="11.745" x2="218.985" y2="11.755" layer="94"/>
+<rectangle x1="219.225" y1="11.745" x2="219.815" y2="11.755" layer="94"/>
+<rectangle x1="220.065" y1="11.745" x2="220.685" y2="11.755" layer="94"/>
+<rectangle x1="218.045" y1="11.755" x2="218.165" y2="11.765" layer="94"/>
+<rectangle x1="218.475" y1="11.755" x2="218.975" y2="11.765" layer="94"/>
+<rectangle x1="219.235" y1="11.755" x2="219.805" y2="11.765" layer="94"/>
+<rectangle x1="220.075" y1="11.755" x2="220.695" y2="11.765" layer="94"/>
+<rectangle x1="218.055" y1="11.765" x2="218.165" y2="11.775" layer="94"/>
+<rectangle x1="218.475" y1="11.765" x2="218.965" y2="11.775" layer="94"/>
+<rectangle x1="219.235" y1="11.765" x2="219.795" y2="11.775" layer="94"/>
+<rectangle x1="220.075" y1="11.765" x2="220.705" y2="11.775" layer="94"/>
+<rectangle x1="218.065" y1="11.775" x2="218.165" y2="11.785" layer="94"/>
+<rectangle x1="218.475" y1="11.775" x2="218.955" y2="11.785" layer="94"/>
+<rectangle x1="219.235" y1="11.775" x2="219.795" y2="11.785" layer="94"/>
+<rectangle x1="220.085" y1="11.775" x2="220.715" y2="11.785" layer="94"/>
+<rectangle x1="218.075" y1="11.785" x2="218.165" y2="11.795" layer="94"/>
+<rectangle x1="218.485" y1="11.785" x2="218.955" y2="11.795" layer="94"/>
+<rectangle x1="219.245" y1="11.785" x2="219.785" y2="11.795" layer="94"/>
+<rectangle x1="220.095" y1="11.785" x2="220.725" y2="11.795" layer="94"/>
+<rectangle x1="218.075" y1="11.795" x2="218.165" y2="11.805" layer="94"/>
+<rectangle x1="218.495" y1="11.795" x2="218.965" y2="11.805" layer="94"/>
+<rectangle x1="219.245" y1="11.795" x2="219.785" y2="11.805" layer="94"/>
+<rectangle x1="220.105" y1="11.795" x2="220.735" y2="11.805" layer="94"/>
+<rectangle x1="218.085" y1="11.805" x2="218.165" y2="11.815" layer="94"/>
+<rectangle x1="218.515" y1="11.805" x2="218.965" y2="11.815" layer="94"/>
+<rectangle x1="219.255" y1="11.805" x2="219.775" y2="11.815" layer="94"/>
+<rectangle x1="220.105" y1="11.805" x2="220.745" y2="11.815" layer="94"/>
+<rectangle x1="218.095" y1="11.815" x2="218.165" y2="11.825" layer="94"/>
+<rectangle x1="218.525" y1="11.815" x2="218.965" y2="11.825" layer="94"/>
+<rectangle x1="219.255" y1="11.815" x2="219.775" y2="11.825" layer="94"/>
+<rectangle x1="220.115" y1="11.815" x2="220.755" y2="11.825" layer="94"/>
+<rectangle x1="218.105" y1="11.825" x2="218.165" y2="11.835" layer="94"/>
+<rectangle x1="218.545" y1="11.825" x2="218.975" y2="11.835" layer="94"/>
+<rectangle x1="219.255" y1="11.825" x2="219.765" y2="11.835" layer="94"/>
+<rectangle x1="220.125" y1="11.825" x2="220.765" y2="11.835" layer="94"/>
+<rectangle x1="218.115" y1="11.835" x2="218.165" y2="11.845" layer="94"/>
+<rectangle x1="218.565" y1="11.835" x2="218.975" y2="11.845" layer="94"/>
+<rectangle x1="219.265" y1="11.835" x2="219.775" y2="11.845" layer="94"/>
+<rectangle x1="220.135" y1="11.835" x2="220.775" y2="11.845" layer="94"/>
+<rectangle x1="218.125" y1="11.845" x2="218.165" y2="11.855" layer="94"/>
+<rectangle x1="218.575" y1="11.845" x2="218.975" y2="11.855" layer="94"/>
+<rectangle x1="219.265" y1="11.845" x2="219.775" y2="11.855" layer="94"/>
+<rectangle x1="220.135" y1="11.845" x2="220.785" y2="11.855" layer="94"/>
+<rectangle x1="218.135" y1="11.855" x2="218.175" y2="11.865" layer="94"/>
+<rectangle x1="218.595" y1="11.855" x2="218.985" y2="11.865" layer="94"/>
+<rectangle x1="219.275" y1="11.855" x2="219.785" y2="11.865" layer="94"/>
+<rectangle x1="220.145" y1="11.855" x2="220.795" y2="11.865" layer="94"/>
+<rectangle x1="218.145" y1="11.865" x2="218.175" y2="11.875" layer="94"/>
+<rectangle x1="218.615" y1="11.865" x2="218.985" y2="11.875" layer="94"/>
+<rectangle x1="219.275" y1="11.865" x2="219.795" y2="11.875" layer="94"/>
+<rectangle x1="220.155" y1="11.865" x2="220.805" y2="11.875" layer="94"/>
+<rectangle x1="218.155" y1="11.875" x2="218.175" y2="11.885" layer="94"/>
+<rectangle x1="218.625" y1="11.875" x2="218.985" y2="11.885" layer="94"/>
+<rectangle x1="219.275" y1="11.875" x2="219.795" y2="11.885" layer="94"/>
+<rectangle x1="220.155" y1="11.875" x2="220.825" y2="11.885" layer="94"/>
+<rectangle x1="218.645" y1="11.885" x2="218.985" y2="11.895" layer="94"/>
+<rectangle x1="219.285" y1="11.885" x2="219.805" y2="11.895" layer="94"/>
+<rectangle x1="220.165" y1="11.885" x2="220.835" y2="11.895" layer="94"/>
+<rectangle x1="218.665" y1="11.895" x2="218.995" y2="11.905" layer="94"/>
+<rectangle x1="219.285" y1="11.895" x2="219.815" y2="11.905" layer="94"/>
+<rectangle x1="220.175" y1="11.895" x2="220.845" y2="11.905" layer="94"/>
+<rectangle x1="218.675" y1="11.905" x2="218.995" y2="11.915" layer="94"/>
+<rectangle x1="219.295" y1="11.905" x2="219.815" y2="11.915" layer="94"/>
+<rectangle x1="220.185" y1="11.905" x2="220.855" y2="11.915" layer="94"/>
+<rectangle x1="218.695" y1="11.915" x2="218.995" y2="11.925" layer="94"/>
+<rectangle x1="219.295" y1="11.915" x2="219.825" y2="11.925" layer="94"/>
+<rectangle x1="220.645" y1="11.915" x2="220.865" y2="11.925" layer="94"/>
+<rectangle x1="218.715" y1="11.925" x2="219.005" y2="11.935" layer="94"/>
+<rectangle x1="219.295" y1="11.925" x2="219.825" y2="11.935" layer="94"/>
+<rectangle x1="218.725" y1="11.935" x2="219.005" y2="11.945" layer="94"/>
+<rectangle x1="219.305" y1="11.935" x2="219.835" y2="11.945" layer="94"/>
+<rectangle x1="218.745" y1="11.945" x2="219.005" y2="11.955" layer="94"/>
+<rectangle x1="219.305" y1="11.945" x2="219.845" y2="11.955" layer="94"/>
+<rectangle x1="218.755" y1="11.955" x2="219.015" y2="11.965" layer="94"/>
+<rectangle x1="219.315" y1="11.955" x2="219.845" y2="11.965" layer="94"/>
+<rectangle x1="218.775" y1="11.965" x2="219.015" y2="11.975" layer="94"/>
+<rectangle x1="219.335" y1="11.965" x2="219.855" y2="11.975" layer="94"/>
+<rectangle x1="218.795" y1="11.975" x2="219.015" y2="11.985" layer="94"/>
+<rectangle x1="219.375" y1="11.975" x2="219.855" y2="11.985" layer="94"/>
+<rectangle x1="218.805" y1="11.985" x2="219.015" y2="11.995" layer="94"/>
+<rectangle x1="219.405" y1="11.985" x2="219.865" y2="11.995" layer="94"/>
+<rectangle x1="218.825" y1="11.995" x2="219.025" y2="12.005" layer="94"/>
+<rectangle x1="219.435" y1="11.995" x2="219.875" y2="12.005" layer="94"/>
+<rectangle x1="218.845" y1="12.005" x2="219.025" y2="12.015" layer="94"/>
+<rectangle x1="219.475" y1="12.005" x2="219.875" y2="12.015" layer="94"/>
+<rectangle x1="218.855" y1="12.015" x2="219.025" y2="12.025" layer="94"/>
+<rectangle x1="219.505" y1="12.015" x2="219.885" y2="12.025" layer="94"/>
+<rectangle x1="218.875" y1="12.025" x2="219.035" y2="12.035" layer="94"/>
+<rectangle x1="219.545" y1="12.025" x2="219.895" y2="12.035" layer="94"/>
+<rectangle x1="218.895" y1="12.035" x2="219.035" y2="12.045" layer="94"/>
+<rectangle x1="219.575" y1="12.035" x2="219.895" y2="12.045" layer="94"/>
+<rectangle x1="218.905" y1="12.045" x2="219.035" y2="12.055" layer="94"/>
+<rectangle x1="219.605" y1="12.045" x2="219.905" y2="12.055" layer="94"/>
+<rectangle x1="218.925" y1="12.055" x2="219.045" y2="12.065" layer="94"/>
+<rectangle x1="219.645" y1="12.055" x2="219.905" y2="12.065" layer="94"/>
+<rectangle x1="218.945" y1="12.065" x2="219.045" y2="12.075" layer="94"/>
+<rectangle x1="219.675" y1="12.065" x2="219.915" y2="12.075" layer="94"/>
+<rectangle x1="218.955" y1="12.075" x2="219.045" y2="12.085" layer="94"/>
+<rectangle x1="219.705" y1="12.075" x2="219.925" y2="12.085" layer="94"/>
+<rectangle x1="218.975" y1="12.085" x2="219.045" y2="12.095" layer="94"/>
+<rectangle x1="219.745" y1="12.085" x2="219.925" y2="12.095" layer="94"/>
+<rectangle x1="218.985" y1="12.095" x2="219.055" y2="12.105" layer="94"/>
+<rectangle x1="219.775" y1="12.095" x2="219.935" y2="12.105" layer="94"/>
+<rectangle x1="219.005" y1="12.105" x2="219.055" y2="12.115" layer="94"/>
+<rectangle x1="219.815" y1="12.105" x2="219.935" y2="12.115" layer="94"/>
+<rectangle x1="219.025" y1="12.115" x2="219.055" y2="12.125" layer="94"/>
+<rectangle x1="219.845" y1="12.115" x2="219.945" y2="12.125" layer="94"/>
+<rectangle x1="219.035" y1="12.125" x2="219.065" y2="12.135" layer="94"/>
+<rectangle x1="219.875" y1="12.125" x2="219.955" y2="12.135" layer="94"/>
+<rectangle x1="219.055" y1="12.135" x2="219.065" y2="12.145" layer="94"/>
+<rectangle x1="219.915" y1="12.135" x2="219.955" y2="12.145" layer="94"/>
+<rectangle x1="219.945" y1="12.145" x2="219.965" y2="12.155" layer="94"/>
+<text x="0" y="-0.05" size="0.02" layer="94" font="vector">/Users/seon/Dropbox/Unexpected Maker/Branding/UM_Logo_White2.bmp</text>
+<text x="224.796" y="5.773" size="2" layer="94" font="vector">unexpectedmaker.com</text>
+<text x="171.416" y="15.243" size="2.54" layer="94" font="vector">Title:</text>
+<wire x1="232.41" y1="19.05" x2="232.41" y2="13.97" width="0.1016" layer="94"/>
+<text x="234.916" y="15.243" size="2.54" layer="94" font="vector">Rev:</text>
+<text x="243.84" y="15.24" size="2.54" layer="94" font="vector">&gt;REV</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PSRAM" prefix="IC">
+<description>&lt;b&gt;H-bridge driver&lt;/b&gt; for brush motors&lt;p&gt;
+Source: http://www.rohm.com/products/databook/motor/pdf/bd623x_series-e.pdf</description>
+<gates>
+<gate name="P" symbol="LY68L6400SLIT" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOP8">
+<connects>
+<connect gate="P" pin="CE" pad="1"/>
+<connect gate="P" pin="GND" pad="4"/>
+<connect gate="P" pin="SCLK" pad="6"/>
+<connect gate="P" pin="SIO0" pad="5"/>
+<connect gate="P" pin="SIO1" pad="2"/>
+<connect gate="P" pin="SIO2" pad="3"/>
+<connect gate="P" pin="SIO3" pad="7"/>
+<connect gate="P" pin="VCC" pad="8"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:26262/1"/>
+</package3dinstances>
+<technologies>
+<technology name="0">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="BD6230F-E2" constant="no"/>
+<attribute name="OC_FARNELL" value="1716264" constant="no"/>
+<attribute name="OC_NEWARK" value="15R0529" constant="no"/>
+</technology>
+<technology name="1">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="BD6231F-E2" constant="no"/>
+<attribute name="OC_FARNELL" value="1716265" constant="no"/>
+<attribute name="OC_NEWARK" value="15R0530" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="ESP32-PICO-D4" prefix="IC">
+<gates>
+<gate name="G$1" symbol="CY8C29666" x="0" y="0"/>
+<gate name="G$2" symbol="GNDPAD" x="35.56" y="-27.94"/>
+</gates>
+<devices>
+<device name="" package="PICO-D4-QFN48">
+<connects>
+<connect gate="G$1" pin="CAP1_NC" pad="48"/>
+<connect gate="G$1" pin="CAP2_NC" pad="47"/>
+<connect gate="G$1" pin="CLK" pad="31"/>
+<connect gate="G$1" pin="CMD" pad="30"/>
+<connect gate="G$1" pin="EN" pad="9"/>
+<connect gate="G$1" pin="IO0" pad="23"/>
+<connect gate="G$1" pin="IO12" pad="18"/>
+<connect gate="G$1" pin="IO13" pad="20"/>
+<connect gate="G$1" pin="IO14" pad="17"/>
+<connect gate="G$1" pin="IO15" pad="21"/>
+<connect gate="G$1" pin="IO16" pad="25"/>
+<connect gate="G$1" pin="IO17" pad="27"/>
+<connect gate="G$1" pin="IO18" pad="35"/>
+<connect gate="G$1" pin="IO19" pad="38"/>
+<connect gate="G$1" pin="IO2" pad="22"/>
+<connect gate="G$1" pin="IO21" pad="42"/>
+<connect gate="G$1" pin="IO22" pad="39"/>
+<connect gate="G$1" pin="IO23" pad="36"/>
+<connect gate="G$1" pin="IO25" pad="14"/>
+<connect gate="G$1" pin="IO26" pad="15"/>
+<connect gate="G$1" pin="IO27" pad="16"/>
+<connect gate="G$1" pin="IO32" pad="12"/>
+<connect gate="G$1" pin="IO33" pad="13"/>
+<connect gate="G$1" pin="IO34" pad="10"/>
+<connect gate="G$1" pin="IO35" pad="11"/>
+<connect gate="G$1" pin="IO4" pad="24"/>
+<connect gate="G$1" pin="IO5" pad="34"/>
+<connect gate="G$1" pin="LNA_IN" pad="2"/>
+<connect gate="G$1" pin="SD0" pad="32"/>
+<connect gate="G$1" pin="SD1" pad="33"/>
+<connect gate="G$1" pin="SD2" pad="28"/>
+<connect gate="G$1" pin="SD3" pad="29"/>
+<connect gate="G$1" pin="SENSOR_CAPN" pad="7"/>
+<connect gate="G$1" pin="SENSOR_CAPP" pad="6"/>
+<connect gate="G$1" pin="SENSOR_VN" pad="8"/>
+<connect gate="G$1" pin="SENSOR_VP" pad="5"/>
+<connect gate="G$1" pin="U0RXD" pad="40"/>
+<connect gate="G$1" pin="U0TXD" pad="41"/>
+<connect gate="G$1" pin="VDD3P3_CPU" pad="37"/>
+<connect gate="G$1" pin="VDD3P3_RTC" pad="19"/>
+<connect gate="G$1" pin="VDDA" pad="1"/>
+<connect gate="G$1" pin="VDDA3P3_1" pad="3"/>
+<connect gate="G$1" pin="VDDA_2" pad="43"/>
+<connect gate="G$1" pin="VDDA_3" pad="46"/>
+<connect gate="G$1" pin="VDDA_3P3" pad="4"/>
+<connect gate="G$1" pin="VDD_SDIO_NC" pad="26"/>
+<connect gate="G$1" pin="XTAL_N_NC" pad="44"/>
+<connect gate="G$1" pin="XTAL_P_NC" pad="45"/>
+<connect gate="G$2" pin="GNDPAD" pad="EXP"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="FRAME_A4_TINYPICO">
+<description>Frame A4</description>
+<gates>
+<gate name="G$1" symbol="FRAME_A4_TINYPICO" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="47219-2001">
+<packages>
+<package name="MOLEX_47219-2001">
+<wire x1="-6.8" y1="-7.25" x2="6.8" y2="-7.25" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="7.25" x2="6.8" y2="7.25" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="7.2" x2="-6.8" y2="4.8" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="-5.9" x2="-6.8" y2="-3.5" width="0.127" layer="51"/>
+<wire x1="-6.8" y1="2.3" x2="-6.8" y2="4.8" width="0.127" layer="51"/>
+<wire x1="6.8" y1="7.2" x2="6.8" y2="4.8" width="0.127" layer="21"/>
+<wire x1="6.8" y1="4.8" x2="6.8" y2="-5.9" width="0.127" layer="51"/>
+<wire x1="-6" y1="-7.2" x2="-6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="6" y1="-7.2" x2="6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="-6" y1="-6.5" x2="-4.3" y2="-5.5" width="0.127" layer="21"/>
+<wire x1="-4.3" y1="-5.5" x2="-1.9" y2="-4.9" width="0.127" layer="21"/>
+<wire x1="-1.9" y1="-4.9" x2="1.6" y2="-4.9" width="0.127" layer="21"/>
+<wire x1="1.6" y1="-4.9" x2="4.2" y2="-5.5" width="0.127" layer="21"/>
+<wire x1="4.2" y1="-5.5" x2="6" y2="-6.5" width="0.127" layer="21"/>
+<wire x1="-6.8" y1="4.8" x2="6.8" y2="4.8" width="0.127" layer="21"/>
+<text x="-8.20976875" y="-6.10726875" size="1.271509375" layer="25" rot="R90">&gt;NAME</text>
+<text x="9.252459375" y="-5.75153125" size="1.270340625" layer="27" rot="R90">&gt;VALUE</text>
+<wire x1="-7.9" y1="7.6" x2="7.9" y2="7.6" width="0.127" layer="39"/>
+<wire x1="7.9" y1="7.6" x2="7.9" y2="-7.6" width="0.127" layer="39"/>
+<wire x1="7.9" y1="-7.6" x2="-7.9" y2="-7.6" width="0.127" layer="39"/>
+<wire x1="-7.9" y1="-7.6" x2="-7.9" y2="7.6" width="0.127" layer="39"/>
+<smd name="1" x="3.2" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="2" x="2.1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="3" x="1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="4" x="-0.1" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="5" x="-1.2" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="6" x="-2.3" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="7" x="-3.4" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="8" x="-4.5" y="-2.1" dx="0.8" dy="1.5" layer="1"/>
+<smd name="G1" x="6.875" y="-4.7" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G2" x="6.875" y="3.6" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G3" x="-6.875" y="3.6" dx="1.5" dy="2.05" layer="1"/>
+<smd name="G4" x="-6.875" y="-4.7" dx="1.5" dy="2.05" layer="1"/>
+</package>
+</packages>
+<symbols>
+<symbol name="47219-2001">
+<wire x1="-12.7" y1="10.16" x2="-12.7" y2="-10.16" width="0.254" layer="94"/>
+<wire x1="-12.7" y1="-10.16" x2="12.7" y2="-10.16" width="0.254" layer="94"/>
+<wire x1="12.7" y1="-10.16" x2="12.7" y2="10.16" width="0.254" layer="94"/>
+<wire x1="12.7" y1="10.16" x2="-12.7" y2="10.16" width="0.254" layer="94"/>
+<text x="-12.7105" y="10.931" size="1.27105" layer="95">&gt;NAME</text>
+<text x="-12.7125" y="-11.9498" size="1.27125" layer="95">&gt;VALUE</text>
+<pin name="DAT2" x="-17.78" y="-5.08" length="middle"/>
+<pin name="CD/DAT3" x="-17.78" y="-7.62" length="middle"/>
+<pin name="CMD" x="-17.78" y="2.54" length="middle"/>
+<pin name="VDD" x="17.78" y="7.62" length="middle" direction="pwr" rot="R180"/>
+<pin name="CLK" x="-17.78" y="7.62" length="middle" direction="in" function="clk"/>
+<pin name="VSS" x="17.78" y="-7.62" length="middle" direction="pwr" rot="R180"/>
+<pin name="DAT0" x="-17.78" y="0" length="middle"/>
+<pin name="DAT1" x="-17.78" y="-2.54" length="middle"/>
+<pin name="GND@1" x="17.78" y="2.54" length="middle" direction="pwr" rot="R180"/>
+<pin name="GND@2" x="17.78" y="0" length="middle" direction="pwr" rot="R180"/>
+<pin name="GND@3" x="17.78" y="-2.54" length="middle" direction="pwr" rot="R180"/>
+<pin name="GND@4" x="17.78" y="-5.08" length="middle" direction="pwr" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="47219-2001" prefix="J">
+<description>&lt;b&gt;1.10mm Pitch microSD Card Connector, Hinge Type, Lead-Free&lt;/b&gt;&lt;p&gt;http://www.snapeda.com/parts/47219-2001/Molex%20/%20Waldom/view-part/# &lt;a href="https://pricing.snapeda.com/parts/47219-2001/Molex/view-part?ref=eda"&gt;Check prices&lt;/a&gt;</description>
+<gates>
+<gate name="G$1" symbol="47219-2001" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="MOLEX_47219-2001">
+<connects>
+<connect gate="G$1" pin="CD/DAT3" pad="2"/>
+<connect gate="G$1" pin="CLK" pad="5"/>
+<connect gate="G$1" pin="CMD" pad="3"/>
+<connect gate="G$1" pin="DAT0" pad="7"/>
+<connect gate="G$1" pin="DAT1" pad="8"/>
+<connect gate="G$1" pin="DAT2" pad="1"/>
+<connect gate="G$1" pin="GND@1" pad="G1"/>
+<connect gate="G$1" pin="GND@2" pad="G2"/>
+<connect gate="G$1" pin="GND@3" pad="G3"/>
+<connect gate="G$1" pin="GND@4" pad="G4"/>
+<connect gate="G$1" pin="VDD" pad="4"/>
+<connect gate="G$1" pin="VSS" pad="6"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="AVAILABILITY" value="In Stock"/>
+<attribute name="DESCRIPTION" value=" 8 Position Card Connector Secure Digital - microSD™ Surface Mount, Right Angle Gold "/>
+<attribute name="MF" value="Molex"/>
+<attribute name="MP" value="47219-2001"/>
+<attribute name="PACKAGE" value="None"/>
+<attribute name="PRICE" value="None"/>
+<attribute name="PURCHASE-URL" value="https://pricing.snapeda.com/search/part/47219-2001/?ref=eda"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="adafruit" urn="urn:adsk.eagle:library:420">
+<packages>
+<package name="1X08-CLEANBIG" urn="urn:adsk.eagle:footprint:6240062/1" library_version="2">
+<pad name="1" x="-8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="2" x="-6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="3" x="-3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="4" x="-1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="5" x="1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="6" x="3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="7" x="6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="8" x="8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<text x="-10.2362" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-10.16" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="6.096" y1="-0.254" x2="6.604" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="-6.604" y1="-0.254" x2="-6.096" y2="0.254" layer="51"/>
+<rectangle x1="-9.144" y1="-0.254" x2="-8.636" y2="0.254" layer="51"/>
+<rectangle x1="8.636" y1="-0.254" x2="9.144" y2="0.254" layer="51"/>
+</package>
+<package name="1X08-BIG" urn="urn:adsk.eagle:footprint:6240061/1" library_version="2">
+<wire x1="-10.16" y1="1.27" x2="10.16" y2="1.27" width="0.127" layer="21"/>
+<wire x1="10.16" y1="1.27" x2="10.16" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="10.16" y1="-1.27" x2="-10.16" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="-10.16" y1="-1.27" x2="-10.16" y2="1.27" width="0.127" layer="21"/>
+<pad name="1" x="-8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="2" x="-6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="3" x="-3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="4" x="-1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="5" x="1.27" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="6" x="3.81" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="7" x="6.35" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="8" x="8.89" y="0" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<text x="-10.2362" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-10.16" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="6.096" y1="-0.254" x2="6.604" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="-6.604" y1="-0.254" x2="-6.096" y2="0.254" layer="51"/>
+<rectangle x1="-9.144" y1="-0.254" x2="-8.636" y2="0.254" layer="51"/>
+<rectangle x1="8.636" y1="-0.254" x2="9.144" y2="0.254" layer="51"/>
+</package>
+<package name="1X08-LOCK" urn="urn:adsk.eagle:footprint:6240063/1" library_version="2">
+<wire x1="-10.16" y1="1.27" x2="10.16" y2="1.27" width="0.127" layer="21"/>
+<wire x1="10.16" y1="1.27" x2="10.16" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="10.16" y1="-1.27" x2="-10.16" y2="-1.27" width="0.127" layer="21"/>
+<wire x1="-10.16" y1="-1.27" x2="-10.16" y2="1.27" width="0.127" layer="21"/>
+<pad name="1" x="-8.89" y="0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="2" x="-6.35" y="-0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="3" x="-3.81" y="0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="4" x="-1.27" y="-0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="5" x="1.27" y="0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="6" x="3.81" y="-0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="7" x="6.35" y="0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<pad name="8" x="8.89" y="-0.127" drill="1.016" diameter="1.778" shape="octagon" rot="R90"/>
+<text x="-10.2362" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-10.16" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="6.096" y1="-0.254" x2="6.604" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="-6.604" y1="-0.254" x2="-6.096" y2="0.254" layer="51"/>
+<rectangle x1="-9.144" y1="-0.254" x2="-8.636" y2="0.254" layer="51"/>
+<rectangle x1="8.636" y1="-0.254" x2="9.144" y2="0.254" layer="51"/>
+</package>
+<package name="1X08-3.5MM" urn="urn:adsk.eagle:footprint:6240172/1" library_version="2">
+<wire x1="-14" y1="3.4" x2="-14" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="-14" y1="-2.5" x2="-14" y2="-3.6" width="0.127" layer="21"/>
+<wire x1="-14" y1="-3.6" x2="14" y2="-3.6" width="0.127" layer="21"/>
+<wire x1="14" y1="-3.6" x2="14" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="14" y1="-2.5" x2="14" y2="3.4" width="0.127" layer="21"/>
+<wire x1="14" y1="3.4" x2="-14" y2="3.4" width="0.127" layer="21"/>
+<wire x1="-14" y1="-2.5" x2="14" y2="-2.5" width="0.127" layer="21"/>
+<pad name="5" x="1.75" y="0" drill="1" diameter="2.1844"/>
+<pad name="4" x="-1.75" y="0" drill="1" diameter="2.1844"/>
+<pad name="3" x="-5.25" y="0" drill="1" diameter="2.1844"/>
+<pad name="2" x="-8.75" y="0" drill="1" diameter="2.1844"/>
+<pad name="1" x="-12.25" y="0" drill="1" diameter="2.1844"/>
+<pad name="6" x="5.25" y="0" drill="1" diameter="2.1844"/>
+<pad name="7" x="8.75" y="0" drill="1" diameter="2.1844"/>
+<pad name="8" x="12.25" y="0" drill="1" diameter="2.1844"/>
+<text x="13.12" y="-5.81" size="1.27" layer="25" rot="R180">&gt;NAME</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="1X08-CLEANBIG" urn="urn:adsk.eagle:package:6240708/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="1X08-CLEANBIG"/>
+</packageinstances>
+</package3d>
+<package3d name="1X08-BIG" urn="urn:adsk.eagle:package:6240707/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="1X08-BIG"/>
+</packageinstances>
+</package3d>
+<package3d name="1X08-LOCK" urn="urn:adsk.eagle:package:6240709/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="1X08-LOCK"/>
+</packageinstances>
+</package3d>
+<package3d name="1X08-3.5MM" urn="urn:adsk.eagle:package:6240817/1" type="box" library_version="2">
+<packageinstances>
+<packageinstance name="1X08-3.5MM"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="PINHD8" urn="urn:adsk.eagle:symbol:6239535/1" library_version="2">
+<wire x1="-6.35" y1="-12.7" x2="1.27" y2="-12.7" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-12.7" x2="1.27" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="10.16" x2="-6.35" y2="10.16" width="0.4064" layer="94"/>
+<wire x1="-6.35" y1="10.16" x2="-6.35" y2="-12.7" width="0.4064" layer="94"/>
+<text x="-6.35" y="10.795" size="1.778" layer="95">&gt;NAME</text>
+<text x="-6.35" y="-15.24" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="1" x="-2.54" y="7.62" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="2" x="-2.54" y="5.08" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="3" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="4" x="-2.54" y="0" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="5" x="-2.54" y="-2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="6" x="-2.54" y="-5.08" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="7" x="-2.54" y="-7.62" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="8" x="-2.54" y="-10.16" visible="pad" length="short" direction="pas" function="dot"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PINHD-1X8" urn="urn:adsk.eagle:component:6241024/1" prefix="JP" uservalue="yes" library_version="2">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="PINHD8" x="0" y="0"/>
+</gates>
+<devices>
+<device name="CLEANBIG" package="1X08-CLEANBIG">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240708/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="BIG" package="1X08-BIG">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240707/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="LOCK" package="1X08-LOCK">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240709/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="-3.5MM" package="1X08-3.5MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:6240817/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="SparkFun-RF" urn="urn:adsk.eagle:library:531">
+<description>&lt;h3&gt;SparkFun RF, WiFi, Cellular, and Bluetooth&lt;/h3&gt;
+In this library you'll find things that send or receive RF-- cellular modules, Bluetooth, WiFi, etc.
+&lt;br&gt;
+&lt;br&gt;
+We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
+&lt;br&gt;
+&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
+&lt;br&gt;
+&lt;br&gt;
+&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
+&lt;br&gt;
+&lt;br&gt;
+You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<packages>
+<package name="TRACE_ANTENNA_2.4GHZ_25.7MM" urn="urn:adsk.eagle:footprint:39531/1" library_version="1">
+<description>&lt;h3&gt;2.4GHz Inverted F PCB Trace Antenna&lt;/h3&gt;
+&lt;p&gt;PCB trace antenna with a 25.7 x 7.5 mm footprint.&lt;/p&gt;
+&lt;p&gt;Based on layout from &lt;a href="http://www.ti.com/lit/an/swru120b/swru120b.pdf"&gt;TI design note DN0007&lt;/a&gt;.&lt;/p&gt;</description>
+<polygon width="0.002540625" layer="1">
+<vertex x="-0.23" y="0"/>
+<vertex x="-0.23" y="2.28"/>
+<vertex x="-0.73" y="2.69"/>
+<vertex x="-3.88" y="2.69"/>
+<vertex x="-3.88" y="3.9"/>
+<vertex x="-2.88" y="3.9"/>
+<vertex x="-2.88" y="4.7"/>
+<vertex x="-8.68" y="4.7"/>
+<vertex x="-8.68" y="2.03"/>
+<vertex x="-0.68" y="2.03"/>
+<vertex x="-0.68" y="0"/>
+<vertex x="-1.68" y="0"/>
+<vertex x="-1.68" y="0.7"/>
+<vertex x="-2.88" y="0.7"/>
+<vertex x="-2.88" y="0"/>
+<vertex x="-3.88" y="0"/>
+<vertex x="-3.88" y="0.74"/>
+<vertex x="-10.86" y="0.74"/>
+<vertex x="-10.86" y="6.91"/>
+<vertex x="14.72" y="6.91"/>
+<vertex x="14.72" y="5.7"/>
+<vertex x="-1.68" y="5.7"/>
+<vertex x="-1.68" y="3.9"/>
+<vertex x="-0.68" y="3.9"/>
+<vertex x="-0.68" y="3.29"/>
+<vertex x="0.23" y="2.53"/>
+<vertex x="0.23" y="0"/>
+</polygon>
+<smd name="ANT" x="0" y="0.23" dx="0.46" dy="0.46" layer="1" stop="no" thermals="no" cream="no"/>
+<smd name="GND" x="-1.18" y="0.23" dx="1" dy="0.46" layer="1" stop="no" thermals="no" cream="no"/>
+<smd name="GND2" x="-3.38" y="0.23" dx="1" dy="0.46" layer="1" stop="no" thermals="no" cream="no"/>
+<wire x1="-0.68" y1="0" x2="-11" y2="0" width="0.1" layer="51"/>
+<wire x1="-0.68" y1="-2" x2="-0.68" y2="0" width="0.1" layer="51"/>
+<wire x1="0.68" y1="0" x2="0.68" y2="-2" width="0.1" layer="51"/>
+<wire x1="0.68" y1="0" x2="14.75" y2="0" width="0.1" layer="51"/>
+<wire x1="-11" y1="7.52" x2="14.75" y2="7.52" width="0.1" layer="51"/>
+<text x="-11.049" y="-1.397" size="0.889" layer="51" font="vector">Ground Plane</text>
+<text x="2.921" y="-1.397" size="0.889" layer="51" font="vector">Ground Plane</text>
+<text x="-4.449" y="7.703" size="0.889" layer="51" font="vector">Board edge</text>
+<text x="3.81" y="4.445" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="3.81" y="3.81" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+</package>
+<package name="TRACE_ANTENNA_2.4GHZ_15.2MM" urn="urn:adsk.eagle:footprint:39532/1" library_version="1">
+<description>&lt;h3&gt;2.4GHz Meander PCB Trace Antenna&lt;/h3&gt;
+&lt;p&gt;PCB trace antenna with a 15.2 x 5.7mm footprint.&lt;/p&gt;
+&lt;p&gt;Based on layout from &lt;a href="http://www.ti.com/lit/an/swra117d/swra117d.pdf"&gt;TI app note AN043&lt;/a&gt;.&lt;/p&gt;</description>
+<polygon width="0.002540625" layer="1">
+<vertex x="-0.25" y="-0.5"/>
+<vertex x="-0.25" y="4.4"/>
+<vertex x="-1.65" y="4.4"/>
+<vertex x="-1.65" y="-0.5"/>
+<vertex x="-2.55" y="-0.5"/>
+<vertex x="-2.55" y="4.9"/>
+<vertex x="2.45" y="4.9"/>
+<vertex x="2.45" y="2.26"/>
+<vertex x="4.45" y="2.26"/>
+<vertex x="4.45" y="4.9"/>
+<vertex x="7.15" y="4.9"/>
+<vertex x="7.15" y="2.26"/>
+<vertex x="9.15" y="2.26"/>
+<vertex x="9.15" y="4.9"/>
+<vertex x="11.85" y="4.9"/>
+<vertex x="11.85" y="0.46"/>
+<vertex x="11.35" y="0.46"/>
+<vertex x="11.35" y="4.4"/>
+<vertex x="9.65" y="4.4"/>
+<vertex x="9.65" y="1.76"/>
+<vertex x="6.65" y="1.76"/>
+<vertex x="6.65" y="4.4"/>
+<vertex x="4.95" y="4.4"/>
+<vertex x="4.95" y="1.76"/>
+<vertex x="1.95" y="1.76"/>
+<vertex x="1.95" y="4.4"/>
+<vertex x="0.25" y="4.4"/>
+<vertex x="0.25" y="-0.5"/>
+</polygon>
+<wire x1="-3" y1="0" x2="12" y2="0" width="0.05" layer="51"/>
+<wire x1="-3" y1="5.2" x2="12" y2="5.2" width="0.05" layer="51"/>
+<smd name="GND" x="-2.1" y="-0.25" dx="0.9" dy="0.5" layer="1" stop="no" thermals="no" cream="no"/>
+<smd name="ANT" x="0" y="-0.25" dx="0.5" dy="0.5" layer="1" stop="no" thermals="no" cream="no"/>
+<text x="1" y="-0.8" size="0.64" layer="51" font="vector">Ground Plane</text>
+<text x="1.5" y="5.5" size="0.64" layer="51" font="vector">Board Edge</text>
+<text x="0" y="1.27" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="TRACE_ANTENNA_2.4GHZ_25.7MM" urn="urn:adsk.eagle:package:39574/1" type="box" library_version="1">
+<description>2.4GHz Inverted F PCB Trace Antenna
+PCB trace antenna with a 25.7 x 7.5 mm footprint.
+Based on layout from TI design note DN0007.</description>
+<packageinstances>
+<packageinstance name="TRACE_ANTENNA_2.4GHZ_25.7MM"/>
+</packageinstances>
+</package3d>
+<package3d name="TRACE_ANTENNA_2.4GHZ_15.2MM" urn="urn:adsk.eagle:package:39575/1" type="box" library_version="1">
+<description>2.4GHz Meander PCB Trace Antenna
+PCB trace antenna with a 15.2 x 5.7mm footprint.
+Based on layout from TI app note AN043.</description>
+<packageinstances>
+<packageinstance name="TRACE_ANTENNA_2.4GHZ_15.2MM"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="ANTENNA-GROUNDED" urn="urn:adsk.eagle:symbol:39530/1" library_version="1">
+<description>&lt;h3&gt;Antenna (with ground termination)&lt;/h3&gt;</description>
+<wire x1="0" y1="-2.54" x2="0" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="-2.54" y1="0" x2="2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="-2.54" y2="0" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-5.08" x2="2.54" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="2.54" y2="-5.08" width="0.254" layer="94"/>
+<circle x="0" y="-5.08" radius="1.1359" width="0.254" layer="94"/>
+<text x="3.048" y="-5.08" size="1.778" layer="95" font="vector">&gt;NAME</text>
+<text x="3.048" y="-7.366" size="1.778" layer="96" font="vector">&gt;VALUE</text>
+<pin name="GND" x="2.54" y="-10.16" visible="off" length="short" rot="R90"/>
+<pin name="SIGNAL" x="0" y="-10.16" visible="off" length="short" rot="R90"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="ANTENNA-GROUNDED" urn="urn:adsk.eagle:component:39611/1" prefix="E" library_version="1">
+<description>&lt;h3&gt;Antenna w/ Ground Connection&lt;/h3&gt;
+&lt;p&gt;2.4GHz antennae with signal and ground terminals.&lt;/p&gt;
+&lt;p&gt;&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;TRACE_ANTENNA_2.4GHZ_15.2MM&lt;/b&gt; - Meander Trace antenna
+&lt;ul&gt;&lt;li&gt;15.2 x 5.7mm footprint&lt;/li&gt;
+&lt;li&gt;Based on layout from &lt;a href="http://www.ti.com/lit/an/swra117d/swra117d.pdf"&gt;TI app note AN043&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;
+&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;TRACE_ANTENNA_2.4GHZ_25.7MM&lt;/b&gt; - Inverted F trace antenna
+&lt;ul&gt;&lt;li&gt;25.7 x 7.5 mm footprint.&lt;/li&gt;
+&lt;li&gt;Based on layout from &lt;a href="http://www.ti.com/lit/an/swru120b/swru120b.pdf"&gt;TI design note DN0007&lt;/a&gt;.&lt;/li&gt;&lt;/ul&gt;
+&lt;/li&gt;
+&lt;/ul&gt;&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="ANTENNA-GROUNDED" x="0" y="5.08"/>
+</gates>
+<devices>
+<device name="TRACE-25.7MM" package="TRACE_ANTENNA_2.4GHZ_25.7MM">
+<connects>
+<connect gate="G$1" pin="GND" pad="GND GND2"/>
+<connect gate="G$1" pin="SIGNAL" pad="ANT"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39574/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="TRACE-15.2MM" package="TRACE_ANTENNA_2.4GHZ_15.2MM">
+<connects>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="SIGNAL" pad="ANT"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39575/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+</libraries>
+<attributes>
+<attribute name="DATE" value="22-04-2019"/>
+<attribute name="REV" value="V1 P3"/>
+<attribute name="TITLE" value="TinyPICO"/>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0" drill="0">
+</class>
+<class number="1" name="power" width="0.4064" drill="0">
+</class>
+</classes>
+<parts>
+<part name="FRAME2" library="UnexpectedMaker" deviceset="FRAME_A4_TINYPICO" device="">
+<attribute name="CDATE" value="24/04/2019"/>
+<attribute name="REV" value="V1 P3"/>
+<attribute name="SHEET_NUM" value="1/1"/>
+<attribute name="TITLE" value="TinyPICO"/>
+</part>
+<part name="U$2" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="R4" library="microbuilder" deviceset="RESISTOR" device="_0402MP" value="10K"/>
+<part name="U$5" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="PICO-D4" library="UnexpectedMaker" deviceset="ESP32-PICO-D4" device=""/>
+<part name="U$4" library="microbuilder" deviceset="GND" device=""/>
+<part name="U$13" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="U$9" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="U$14" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="C1" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="0.1uF"/>
+<part name="U$7" library="microbuilder" deviceset="GND" device=""/>
+<part name="C2" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="0.1uF"/>
+<part name="U$15" library="microbuilder" deviceset="GND" device=""/>
+<part name="U$19" library="microbuilder" deviceset="GND" device=""/>
+<part name="U$21" library="microbuilder" deviceset="GND" device=""/>
+<part name="C5" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="1.5pF"/>
+<part name="R6" library="microbuilder" deviceset="RESISTOR" device="_0402MP" value="442K"/>
+<part name="R7" library="microbuilder" deviceset="RESISTOR" device="_0402MP" value="160K"/>
+<part name="GND13" library="supply1" deviceset="GND" device=""/>
+<part name="U$34" library="microbuilder" deviceset="GND" device=""/>
+<part name="LY68L6400SLIT" library="UnexpectedMaker" deviceset="PSRAM" device="" package3d_urn="urn:adsk.eagle:package:26262/1" technology="0"/>
+<part name="GND1" library="supply1" deviceset="GND" device=""/>
+<part name="C6" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="0.1uF"/>
+<part name="U$17" library="microbuilder" deviceset="GND" device=""/>
+<part name="L1" library="Nordic_nRF" library_urn="urn:adsk.eagle:library:169009" deviceset="INDUCTOR" device="_0402_N" package3d_urn="urn:adsk.eagle:package:2593732/1" value="7.5nH"/>
+<part name="C4" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="0.75pF"/>
+<part name="J2" library="47219-2001" deviceset="47219-2001" device=""/>
+<part name="JP2" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="PINHD-1X8" device="CLEANBIG" package3d_urn="urn:adsk.eagle:package:6240708/1" override_package3d_urn="urn:adsk.eagle:package:21520910/2" override_package_urn="urn:adsk.eagle:footprint:6240062/1">
+<attribute name="BOTTOM" value="1"/>
+<attribute name="MPN" value="83-15410"/>
+<attribute name="THRU-HOLE" value="1"/>
+</part>
+<part name="JP1" library="adafruit" library_urn="urn:adsk.eagle:library:420" deviceset="PINHD-1X8" device="CLEANBIG" package3d_urn="urn:adsk.eagle:package:6240708/1" override_package3d_urn="urn:adsk.eagle:package:21520912/2" override_package_urn="urn:adsk.eagle:footprint:6240062/1">
+<attribute name="BOTTOM" value="1"/>
+<attribute name="MPN" value="83-15410"/>
+<attribute name="THRU-HOLE" value="1"/>
+</part>
+<part name="U$1" library="microbuilder" deviceset="GND" device=""/>
+<part name="U$3" library="microbuilder" deviceset="3.3V" device=""/>
+<part name="C3" library="microbuilder" deviceset="CAP_CERAMIC" device="_0402MP" value="10uF"/>
+<part name="E1" library="SparkFun-RF" library_urn="urn:adsk.eagle:library:531" deviceset="ANTENNA-GROUNDED" device="TRACE-15.2MM" package3d_urn="urn:adsk.eagle:package:39575/1"/>
+</parts>
+<sheets>
+<sheet>
+<plain>
+<text x="5.842" y="178.308" size="1.778" layer="94">USB, POWER PATHS, CHARGING AND FILTERING</text>
+<wire x1="5.08" y1="109.22" x2="137.16" y2="109.22" width="0.1524" layer="94" style="shortdash"/>
+<wire x1="137.16" y1="109.22" x2="170.18" y2="109.22" width="0.1524" layer="94" style="shortdash"/>
+<wire x1="185.42" y1="109.22" x2="185.42" y2="182.88" width="0.1524" layer="94" style="shortdash"/>
+<wire x1="256.54" y1="109.22" x2="185.42" y2="109.22" width="0.1524" layer="94" style="shortdash"/>
+<text x="40.64" y="104.14" size="1.778" layer="94">PICO-D4</text>
+<wire x1="170.18" y1="109.22" x2="185.42" y2="109.22" width="0.1524" layer="94" style="shortdash"/>
+<wire x1="137.16" y1="109.22" x2="137.16" y2="182.88" width="0.1524" layer="94" style="shortdash"/>
+<wire x1="170.18" y1="40.64" x2="170.18" y2="109.22" width="0.1524" layer="94" style="shortdash"/>
+<text x="205.74" y="76.2" size="1.778" layer="94">PSRAM</text>
+</plain>
+<instances>
+<instance part="FRAME2" gate="G$1" x="0" y="0" smashed="yes">
+<attribute name="TITLE" x="182.88" y="15.24" size="2.54" layer="94" font="vector"/>
+<attribute name="REV" x="243.84" y="15.24" size="2.54" layer="94" font="vector"/>
+<attribute name="SHEET_NUM" x="182.88" y="5.21" size="2.54" layer="94" font="vector"/>
+<attribute name="CDATE" x="171.45" y="10.16" size="2.286" layer="94" font="vector"/>
+</instance>
+<instance part="U$2" gate="G$1" x="38.1" y="76.2" smashed="yes">
+<attribute name="VALUE" x="36.576" y="77.216" size="1.27" layer="96"/>
+</instance>
+<instance part="R4" gate="G$1" x="180.34" y="127" smashed="yes" rot="R90">
+<attribute name="NAME" x="177.8" y="127" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="180.34" y="127" size="1.016" layer="96" font="vector" ratio="15" rot="R90" align="center"/>
+</instance>
+<instance part="U$5" gate="G$1" x="180.34" y="134.62" smashed="yes">
+<attribute name="VALUE" x="178.816" y="135.636" size="1.27" layer="96"/>
+</instance>
+<instance part="PICO-D4" gate="G$1" x="76.2" y="53.34" smashed="yes">
+<attribute name="NAME" x="53.34" y="33.02" size="1.27" layer="95"/>
+<attribute name="VALUE" x="53.34" y="30.48" size="1.27" layer="95"/>
+</instance>
+<instance part="PICO-D4" gate="G$2" x="114.3" y="25.4" smashed="yes"/>
+<instance part="U$4" gate="G$1" x="114.3" y="17.78" smashed="yes">
+<attribute name="VALUE" x="112.776" y="15.24" size="1.27" layer="96"/>
+</instance>
+<instance part="U$13" gate="G$1" x="10.16" y="58.42" smashed="yes" rot="R90">
+<attribute name="VALUE" x="9.144" y="56.896" size="1.27" layer="96" rot="R90"/>
+</instance>
+<instance part="U$9" gate="G$1" x="68.58" y="99.06" smashed="yes">
+<attribute name="VALUE" x="67.056" y="100.076" size="1.27" layer="96"/>
+</instance>
+<instance part="U$14" gate="G$1" x="83.82" y="12.7" smashed="yes" rot="R180">
+<attribute name="VALUE" x="85.344" y="11.684" size="1.27" layer="96" rot="R180"/>
+</instance>
+<instance part="C1" gate="G$1" x="22.86" y="45.72" smashed="yes">
+<attribute name="NAME" x="20.57" y="46.97" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="25.16" y="46.97" size="1.27" layer="96" font="vector" rot="R90" align="center"/>
+</instance>
+<instance part="U$7" gate="G$1" x="22.86" y="38.1" smashed="yes">
+<attribute name="VALUE" x="21.336" y="35.56" size="1.27" layer="96"/>
+</instance>
+<instance part="C2" gate="G$1" x="27.94" y="35.56" smashed="yes">
+<attribute name="NAME" x="25.65" y="36.81" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="30.24" y="36.81" size="1.27" layer="96" font="vector" rot="R90" align="center"/>
+</instance>
+<instance part="U$15" gate="G$1" x="27.94" y="27.94" smashed="yes">
+<attribute name="VALUE" x="26.416" y="25.4" size="1.27" layer="96"/>
+</instance>
+<instance part="U$19" gate="G$1" x="20.32" y="91.44" smashed="yes" rot="R180">
+<attribute name="VALUE" x="21.844" y="93.98" size="1.27" layer="96" rot="R180"/>
+</instance>
+<instance part="U$21" gate="G$1" x="30.48" y="86.36" smashed="yes" rot="R180">
+<attribute name="VALUE" x="32.004" y="88.9" size="1.27" layer="96" rot="R180"/>
+</instance>
+<instance part="C5" gate="G$1" x="22.86" y="63.5" smashed="yes" rot="R270">
+<attribute name="NAME" x="24.11" y="65.79" size="1.27" layer="95" font="vector" align="center"/>
+<attribute name="VALUE" x="24.11" y="61.2" size="1.27" layer="96" font="vector" align="center"/>
+</instance>
+<instance part="R6" gate="G$1" x="160.02" y="132.08" smashed="yes" rot="R270">
+<attribute name="NAME" x="162.56" y="132.08" size="1.27" layer="95" font="vector" rot="R270" align="center"/>
+<attribute name="VALUE" x="160.02" y="132.08" size="1.016" layer="96" font="vector" ratio="15" rot="R270" align="center"/>
+</instance>
+<instance part="R7" gate="G$1" x="160.02" y="121.92" smashed="yes" rot="R270">
+<attribute name="NAME" x="162.56" y="121.92" size="1.27" layer="95" font="vector" rot="R270" align="center"/>
+<attribute name="VALUE" x="160.02" y="121.92" size="1.016" layer="96" font="vector" ratio="15" rot="R270" align="center"/>
+</instance>
+<instance part="GND13" gate="1" x="160.02" y="114.3" smashed="yes">
+<attribute name="VALUE" x="157.48" y="111.76" size="1.778" layer="96"/>
+</instance>
+<instance part="U$34" gate="G$1" x="12.7" y="71.12" smashed="yes">
+<attribute name="VALUE" x="11.176" y="68.58" size="1.27" layer="96"/>
+</instance>
+<instance part="LY68L6400SLIT" gate="P" x="195.58" y="91.44" smashed="yes">
+<attribute name="NAME" x="187.96" y="102.87" size="1.778" layer="95"/>
+<attribute name="VALUE" x="187.96" y="78.74" size="1.778" layer="96"/>
+</instance>
+<instance part="GND1" gate="1" x="185.42" y="76.2" smashed="yes" rot="MR0">
+<attribute name="VALUE" x="187.96" y="73.66" size="1.778" layer="96" rot="MR0"/>
+</instance>
+<instance part="C6" gate="G$1" x="220.98" y="93.98" smashed="yes">
+<attribute name="NAME" x="218.69" y="95.23" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="223.28" y="95.23" size="1.27" layer="96" font="vector" rot="R90" align="center"/>
+</instance>
+<instance part="U$17" gate="G$1" x="220.98" y="86.36" smashed="yes">
+<attribute name="VALUE" x="219.456" y="83.82" size="1.27" layer="96"/>
+</instance>
+<instance part="L1" gate="L$1" x="20.32" y="76.2" smashed="yes">
+<attribute name="NAME" x="19.05" y="71.12" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="24.13" y="71.12" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="C4" gate="G$1" x="30.48" y="73.66" smashed="yes" rot="R180">
+<attribute name="NAME" x="32.77" y="72.41" size="1.27" layer="95" font="vector" rot="R270" align="center"/>
+<attribute name="VALUE" x="28.18" y="72.41" size="1.27" layer="96" font="vector" rot="R270" align="center"/>
+</instance>
+<instance part="J2" gate="G$1" x="93.98" y="144.78" smashed="yes">
+<attribute name="NAME" x="81.2695" y="155.711" size="1.27105" layer="95"/>
+<attribute name="VALUE" x="81.2675" y="132.8302" size="1.27125" layer="95"/>
+</instance>
+<instance part="JP2" gate="G$1" x="220.98" y="152.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="227.33" y="141.605" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="227.33" y="167.64" size="1.778" layer="96" rot="R180"/>
+<attribute name="MPN" x="220.98" y="152.4" size="1.778" layer="96" rot="R180" display="off"/>
+<attribute name="THRU-HOLE" x="220.98" y="152.4" size="1.778" layer="96" rot="R180" display="off"/>
+<attribute name="BOTTOM" x="220.98" y="152.4" size="1.778" layer="96" rot="R180" display="off"/>
+</instance>
+<instance part="JP1" gate="G$1" x="210.82" y="154.94" smashed="yes">
+<attribute name="NAME" x="204.47" y="165.735" size="1.778" layer="95"/>
+<attribute name="VALUE" x="204.47" y="139.7" size="1.778" layer="96"/>
+<attribute name="MPN" x="210.82" y="154.94" size="1.778" layer="96" display="off"/>
+<attribute name="THRU-HOLE" x="210.82" y="154.94" size="1.778" layer="96" display="off"/>
+<attribute name="BOTTOM" x="210.82" y="154.94" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="U$1" gate="G$1" x="119.38" y="134.62" smashed="yes">
+<attribute name="VALUE" x="117.856" y="132.08" size="1.27" layer="96"/>
+</instance>
+<instance part="U$3" gate="G$1" x="124.46" y="157.48" smashed="yes">
+<attribute name="VALUE" x="122.936" y="158.496" size="1.27" layer="96"/>
+</instance>
+<instance part="C3" gate="G$1" x="124.46" y="147.32" smashed="yes">
+<attribute name="NAME" x="122.17" y="148.57" size="1.27" layer="95" font="vector" rot="R90" align="center"/>
+<attribute name="VALUE" x="126.76" y="148.57" size="1.27" layer="96" font="vector" rot="R90" align="center"/>
+</instance>
+<instance part="E1" gate="G$1" x="15.24" y="93.98" smashed="yes" rot="MR0">
+<attribute name="NAME" x="12.192" y="88.9" size="1.778" layer="95" font="vector" rot="MR0"/>
+<attribute name="VALUE" x="12.192" y="86.614" size="1.778" layer="96" font="vector" rot="MR0"/>
+</instance>
+</instances>
+<busses>
+</busses>
+<nets>
+<net name="GND" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$2" pin="GNDPAD"/>
+<wire x1="114.3" y1="22.86" x2="114.3" y2="20.32" width="0.1524" layer="91"/>
+<pinref part="U$4" gate="G$1" pin="GND"/>
+</segment>
+<segment>
+<pinref part="C1" gate="G$1" pin="2"/>
+<pinref part="U$7" gate="G$1" pin="GND"/>
+<wire x1="22.86" y1="43.18" x2="22.86" y2="40.64" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C2" gate="G$1" pin="2"/>
+<pinref part="U$15" gate="G$1" pin="GND"/>
+<wire x1="27.94" y1="33.02" x2="27.94" y2="30.48" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$19" gate="G$1" pin="GND"/>
+<wire x1="20.32" y1="83.82" x2="20.32" y2="88.9" width="0.1524" layer="91"/>
+<pinref part="L1" gate="L$1" pin="1"/>
+</segment>
+<segment>
+<pinref part="U$21" gate="G$1" pin="GND"/>
+<pinref part="C4" gate="G$1" pin="2"/>
+<wire x1="30.48" y1="76.2" x2="30.48" y2="83.82" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="R7" gate="G$1" pin="2"/>
+<pinref part="GND13" gate="1" pin="GND"/>
+</segment>
+<segment>
+<pinref part="U$34" gate="G$1" pin="GND"/>
+<pinref part="E1" gate="G$1" pin="GND"/>
+<wire x1="12.7" y1="83.82" x2="12.7" y2="73.66" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="GND"/>
+<wire x1="185.42" y1="83.82" x2="185.42" y2="78.74" width="0.1524" layer="91"/>
+<pinref part="GND1" gate="1" pin="GND"/>
+</segment>
+<segment>
+<pinref part="C6" gate="G$1" pin="2"/>
+<pinref part="U$17" gate="G$1" pin="GND"/>
+<wire x1="220.98" y1="91.44" x2="220.98" y2="88.9" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="7"/>
+<wire x1="208.28" y1="147.32" x2="198.12" y2="147.32" width="0.1524" layer="91"/>
+<label x="198.12" y="147.32" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="J2" gate="G$1" pin="GND@4"/>
+<wire x1="111.76" y1="139.7" x2="119.38" y2="139.7" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="GND"/>
+<wire x1="119.38" y1="139.7" x2="119.38" y2="144.78" width="0.1524" layer="91"/>
+<pinref part="J2" gate="G$1" pin="GND@3"/>
+<wire x1="119.38" y1="144.78" x2="119.38" y2="137.16" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="142.24" x2="119.38" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="142.24" x2="119.38" y2="139.7" width="0.1524" layer="91"/>
+<junction x="119.38" y="139.7"/>
+<pinref part="J2" gate="G$1" pin="GND@2"/>
+<wire x1="111.76" y1="144.78" x2="119.38" y2="144.78" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="144.78" x2="119.38" y2="142.24" width="0.1524" layer="91"/>
+<junction x="119.38" y="142.24"/>
+<pinref part="J2" gate="G$1" pin="GND@1"/>
+<wire x1="111.76" y1="147.32" x2="119.38" y2="147.32" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="147.32" x2="119.38" y2="144.78" width="0.1524" layer="91"/>
+<junction x="119.38" y="144.78"/>
+<pinref part="C3" gate="G$1" pin="2"/>
+<wire x1="124.46" y1="144.78" x2="119.38" y2="144.78" width="0.1524" layer="91"/>
+<junction x="119.38" y="144.78"/>
+<pinref part="J2" gate="G$1" pin="VSS"/>
+<wire x1="111.76" y1="137.16" x2="119.38" y2="137.16" width="0.1524" layer="91"/>
+<junction x="119.38" y="137.16"/>
+</segment>
+</net>
+<net name="3.3V" class="0">
+<segment>
+<pinref part="R4" gate="G$1" pin="2"/>
+<pinref part="U$5" gate="G$1" pin="3.3V"/>
+</segment>
+<segment>
+<pinref part="U$2" gate="G$1" pin="3.3V"/>
+<wire x1="38.1" y1="73.66" x2="38.1" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="PICO-D4" gate="G$1" pin="VDDA"/>
+<wire x1="38.1" y1="66.04" x2="43.18" y2="66.04" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="VDDA_3"/>
+<wire x1="60.96" y1="81.28" x2="60.96" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="93.98" x2="68.58" y2="93.98" width="0.1524" layer="91"/>
+<pinref part="PICO-D4" gate="G$1" pin="VDDA_2"/>
+<wire x1="68.58" y1="81.28" x2="68.58" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="93.98" x2="83.82" y2="93.98" width="0.1524" layer="91"/>
+<junction x="68.58" y="93.98"/>
+<pinref part="PICO-D4" gate="G$1" pin="VDD3P3_CPU"/>
+<wire x1="83.82" y1="81.28" x2="83.82" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="68.58" y1="93.98" x2="68.58" y2="96.52" width="0.1524" layer="91"/>
+<pinref part="U$9" gate="G$1" pin="3.3V"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="VDD3P3_RTC"/>
+<wire x1="83.82" y1="25.4" x2="83.82" y2="15.24" width="0.1524" layer="91"/>
+<pinref part="U$14" gate="G$1" pin="3.3V"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="VDDA3P3_1"/>
+<wire x1="43.18" y1="60.96" x2="33.02" y2="60.96" width="0.1524" layer="91"/>
+<pinref part="PICO-D4" gate="G$1" pin="VDDA_3P3"/>
+<wire x1="43.18" y1="58.42" x2="33.02" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="60.96" x2="33.02" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="58.42" x2="22.86" y2="58.42" width="0.1524" layer="91"/>
+<junction x="33.02" y="58.42"/>
+<label x="27.94" y="58.42" size="1.778" layer="95" rot="R180"/>
+<pinref part="U$13" gate="G$1" pin="3.3V"/>
+<pinref part="C1" gate="G$1" pin="1"/>
+<wire x1="22.86" y1="58.42" x2="12.7" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="50.8" x2="22.86" y2="58.42" width="0.1524" layer="91"/>
+<junction x="22.86" y="58.42"/>
+</segment>
+<segment>
+<pinref part="JP2" gate="G$1" pin="1"/>
+<wire x1="223.52" y1="144.78" x2="233.68" y2="144.78" width="0.1524" layer="91"/>
+<label x="233.68" y="144.78" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="U$3" gate="G$1" pin="3.3V"/>
+<pinref part="C3" gate="G$1" pin="1"/>
+<wire x1="124.46" y1="152.4" x2="124.46" y2="154.94" width="0.1524" layer="91"/>
+<pinref part="J2" gate="G$1" pin="VDD"/>
+<wire x1="111.76" y1="152.4" x2="124.46" y2="152.4" width="0.1524" layer="91"/>
+<junction x="124.46" y="152.4"/>
+</segment>
+</net>
+<net name="RESET" class="0">
+<segment>
+<pinref part="R4" gate="G$1" pin="1"/>
+<label x="182.88" y="114.3" size="1.778" layer="95" rot="R90"/>
+<wire x1="180.34" y1="121.92" x2="180.34" y2="111.76" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C2" gate="G$1" pin="1"/>
+<pinref part="PICO-D4" gate="G$1" pin="EN"/>
+<wire x1="43.18" y1="45.72" x2="27.94" y2="45.72" width="0.1524" layer="91"/>
+<label x="33.02" y="45.72" size="1.778" layer="95"/>
+<wire x1="27.94" y1="40.64" x2="27.94" y2="45.72" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="JP2" gate="G$1" pin="8"/>
+<wire x1="223.52" y1="162.56" x2="233.68" y2="162.56" width="0.1524" layer="91"/>
+<label x="233.68" y="162.56" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO0" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO0"/>
+<wire x1="93.98" y1="25.4" x2="93.98" y2="17.78" width="0.1524" layer="91"/>
+<label x="93.98" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="5"/>
+<wire x1="208.28" y1="152.4" x2="198.12" y2="152.4" width="0.1524" layer="91"/>
+<label x="198.12" y="152.4" size="1.778" layer="95" rot="R180"/>
+</segment>
+</net>
+<net name="TXD" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="U0TXD"/>
+<wire x1="73.66" y1="81.28" x2="73.66" y2="88.9" width="0.1524" layer="91"/>
+<label x="73.66" y="83.82" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="1"/>
+<wire x1="208.28" y1="162.56" x2="198.12" y2="162.56" width="0.1524" layer="91"/>
+<label x="198.12" y="162.56" size="1.778" layer="95" rot="R180"/>
+</segment>
+</net>
+<net name="RXD" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="U0RXD"/>
+<wire x1="76.2" y1="81.28" x2="76.2" y2="88.9" width="0.1524" layer="91"/>
+<label x="76.2" y="83.82" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="2"/>
+<wire x1="208.28" y1="160.02" x2="198.12" y2="160.02" width="0.1524" layer="91"/>
+<label x="198.12" y="160.02" size="1.778" layer="95" rot="R180"/>
+</segment>
+</net>
+<net name="GPIO35" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO35"/>
+<wire x1="43.18" y1="40.64" x2="33.02" y2="40.64" width="0.1524" layer="91"/>
+<label x="33.02" y="40.64" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="R6" gate="G$1" pin="2"/>
+<pinref part="R7" gate="G$1" pin="1"/>
+<wire x1="160.02" y1="127" x2="152.4" y2="127" width="0.1524" layer="91"/>
+<junction x="160.02" y="127"/>
+<label x="152.4" y="127" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO32" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO32"/>
+<wire x1="43.18" y1="38.1" x2="33.02" y2="38.1" width="0.1524" layer="91"/>
+<label x="33.02" y="38.1" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO33" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO33"/>
+<wire x1="68.58" y1="25.4" x2="68.58" y2="15.24" width="0.1524" layer="91"/>
+<label x="68.58" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO25" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO25"/>
+<wire x1="71.12" y1="25.4" x2="71.12" y2="15.24" width="0.1524" layer="91"/>
+<label x="71.12" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO26" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO26"/>
+<wire x1="73.66" y1="25.4" x2="73.66" y2="15.24" width="0.1524" layer="91"/>
+<label x="73.66" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO27" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO27"/>
+<wire x1="76.2" y1="25.4" x2="76.2" y2="15.24" width="0.1524" layer="91"/>
+<label x="76.2" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO12" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO12"/>
+<wire x1="81.28" y1="25.4" x2="81.28" y2="15.24" width="0.1524" layer="91"/>
+<label x="81.28" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="3"/>
+<wire x1="208.28" y1="157.48" x2="198.12" y2="157.48" width="0.1524" layer="91"/>
+<label x="198.12" y="157.48" size="1.778" layer="95" rot="R180"/>
+</segment>
+</net>
+<net name="GPIO4" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO4"/>
+<wire x1="96.52" y1="25.4" x2="96.52" y2="15.24" width="0.1524" layer="91"/>
+<label x="96.52" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+<segment>
+<pinref part="JP1" gate="G$1" pin="4"/>
+<wire x1="208.28" y1="154.94" x2="198.12" y2="154.94" width="0.1524" layer="91"/>
+<label x="198.12" y="154.94" size="1.778" layer="95" rot="R180"/>
+</segment>
+</net>
+<net name="GPIO16" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO16"/>
+<wire x1="109.22" y1="43.18" x2="119.38" y2="43.18" width="0.1524" layer="91"/>
+<label x="111.76" y="43.18" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO17" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO17"/>
+<wire x1="109.22" y1="48.26" x2="119.38" y2="48.26" width="0.1524" layer="91"/>
+<label x="111.76" y="48.26" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="SIO1"/>
+<wire x1="185.42" y1="93.98" x2="177.8" y2="93.98" width="0.1524" layer="91"/>
+<label x="177.8" y="93.98" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="CLK" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="CLK"/>
+<wire x1="109.22" y1="58.42" x2="119.38" y2="58.42" width="0.1524" layer="91"/>
+<label x="114.3" y="58.42" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="SCLK"/>
+<wire x1="208.28" y1="88.9" x2="215.9" y2="88.9" width="0.1524" layer="91"/>
+<label x="208.28" y="88.9" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SENS_VP" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SENSOR_VP"/>
+<wire x1="43.18" y1="55.88" x2="33.02" y2="55.88" width="0.1524" layer="91"/>
+<label x="35.56" y="55.88" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="JP2" gate="G$1" pin="7"/>
+<wire x1="223.52" y1="160.02" x2="233.68" y2="160.02" width="0.1524" layer="91"/>
+<label x="233.68" y="160.02" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SENS_CAPP" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SENSOR_CAPP"/>
+<wire x1="43.18" y1="53.34" x2="33.02" y2="53.34" width="0.1524" layer="91"/>
+<label x="35.56" y="53.34" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SENS_CAPN" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SENSOR_CAPN"/>
+<wire x1="43.18" y1="50.8" x2="33.02" y2="50.8" width="0.1524" layer="91"/>
+<label x="35.56" y="50.8" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="SENS_VN" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SENSOR_VN"/>
+<wire x1="43.18" y1="48.26" x2="33.02" y2="48.26" width="0.1524" layer="91"/>
+<label x="35.56" y="48.26" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="STAT" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO34"/>
+<wire x1="43.18" y1="43.18" x2="33.02" y2="43.18" width="0.1524" layer="91"/>
+<label x="33.02" y="43.18" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="ANT" class="0">
+<segment>
+<wire x1="20.32" y1="68.58" x2="20.32" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="C5" gate="G$1" pin="2"/>
+<wire x1="20.32" y1="63.5" x2="15.24" y2="63.5" width="0.1524" layer="91"/>
+<junction x="20.32" y="63.5"/>
+<label x="17.78" y="63.5" size="1.778" layer="95" rot="R90"/>
+<wire x1="15.24" y1="83.82" x2="15.24" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="L1" gate="L$1" pin="2"/>
+<pinref part="E1" gate="G$1" pin="SIGNAL"/>
+</segment>
+</net>
+<net name="GPIO9" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SD2"/>
+<wire x1="109.22" y1="50.8" x2="119.38" y2="50.8" width="0.1524" layer="91"/>
+<label x="114.3" y="50.8" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO10" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SD3"/>
+<wire x1="109.22" y1="53.34" x2="119.38" y2="53.34" width="0.1524" layer="91"/>
+<label x="114.3" y="53.34" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="CE"/>
+<label x="177.8" y="99.06" size="1.778" layer="95"/>
+<wire x1="185.42" y1="99.06" x2="177.8" y2="99.06" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="GPIO7" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SD0"/>
+<wire x1="109.22" y1="60.96" x2="119.38" y2="60.96" width="0.1524" layer="91"/>
+<label x="114.3" y="60.96" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="SIO2"/>
+<wire x1="185.42" y1="88.9" x2="177.8" y2="88.9" width="0.1524" layer="91"/>
+<label x="177.8" y="88.9" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO11" class="0">
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="SIO3"/>
+<wire x1="208.28" y1="93.98" x2="215.9" y2="93.98" width="0.1524" layer="91"/>
+<label x="208.28" y="93.98" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="CMD"/>
+<wire x1="109.22" y1="55.88" x2="119.38" y2="55.88" width="0.1524" layer="91"/>
+<label x="114.3" y="55.88" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO8" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="SD1"/>
+<wire x1="109.22" y1="63.5" x2="119.38" y2="63.5" width="0.1524" layer="91"/>
+<label x="114.3" y="63.5" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="SIO0"/>
+<wire x1="208.28" y1="83.82" x2="215.9" y2="83.82" width="0.1524" layer="91"/>
+<label x="208.28" y="83.82" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="VDDSDIO" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="VDD_SDIO_NC"/>
+<wire x1="109.22" y1="45.72" x2="119.38" y2="45.72" width="0.1524" layer="91"/>
+<label x="111.76" y="45.72" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="LY68L6400SLIT" gate="P" pin="VCC"/>
+<label x="208.28" y="99.06" size="1.778" layer="95"/>
+<pinref part="C6" gate="G$1" pin="1"/>
+<wire x1="208.28" y1="99.06" x2="220.98" y2="99.06" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$3" class="0">
+<segment>
+<wire x1="38.1" y1="115.57" x2="38.1" y2="115.316" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="GPIO22/DC" class="0">
+<segment>
+<pinref part="JP1" gate="G$1" pin="6"/>
+<wire x1="208.28" y1="149.86" x2="198.12" y2="149.86" width="0.1524" layer="91"/>
+<label x="198.12" y="149.86" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO22"/>
+<wire x1="78.74" y1="81.28" x2="78.74" y2="88.9" width="0.1524" layer="91"/>
+<label x="78.74" y="83.82" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO21/RESET" class="0">
+<segment>
+<pinref part="JP2" gate="G$1" pin="2"/>
+<wire x1="223.52" y1="147.32" x2="233.68" y2="147.32" width="0.1524" layer="91"/>
+<label x="233.68" y="147.32" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO21"/>
+<wire x1="71.12" y1="81.28" x2="71.12" y2="88.9" width="0.1524" layer="91"/>
+<label x="71.12" y="83.82" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO18/SCK" class="0">
+<segment>
+<pinref part="JP2" gate="G$1" pin="5"/>
+<wire x1="223.52" y1="154.94" x2="233.68" y2="154.94" width="0.1524" layer="91"/>
+<label x="233.68" y="154.94" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO18"/>
+<wire x1="109.22" y1="68.58" x2="119.38" y2="68.58" width="0.1524" layer="91"/>
+<label x="111.76" y="68.58" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO5/CS" class="0">
+<segment>
+<pinref part="JP2" gate="G$1" pin="6"/>
+<wire x1="223.52" y1="157.48" x2="233.68" y2="157.48" width="0.1524" layer="91"/>
+<label x="233.68" y="157.48" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO5"/>
+<wire x1="109.22" y1="66.04" x2="119.38" y2="66.04" width="0.1524" layer="91"/>
+<label x="111.76" y="66.04" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO23/MOSI" class="0">
+<segment>
+<pinref part="JP2" gate="G$1" pin="3"/>
+<wire x1="223.52" y1="149.86" x2="233.68" y2="149.86" width="0.1524" layer="91"/>
+<label x="233.68" y="149.86" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO23"/>
+<wire x1="109.22" y1="71.12" x2="119.38" y2="71.12" width="0.1524" layer="91"/>
+<label x="111.76" y="71.12" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="VIN" class="1">
+<segment>
+<pinref part="JP1" gate="G$1" pin="8"/>
+<wire x1="208.28" y1="144.78" x2="198.12" y2="144.78" width="0.1524" layer="91"/>
+<label x="198.12" y="144.78" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="R6" gate="G$1" pin="1"/>
+<wire x1="160.02" y1="139.7" x2="160.02" y2="137.16" width="0.1524" layer="91"/>
+<label x="162.56" y="137.16" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO19/MISO" class="0">
+<segment>
+<pinref part="JP2" gate="G$1" pin="4"/>
+<wire x1="223.52" y1="152.4" x2="233.68" y2="152.4" width="0.1524" layer="91"/>
+<label x="233.68" y="152.4" size="1.778" layer="95"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO19"/>
+<wire x1="81.28" y1="81.28" x2="81.28" y2="88.9" width="0.1524" layer="91"/>
+<label x="81.28" y="83.82" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="LNA_IN" class="0">
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="LNA_IN"/>
+<pinref part="C5" gate="G$1" pin="1"/>
+<wire x1="43.18" y1="63.5" x2="30.48" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="C4" gate="G$1" pin="1"/>
+<wire x1="30.48" y1="63.5" x2="27.94" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="68.58" x2="30.48" y2="63.5" width="0.1524" layer="91"/>
+<junction x="30.48" y="63.5"/>
+<label x="30.48" y="63.5" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="GPIO13/SD_MOSI" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="CMD"/>
+<wire x1="76.2" y1="147.32" x2="71.12" y2="147.32" width="0.1524" layer="91"/>
+<label x="71.12" y="147.32" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO13"/>
+<wire x1="86.36" y1="25.4" x2="86.36" y2="15.24" width="0.1524" layer="91"/>
+<label x="86.36" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO2/SD_MISO" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="DAT0"/>
+<wire x1="76.2" y1="144.78" x2="71.12" y2="144.78" width="0.1524" layer="91"/>
+<label x="71.12" y="144.78" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO2"/>
+<wire x1="91.44" y1="25.4" x2="91.44" y2="15.24" width="0.1524" layer="91"/>
+<label x="91.44" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="N$4" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="DAT1"/>
+<wire x1="76.2" y1="142.24" x2="71.12" y2="142.24" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$5" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="DAT2"/>
+<wire x1="76.2" y1="139.7" x2="71.12" y2="139.7" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="GPIO15/SD_CS" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="CD/DAT3"/>
+<wire x1="76.2" y1="137.16" x2="71.12" y2="137.16" width="0.1524" layer="91"/>
+<label x="71.12" y="137.16" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO15"/>
+<wire x1="88.9" y1="25.4" x2="88.9" y2="15.24" width="0.1524" layer="91"/>
+<label x="88.9" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+<net name="GPIO14/SD_CLK" class="0">
+<segment>
+<pinref part="J2" gate="G$1" pin="CLK"/>
+<wire x1="76.2" y1="152.4" x2="71.12" y2="152.4" width="0.1524" layer="91"/>
+<label x="71.12" y="152.4" size="1.778" layer="95" rot="R180"/>
+</segment>
+<segment>
+<pinref part="PICO-D4" gate="G$1" pin="IO14"/>
+<wire x1="78.74" y1="25.4" x2="78.74" y2="15.24" width="0.1524" layer="91"/>
+<label x="78.74" y="15.24" size="1.778" layer="95" rot="R90"/>
+</segment>
+</net>
+</nets>
+</sheet>
+</sheets>
+</schematic>
+</drawing>
+<compatibility>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+<note version="9.4" severity="warning">
+Since Version 9.4, EAGLE supports the overriding of 3D packages
+in schematics and board files. Those overridden 3d packages
+will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>


### PR DESCRIPTION
Don't need to merge this, but just dropping this here for visibility.

This adds a new version of the microcontroller board that uses the ESP32-PICO-D4 chip + 8mb PSRAM + SD card slot. This would enable the block to play Doom :D :D I've already gotten the screen working with Doom on a breadboard with [this code](https://github.com/johnboiles/doom-espidf/tree/john/bws). There's no accelerometer on this board right now, but I bet we could fit that in if we wanted.

I ordered some of these assembled from JLCPCB on 11/12, hopefully it works! I'm least confident in the trace antenna as I've done minimal RF PCB design in the past.

If this works, next step would be to add bluetooth controller support to my [doom-espidf fork](https://github.com/johnboiles/doom-espidf/tree/john/bws). I'd love help with that if anyone wants to take it on.

Doom on the same OLED screen:

https://user-images.githubusercontent.com/218876/142271705-2ec50681-bad0-4c76-8bd8-783a0835b252.MOV

