### PR TITLE
Fireworks: Accelerometer-driven gravity

### DIFF
--- a/blockware/fireworks/lib/Particle/Particle.cpp
+++ b/blockware/fireworks/lib/Particle/Particle.cpp
@@ -5,6 +5,15 @@
 #include <Colors.h>
 #include <Random.h>
 
+Vec2d<float> Particle::__gravity = Vec2d<float>(0, GRAVITY);
+
+void Particle::update_gravity(const Vec2d<float> &gravity_xy)
+{
+  __gravity = gravity_xy;
+  __gravity.normalize();
+  __gravity *= GRAVITY;
+}
+
 Particle::Particle(int x, int y, bool isRocket, int color)
 {
   _age = 0;
@@ -94,7 +103,9 @@ void Particle::tick()
 
   _vel.x *= _resistance;
   _vel.y *= _resistance;
-  _vel.y += GRAVITY;
+
+  _vel.x += __gravity.x;
+  _vel.y += __gravity.y;
 
   _pos.x += _vel.x;
   _pos.y += _vel.y;

--- a/blockware/fireworks/lib/Particle/Particle.cpp
+++ b/blockware/fireworks/lib/Particle/Particle.cpp
@@ -7,7 +7,7 @@
 
 Vec2d<float> Particle::__gravity = Vec2d<float>(0, GRAVITY);
 
-void Particle::update_gravity(const Vec2d<float> &gravity_xy)
+void Particle::updateGravity(const Vec2d<float> &gravity_xy)
 {
   __gravity = gravity_xy;
   __gravity.normalize();

--- a/blockware/fireworks/lib/Particle/Particle.h
+++ b/blockware/fireworks/lib/Particle/Particle.h
@@ -47,7 +47,7 @@ private:
 
 protected:
 public:
-  static void update_gravity(const Vec2d<float> &gravity_xy);
+  static void updateGravity(const Vec2d<float> &gravity_xy);
 public:
   Particle(int x, int y, bool isRocket, int color);
   void draw(GFXcanvas16* canvas);

--- a/blockware/fireworks/lib/Particle/Particle.h
+++ b/blockware/fireworks/lib/Particle/Particle.h
@@ -31,6 +31,8 @@ static inline int randomFireworkColor()
 
 class Particle {
 private:
+  static Vec2d<float> __gravity;
+private:
   int _age;         // how old is this particle?
   bool _isRocket;   // is this particle rocketing?
   Vec2d<float> _pos;  // x,y coords
@@ -44,6 +46,8 @@ private:
   float _resistance;
 
 protected:
+public:
+  static void update_gravity(const Vec2d<float> &gravity_xy);
 public:
   Particle(int x, int y, bool isRocket, int color);
   void draw(GFXcanvas16* canvas);

--- a/blockware/fireworks/src/main.cpp
+++ b/blockware/fireworks/src/main.cpp
@@ -256,6 +256,15 @@ void updateWakeState()
   }
 }
 
+void updateGravity()
+{
+  // Read accelerometer
+  int16_t axes[3];
+  acc->Get_X_AxesRaw(axes);
+
+  Particle::update_gravity(Vec2d<float>(-axes[0], -axes[1]));
+}
+
 void initText()
 {
   centerText(username, posVisUsername, posHidUsername, &sizeUsername, 0, position.y);
@@ -294,6 +303,7 @@ void tick()
 
   // base
   updateWakeState();
+  updateGravity();
   drawParticles();
   drawLogo();
   drawText();

--- a/blockware/fireworks/src/main.cpp
+++ b/blockware/fireworks/src/main.cpp
@@ -223,7 +223,7 @@ void drawParticles()
   }
 }
 
-void updateWakeState()
+void updateWakeState(const int16_t (&accelAxes)[3])
 {
   unsigned long now = millis();
   unsigned long timeSinceUpdate = now - lastWakeUpdate;
@@ -236,11 +236,8 @@ void updateWakeState()
     wakeupText = false;
   }
 
-  // Read accelerometer
-  int16_t axes[3];
-  acc->Get_X_AxesRaw(axes);
-  // Scale values down to be less sensitive
-  uint32_t newAccState = (axes[0] / 256 << 16) | (axes[1] / 256 << 8) | axes[2] / 256;
+  // Scale accelerometer values down to be less sensitive
+  uint32_t newAccState = (accelAxes[0] / 256 << 16) | (accelAxes[1] / 256 << 8) | accelAxes[2] / 256;
 
   // Update wake state
   bool changed = newAccState != accState;
@@ -256,13 +253,14 @@ void updateWakeState()
   }
 }
 
-void updateGravity()
+void updateGravity(const int16_t (&accelAxes)[3])
 {
-  // Read accelerometer
-  int16_t axes[3];
-  acc->Get_X_AxesRaw(axes);
+  Particle::update_gravity(Vec2d<float>(-accelAxes[0], -accelAxes[1]));
+}
 
-  Particle::update_gravity(Vec2d<float>(-axes[0], -axes[1]));
+void readAccelerometer(int16_t (&accelAxes)[3])
+{
+  acc->Get_X_AxesRaw(accelAxes);
 }
 
 void initText()
@@ -302,8 +300,10 @@ void tick()
   // redraw entire canvas on every tick
 
   // base
-  updateWakeState();
-  updateGravity();
+  int16_t accelAxes[3];
+  readAccelerometer(accelAxes);
+  updateWakeState(accelAxes);
+  updateGravity(accelAxes);
   drawParticles();
   drawLogo();
   drawText();

--- a/blockware/fireworks/src/main.cpp
+++ b/blockware/fireworks/src/main.cpp
@@ -255,7 +255,7 @@ void updateWakeState(const int16_t (&accelAxes)[3])
 
 void updateGravity(const int16_t (&accelAxes)[3])
 {
-  Particle::update_gravity(Vec2d<float>(-accelAxes[0], -accelAxes[1]));
+  Particle::updateGravity(Vec2d<float>(-accelAxes[0], -accelAxes[1]));
 }
 
 void readAccelerometer(int16_t (&accelAxes)[3])


### PR DESCRIPTION
Proposing a basic approach to using accelerometer to set gravity direction.
Note that it does make fireworks move very quickly towards the bottom when rotated 180 degrees..