### PR TITLE
Virtualblox accel support

### DIFF
--- a/blockware/fireworks/platformio.ini
+++ b/blockware/fireworks/platformio.ini
@@ -30,3 +30,11 @@ upload_speed = 460800
 
 build_flags = !echo "-DESP8266=1 -DLOGGING=1 -DGIT_REVISION='\"$(git rev-parse HEAD)\"'"
 monitor_speed = 115200
+
+[env:VirtualBlox]
+platform = native
+lib_extra_dirs = ../lib
+lib_deps =
+    VirtualBlox
+build_flags = !../lib/VirtualBlox/platform_build_flags.py
+extra_scripts = ../lib/VirtualBlox/platform_extra_script.py

--- a/blockware/fireworks/src/main.cpp
+++ b/blockware/fireworks/src/main.cpp
@@ -12,7 +12,7 @@
 #include <DefaultConfig.h>
 
 #include <LIS2DW12Sensor.h>
-
+#include <optional>
 
 const int tlWidth = 40;
 const int tlHeight = 33;

--- a/blockware/lib/VirtualBlox/platform_build_flags.py
+++ b/blockware/lib/VirtualBlox/platform_build_flags.py
@@ -49,7 +49,7 @@ lib_includes = "\n".join([f"-I{libs_dir}/{lib}" for lib in libs])
 
 # Build the big flags list
 flags = [
-    "-std=c++17",
+    "-std=c++20",
     arch_flag,
     sdl_flags,
     "-DARDUINO=100",

--- a/blockware/lib/VirtualBlox/platform_build_flags.py
+++ b/blockware/lib/VirtualBlox/platform_build_flags.py
@@ -49,7 +49,7 @@ lib_includes = "\n".join([f"-I{libs_dir}/{lib}" for lib in libs])
 
 # Build the big flags list
 flags = [
-    "-std=c++20",
+    "-std=c++17",
     arch_flag,
     sdl_flags,
     "-DARDUINO=100",

--- a/blockware/lib/VirtualBlox/stubs/LIS2DW12Sensor.cpp
+++ b/blockware/lib/VirtualBlox/stubs/LIS2DW12Sensor.cpp
@@ -1,0 +1,1311 @@
+/**
+ ******************************************************************************
+ * @file    LIS2DW12Sensor.cpp
+ * @author  CLab
+ * @version V1.0.0
+ * @date    15 November 2018
+ * @brief   Implementation of an LIS2DW12 Inertial Measurement Unit (IMU) 3 axes
+ *          sensor.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Includes ------------------------------------------------------------------*/
+
+#include "LIS2DW12Sensor.h"
+
+
+// /* Class Implementation ------------------------------------------------------*/
+
+/** Constructor
+ * @param i2c object of an helper class which handles the I2C peripheral
+ * @param address the address of the component's instance
+ */
+LIS2DW12Sensor::LIS2DW12Sensor(TwoWire *i2c, uint8_t address) : dev_i2c(i2c), address(address)
+{
+}
+
+// /** Constructor
+//  * @param spi object of an helper class which handles the SPI peripheral
+//  * @param cs_pin the chip select pin
+//  * @param spi_speed the SPI speed
+//  */
+// LIS2DW12Sensor::LIS2DW12Sensor(SPIClass *spi, int cs_pin, uint32_t spi_speed) : dev_spi(spi), cs_pin(cs_pin), spi_speed(spi_speed)
+// {
+//   reg_ctx.write_reg = LIS2DW12_io_write;
+//   reg_ctx.read_reg = LIS2DW12_io_read;
+//   reg_ctx.handle = (void *)this;
+//   dev_i2c = NULL;
+//   address = 0;
+//   X_isEnabled = 0;
+// }
+
+/**
+ * @brief  Configure the sensor in order to be used
+ * @retval 0 in case of success, an error code otherwise
+ */
+LIS2DW12StatusTypeDef LIS2DW12Sensor::begin()
+{
+  return LIS2DW12_STATUS_OK;
+}
+
+// /**
+//  * @brief  Disable the sensor and relative resources
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::end()
+// {
+//   /* Disable acc */
+//   if (Disable_X() != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Reset CS configuration */
+//   if(dev_spi)
+//   {
+//     // Configure CS pin
+//     pinMode(cs_pin, INPUT); 
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+/**
+ * @brief  Enable LIS2DW12 Accelerator
+ * @retval 0 in case of success, an error code otherwise
+ */
+LIS2DW12StatusTypeDef LIS2DW12Sensor::Enable_X(void)
+{ 
+  /* Check if the component is already enabled */
+  if (X_isEnabled == 1)
+  {
+    return LIS2DW12_STATUS_OK;
+  }
+  
+  /* Output data rate selection. */
+  if (Set_X_ODR_When_Enabled(X_Last_ODR, X_Last_Operating_Mode, X_Last_Noise) != LIS2DW12_STATUS_OK)
+  {
+    return LIS2DW12_STATUS_ERROR;
+  }
+  
+  X_isEnabled = 1;
+  
+  return LIS2DW12_STATUS_OK;
+}
+
+// /**
+//  * @brief  Disable LIS2DW12 Accelerator
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Disable_X(void)
+// { 
+//   /* Check if the component is already disabled */
+//   if (X_isEnabled == 0)
+//   {
+//     return LIS2DW12_STATUS_OK;
+//   }
+
+//   /* Output data rate selection - power down. */
+//   if (lis2dw12_data_rate_set(&reg_ctx, LIS2DW12_XL_ODR_OFF) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+  
+//   X_isEnabled = 0;
+  
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Read ID of LIS2DW12 Accelerometer and Gyroscope
+//  * @param  id the pointer where the ID of the device is stored
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::ReadID(uint8_t *id)
+// {
+//   if(!id)
+//   { 
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read WHO AM I register */
+//   if (lis2dw12_device_id_get(&reg_ctx, id) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Read data from LIS2DW12 Accelerometer
+//  * @param  acceleration the pointer where the accelerometer data are stored
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_X_Axes(int32_t *acceleration)
+// {
+//   int16_t data_raw[3];
+//   float sensitivity = 0;
+  
+//   /* Read raw data from LIS2DW12 output register. */
+//   if (Get_X_AxesRaw(data_raw) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+  
+//   /* Get LIS2DW12 actual sensitivity. */
+//   if (Get_X_Sensitivity(&sensitivity) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+  
+//   /* Calculate the data. */
+//   acceleration[0] = (int32_t)(data_raw[0] * sensitivity);
+//   acceleration[1] = (int32_t)(data_raw[1] * sensitivity);
+//   acceleration[2] = (int32_t)(data_raw[2] * sensitivity);
+  
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Read Accelerometer Sensitivity
+//  * @param  sensitivity the pointer where the accelerometer sensitivity is stored
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_X_Sensitivity(float *sensitivity)
+// {
+//   LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+//   lis2dw12_fs_t full_scale;
+//   lis2dw12_mode_t mode;
+
+//   /* Read actual full scale selection from sensor. */
+//   if (lis2dw12_full_scale_get(&reg_ctx, &full_scale) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read actual power mode selection from sensor. */
+//   if (lis2dw12_power_mode_get(&reg_ctx, &mode) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   switch(mode)
+//   {
+//     case LIS2DW12_CONT_LOW_PWR_12bit:
+//     case LIS2DW12_SINGLE_LOW_PWR_12bit:
+//     case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+//     case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+//       switch (full_scale)
+//       {
+//         case LIS2DW12_2g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_2G_LOPOW1_MODE;
+//            break;
+
+//         case LIS2DW12_4g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_4G_LOPOW1_MODE;
+//           break;
+
+//         case LIS2DW12_8g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_8G_LOPOW1_MODE;
+//            break;
+
+//         case LIS2DW12_16g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_16G_LOPOW1_MODE;
+//           break;
+
+//         default:
+//           *sensitivity = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     case LIS2DW12_HIGH_PERFORMANCE:
+//     case LIS2DW12_CONT_LOW_PWR_4:
+//     case LIS2DW12_CONT_LOW_PWR_3:
+//     case LIS2DW12_CONT_LOW_PWR_2:
+//     case LIS2DW12_SINGLE_LOW_PWR_4:
+//     case LIS2DW12_SINGLE_LOW_PWR_3:
+//     case LIS2DW12_SINGLE_LOW_PWR_2:
+//     case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+//     case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+//     case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+//     case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+//     case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+//     case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+//     case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+//       switch (full_scale)
+//       {
+//         case LIS2DW12_2g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_2G_OTHER_MODES;
+//            break;
+
+//         case LIS2DW12_4g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_4G_OTHER_MODES;
+//           break;
+
+//         case LIS2DW12_8g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_8G_OTHER_MODES;
+//            break;
+
+//         case LIS2DW12_16g:
+//           *sensitivity = LIS2DW12_ACC_SENSITIVITY_FOR_FS_16G_OTHER_MODES;
+//           break;
+
+//         default:
+//           *sensitivity = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     default:
+//       *sensitivity = -1.0f;
+//       ret = LIS2DW12_STATUS_ERROR;
+//       break;
+//   }
+
+//   return ret;
+// }
+
+/**
+ * @brief  Read raw data from LIS2DW12 Accelerometer
+ * @param  value the pointer where the accelerometer raw data are stored
+ * @retval 0 in case of success, an error code otherwise
+ */
+LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_X_AxesRaw(int16_t *value)
+{
+  LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+
+  value[0] = 0;
+  value[1] = 0;
+  value[2] = 0;
+
+  return ret;
+}
+
+// /**
+//  * @brief  Read LIS2DW12 Accelerometer output data rate
+//  * @param  odr the pointer to the output data rate
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_X_ODR(float* odr)
+// {
+//   LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+//   lis2dw12_odr_t odr_low_level;
+//   lis2dw12_mode_t mode;
+
+//   /* Get current output data rate. */
+//   if (lis2dw12_data_rate_get(&reg_ctx, &odr_low_level) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read actual power mode selection from sensor. */
+//   if (lis2dw12_power_mode_get(&reg_ctx, &mode) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   switch (odr_low_level)
+//   {
+//     case LIS2DW12_XL_ODR_OFF:
+//     case LIS2DW12_XL_SET_SW_TRIG:
+//     case LIS2DW12_XL_SET_PIN_TRIG:
+//       *odr = 0.0f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_1Hz6_LP_ONLY:
+//       switch (mode)
+//       {
+//         case LIS2DW12_HIGH_PERFORMANCE:
+//         case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+//           *odr = 12.5f;
+//            break;
+
+//         case LIS2DW12_CONT_LOW_PWR_4:
+//         case LIS2DW12_CONT_LOW_PWR_3:
+//         case LIS2DW12_CONT_LOW_PWR_2:
+//         case LIS2DW12_CONT_LOW_PWR_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_2:
+//         case LIS2DW12_SINGLE_LOW_PWR_12bit:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+//           *odr = 1.6f;
+//           break;
+
+//         default:
+//           *odr = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     case LIS2DW12_XL_ODR_12Hz5:
+//       *odr = 12.5f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_25Hz:
+//       *odr = 25.0f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_50Hz:
+//       *odr = 50.0f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_100Hz:
+//       *odr = 100.0f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_200Hz:
+//       *odr = 200.0f;
+//       break;
+
+//     case LIS2DW12_XL_ODR_400Hz:
+//       switch (mode)
+//       {
+//         case LIS2DW12_HIGH_PERFORMANCE:
+//         case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+//           *odr = 400.0f;
+//            break;
+
+//         case LIS2DW12_CONT_LOW_PWR_4:
+//         case LIS2DW12_CONT_LOW_PWR_3:
+//         case LIS2DW12_CONT_LOW_PWR_2:
+//         case LIS2DW12_CONT_LOW_PWR_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_2:
+//         case LIS2DW12_SINGLE_LOW_PWR_12bit:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+//           *odr = 200.0f;
+//           break;
+
+//         default:
+//           *odr = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     case LIS2DW12_XL_ODR_800Hz:
+//       switch (mode)
+//       {
+//         case LIS2DW12_HIGH_PERFORMANCE:
+//         case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+//           *odr = 800.0f;
+//            break;
+
+//         case LIS2DW12_CONT_LOW_PWR_4:
+//         case LIS2DW12_CONT_LOW_PWR_3:
+//         case LIS2DW12_CONT_LOW_PWR_2:
+//         case LIS2DW12_CONT_LOW_PWR_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_2:
+//         case LIS2DW12_SINGLE_LOW_PWR_12bit:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+//           *odr = 200.0f;
+//           break;
+
+//         default:
+//           *odr = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     case LIS2DW12_XL_ODR_1k6Hz:
+//       switch (mode)
+//       {
+//         case LIS2DW12_HIGH_PERFORMANCE:
+//         case LIS2DW12_HIGH_PERFORMANCE_LOW_NOISE:
+//           *odr = 1600.0f;
+//            break;
+
+//         case LIS2DW12_CONT_LOW_PWR_4:
+//         case LIS2DW12_CONT_LOW_PWR_3:
+//         case LIS2DW12_CONT_LOW_PWR_2:
+//         case LIS2DW12_CONT_LOW_PWR_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_2:
+//         case LIS2DW12_SINGLE_LOW_PWR_12bit:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_CONT_LOW_PWR_LOW_NOISE_12bit:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_4:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_3:
+//         case LIS2DW12_SINGLE_LOW_PWR_LOW_NOISE_2:
+//         case LIS2DW12_SINGLE_LOW_LOW_NOISE_PWR_12bit:
+//           *odr = 200.0f;
+//           break;
+
+//         default:
+//           *odr = -1.0f;
+//           ret = LIS2DW12_STATUS_ERROR;
+//           break;
+//       }
+//       break;
+
+//     default:
+//       *odr = -1.0f;
+//       ret = LIS2DW12_STATUS_ERROR;
+//       break;
+//   }
+
+//   return ret;
+// }
+
+// /**
+//  * @brief  Set LIS2DW12 Accelerometer output data rate
+//  * @param  odr the output data rate to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_X_ODR(float odr)
+// { 
+//   return Set_X_ODR_With_Mode(odr, LIS2DW12_HIGH_PERFORMANCE_MODE, LIS2DW12_LOW_NOISE_DISABLE);
+// }
+
+// /**
+//  * @brief  Set LIS2DW12 Accelerometer output data rate
+//  * @param  odr the output data rate to be set
+//  * @param  mode the operating mode to be used
+//  * @param  noise the low noise option
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_X_ODR_With_Mode(float odr, LIS2DW12_Operating_Mode_t mode, LIS2DW12_Low_Noise_t noise)
+// {
+//   if(X_isEnabled == 1)
+//   {
+//     if(Set_X_ODR_When_Enabled(odr, mode, noise) != LIS2DW12_STATUS_OK)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+//   }
+//   else
+//   {
+//     if(Set_X_ODR_When_Disabled(odr, mode, noise) != LIS2DW12_STATUS_OK)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+//   }
+  
+//   return LIS2DW12_STATUS_OK;
+// }
+
+/**
+ * @brief  Set LIS2DW12 Accelerometer output data rate when enabled
+ * @param  odr the output data rate to be set
+ * @param  mode the operating mode to be used
+ * @param  noise the low noise option
+ * @retval 0 in case of success, an error code otherwise
+ */
+LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_X_ODR_When_Enabled(float odr, LIS2DW12_Operating_Mode_t mode, LIS2DW12_Low_Noise_t noise)
+{
+  return LIS2DW12_STATUS_OK;
+}
+
+// /**
+//  * @brief  Set LIS2DW12 Accelerometer output data rate when disabled
+//  * @param  odr the output data rate to be set
+//  * @param  mode the operating mode to be used
+//  * @param  noise the low noise option
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_X_ODR_When_Disabled(float odr, LIS2DW12_Operating_Mode_t mode, LIS2DW12_Low_Noise_t noise)
+// {
+//   X_Last_Operating_Mode = mode;
+//   X_Last_Noise = noise;
+
+//   X_Last_ODR = (odr <=    1.6f) ?    1.6f
+//              : (odr <=   12.5f) ?   12.5f
+//              : (odr <=   25.0f) ?   25.0f
+//              : (odr <=   50.0f) ?   50.0f
+//              : (odr <=  100.0f) ?  100.0f
+//              : (odr <=  200.0f) ?  200.0f
+//              : (odr <=  400.0f) ?  400.0f
+//              : (odr <=  800.0f) ?  800.0f
+//              :                    1600.0f;
+                                 
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Read LIS2DW12 Accelerometer full scale
+//  * @param  full_scale the pointer to the full scale
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_X_FS(float* full_scale)
+// {
+//   LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+//   lis2dw12_fs_t fs_low_level;
+
+//   /* Read actual full scale selection from sensor. */
+//   if (lis2dw12_full_scale_get(&reg_ctx, &fs_low_level) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   switch (fs_low_level)
+//   {
+//     case LIS2DW12_2g:
+//       *full_scale =  2;
+//       break;
+
+//     case LIS2DW12_4g:
+//       *full_scale =  4;
+//       break;
+
+//     case LIS2DW12_8g:
+//       *full_scale =  8;
+//       break;
+
+//     case LIS2DW12_16g:
+//       *full_scale = 16;
+//       break;
+
+//     default:
+//       *full_scale = -1;
+//       ret = LIS2DW12_STATUS_ERROR;
+//       break;
+//   }
+
+//   return ret;
+// }
+
+// /**
+//  * @brief  Set LIS2DW12 Accelerometer full scale
+//  * @param  full_scale the full scale to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_X_FS(float full_scale)
+// {
+//   lis2dw12_fs_t new_fs;
+
+//   /* Seems like MISRA C-2012 rule 14.3a violation but only from single file statical analysis point of view because
+//      the parameter passed to the function is not known at the moment of analysis */
+//   new_fs = (full_scale <= 2) ? LIS2DW12_2g
+//          : (full_scale <= 4) ? LIS2DW12_4g
+//          : (full_scale <= 8) ? LIS2DW12_8g
+//          :                     LIS2DW12_16g;
+
+//   if (lis2dw12_full_scale_set(&reg_ctx, new_fs) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Enable the wake up detection for LIS2DW12 accelerometer sensor
+//  * @note  This function sets the LIS2DW12 accelerometer ODR to 200Hz and the LIS2DW12 accelerometer full scale to 2g
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Enable_Wake_Up_Detection(void)
+// {
+//   LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+//   lis2dw12_ctrl4_int1_pad_ctrl_t val;
+
+//   /* Output Data Rate selection */
+//   if (Set_X_ODR(200.0f) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Full scale selection */
+//   if (Set_X_FS(2.0f) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* WAKE_DUR setting */
+//   if (lis2dw12_wkup_dur_set(&reg_ctx, 0x00) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Set wake up threshold. */
+//   if (lis2dw12_wkup_threshold_set(&reg_ctx, 0x02) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (lis2dw12_pin_int1_route_get(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   val.int1_wu = PROPERTY_ENABLE;
+
+//   if (lis2dw12_pin_int1_route_set(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return ret;
+// }
+
+// /**
+//  * @brief Disable the wake up detection for LIS2DW12 accelerometer sensor
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Disable_Wake_Up_Detection(void)
+// {
+//   lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_reg;
+//   lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_reg;
+//   lis2dw12_ctrl_reg7_t ctrl_reg7;
+
+//   /* Disable wake up event on INT1 pin. */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   ctrl4_int1_reg.int1_wu = PROPERTY_DISABLE;
+
+//   if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read INT2 Sleep Change */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL, (uint8_t *)&ctrl5_int2_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /*Disable Interrupts bit if none event is still enabled */
+//   if(ctrl5_int2_reg.int2_sleep_chg == 0 && ctrl4_int1_reg.int1_wu == 0 && ctrl4_int1_reg.int1_6d == 0)
+//   {
+//     if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+
+//     ctrl_reg7.interrupts_enable = PROPERTY_DISABLE;
+
+//     if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+//   }
+
+//   /* Reset wake up threshold. */
+//   if (lis2dw12_wkup_threshold_set(&reg_ctx, 0x00) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* WAKE_DUR setting */
+//   if (lis2dw12_wkup_dur_set(&reg_ctx, 0x00) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Set the wake up threshold for LIS2DW12 accelerometer sensor
+//  * @param thr the threshold to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_Wake_Up_Threshold(uint8_t thr)
+// {
+//   /* Set wake up threshold. */
+//   if (lis2dw12_wkup_threshold_set(&reg_ctx, thr) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Set the wake up duration for LIS2DW12 accelerometer sensor
+//  * @param dur the duration to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_Wake_Up_Duration(uint8_t dur)
+// {
+//   /* Set wake up duration. */
+//   if (lis2dw12_wkup_dur_set(&reg_ctx, dur) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Enable the inactivity detection for LIS2DW12 accelerometer sensor
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Enable_Inactivity_Detection(void)
+// {
+//   lis2dw12_ctrl5_int2_pad_ctrl_t val;
+
+//   /* Output Data Rate and Full scale must be selected externally */
+
+//   /* SLEEP_DUR setting */
+//   if (lis2dw12_act_sleep_dur_set(&reg_ctx, 0x01) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Set wake up threshold. */
+//   if (lis2dw12_wkup_threshold_set(&reg_ctx, 0x02) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Enable inactivity detection. */
+//   if (lis2dw12_act_mode_set(&reg_ctx, LIS2DW12_DETECT_ACT_INACT) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (lis2dw12_pin_int2_route_get(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   val.int2_sleep_chg = PROPERTY_ENABLE;
+
+//   if (lis2dw12_pin_int2_route_set(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Disable the inactivity detection for LIS2DW12 accelerometer sensor
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Disable_Inactivity_Detection(void)
+// {
+//   lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_reg;
+//   lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_reg;
+//   lis2dw12_ctrl_reg7_t ctrl_reg7;
+
+//   /* Disable inactivity event on INT2 pin */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL, (uint8_t *)&ctrl5_int2_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   ctrl5_int2_reg.int2_sleep_chg = PROPERTY_DISABLE;
+
+//   if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL, (uint8_t *)&ctrl5_int2_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read INT1 Wake Up event and INT1 6D Orientation event */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /*Disable Interrupts bit if none event is still enabled */
+//   if(ctrl5_int2_reg.int2_sleep_chg == 0 && ctrl4_int1_reg.int1_wu == 0 && ctrl4_int1_reg.int1_6d == 0)
+//   {
+//     if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+
+//     ctrl_reg7.interrupts_enable = PROPERTY_DISABLE;
+
+//     if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+//   }
+
+//   /* Disable inactivity detection. */
+//   if (lis2dw12_act_mode_set(&reg_ctx, LIS2DW12_NO_DETECTION) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Reset wake up threshold. */
+//   if (lis2dw12_wkup_threshold_set(&reg_ctx, 0x00) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* SLEEP_DUR setting */
+//   if (lis2dw12_act_sleep_dur_set(&reg_ctx, 0x00) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Set the sleep duration for LIS2DW12 accelerometer sensor
+//  * @param dur the duration to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_Sleep_Duration(uint8_t dur)
+// {
+//   /* Set sleep duration. */
+//   if (lis2dw12_act_sleep_dur_set(&reg_ctx, dur) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Enable the 6D orientation detection for LIS2DW12 accelerometer sensor
+//  * @note  This function sets the LIS2DW12 accelerometer ODR to 200Hz and the LIS2DW12 accelerometer full scale to 2g
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Enable_6D_Orientation(void)
+// {
+//   lis2dw12_ctrl4_int1_pad_ctrl_t val;
+
+//   /* Output Data Rate selection */
+//   if(Set_X_ODR(200.0f) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+  
+//   /* Full scale selection. */
+//   if(Set_X_FS(2.0f) != LIS2DW12_STATUS_OK)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* 6D orientation threshold. */
+//   if (lis2dw12_6d_threshold_set(&reg_ctx, 2) != 0) /* 60 degrees */
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Enable 6D orientation event on INT1 pin */
+//   if (lis2dw12_pin_int1_route_get(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   val.int1_6d = PROPERTY_ENABLE;
+
+//   if (lis2dw12_pin_int1_route_set(&reg_ctx, &val) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Disable the 6D orientation detection for LIS2DW12 accelerometer sensor
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Disable_6D_Orientation(void)
+// {
+//   lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_reg;
+//   lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_reg;
+//   lis2dw12_ctrl_reg7_t ctrl_reg7;
+
+//   /* Disable 6D orientation event on INT1 pin */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   ctrl4_int1_reg.int1_6d = PROPERTY_DISABLE;
+
+//   if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /* Read INT2 Sleep Change */
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL, (uint8_t *)&ctrl5_int2_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   /*Disable Interrupts bit if none event is still enabled */
+//   if(ctrl5_int2_reg.int2_sleep_chg == 0 && ctrl4_int1_reg.int1_wu == 0 && ctrl4_int1_reg.int1_6d == 0)
+//   {
+//     if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+
+//     ctrl_reg7.interrupts_enable = PROPERTY_DISABLE;
+
+//     if (lis2dw12_write_reg(&reg_ctx, LIS2DW12_CTRL_REG7, (uint8_t *)&ctrl_reg7, 1) != 0)
+//     {
+//       return LIS2DW12_STATUS_ERROR;
+//     }
+//   }
+
+//   /* Reset 6D orientation threshold. */
+//   if (lis2dw12_6d_threshold_set(&reg_ctx, 0) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Set the 6D orientation threshold for LIS2DW12 accelerometer sensor
+//  * @param thr the threshold to be set
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_6D_Orientation_Threshold(uint8_t thr)
+// {
+//   if(thr > 3)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (lis2dw12_6d_threshold_set(&reg_ctx, thr) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation XL axis for LIS2DW12 accelerometer sensor
+//  * @param xl the pointer to the 6D orientation XL axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_XL(uint8_t *xl)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *xl = data.xl;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation XH axis for LIS2DW12 accelerometer sensor
+//  * @param xh the pointer to the 6D orientation XH axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_XH(uint8_t *xh)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *xh = data.xh;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation YL axis for LIS2DW12 accelerometer sensor
+//  * @param yl the pointer to the 6D orientation YL axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_YL(uint8_t *yl)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *yl = data.yl;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation YH axis for LIS2DW12 accelerometer sensor
+//  * @param yh the pointer to the 6D orientation YH axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_YH(uint8_t *yh)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *yh = data.yh;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation ZL axis for LIS2DW12 accelerometer sensor
+//  * @param zl the pointer to the 6D orientation ZL axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_ZL(uint8_t *zl)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *zl = data.zl;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the 6D orientation ZH axis for LIS2DW12 accelerometer sensor
+//  * @param zh the pointer to the 6D orientation ZH axis
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_6D_Orientation_ZH(uint8_t *zh)
+// {
+//   lis2dw12_sixd_src_t data;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_SIXD_SRC, (uint8_t *)&data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   *zh = data.zh;
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Get the status of all hardware events for LIS2DW12 accelerometer sensor
+//  * @param status the pointer to the status of all hardware events
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_Event_Status(LIS2DW12_Event_Status_t *status)
+// {
+//   lis2dw12_status_t status_reg;
+//   lis2dw12_ctrl4_int1_pad_ctrl_t ctrl4_int1_reg;
+//   lis2dw12_ctrl5_int2_pad_ctrl_t ctrl5_int2_reg;
+
+//   (void)memset((void *)status, 0x0, sizeof(LIS2DW12_Event_Status_t));
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_STATUS, (uint8_t *)&status_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL4_INT1_PAD_CTRL, (uint8_t *)&ctrl4_int1_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_CTRL5_INT2_PAD_CTRL, (uint8_t *)&ctrl5_int2_reg, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if (ctrl4_int1_reg.int1_wu == 1U)
+//   {
+//     if (status_reg.wu_ia == 1U)
+//     {
+//       status->WakeUpStatus = 1;
+//     }
+//   }
+
+//   if (ctrl4_int1_reg.int1_6d == 1U)
+//   {
+//     if (status_reg._6d_ia == 1U)
+//     {
+//       status->D6DOrientationStatus = 1;
+//     }
+//   }
+
+//   if (ctrl5_int2_reg.int2_sleep_chg == 1U)
+//   {
+//     if (status_reg.sleep_state == 1U)
+//     {
+//       status->SleepStatus = 1;
+//     }
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Get the number of samples contained into the FIFO
+//  * @param  num_samples the number of samples contained into the FIFO
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Get_FIFO_Num_Samples(uint16_t *num_samples)
+// {
+//   lis2dw12_fifo_samples_t fifo_samples;
+
+//   if (lis2dw12_read_reg(&reg_ctx, LIS2DW12_FIFO_SAMPLES, (uint8_t *)&fifo_samples, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   if(fifo_samples.diff == 0x20)
+//   {
+//     *num_samples = 32;
+//   }
+//   else
+//   {
+//     *num_samples = fifo_samples.diff;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief  Set the FIFO mode
+//  * @param  mode FIFO mode
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::Set_FIFO_Mode(uint8_t mode)
+// {
+//   LIS2DW12StatusTypeDef ret = LIS2DW12_STATUS_OK;
+
+//   /* Verify that the passed parameter contains one of the valid values. */
+//   switch ((lis2dw12_fmode_t)mode)
+//   {
+//     case LIS2DW12_BYPASS_MODE:
+//     case LIS2DW12_FIFO_MODE:
+//     case LIS2DW12_STREAM_TO_FIFO_MODE:
+//     case LIS2DW12_BYPASS_TO_STREAM_MODE:
+//     case LIS2DW12_STREAM_MODE:
+//       break;
+
+//     default:
+//       ret = LIS2DW12_STATUS_ERROR;
+//       break;
+//   }
+
+//   if (ret == LIS2DW12_STATUS_ERROR)
+//   {
+//     return ret;
+//   }
+
+//   if (lis2dw12_fifo_mode_set(&reg_ctx, (lis2dw12_fmode_t)mode) != 0)
+//   {
+//     ret = LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return ret;
+// }
+
+// /**
+//  * @brief Read the data from register
+//  * @param reg register address
+//  * @param data register data
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::ReadReg(uint8_t reg, uint8_t *data)
+// {
+
+//   if (lis2dw12_read_reg(&reg_ctx, reg, data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+// /**
+//  * @brief Write the data to register
+//  * @param reg register address
+//  * @param data register data
+//  * @retval 0 in case of success, an error code otherwise
+//  */
+// LIS2DW12StatusTypeDef LIS2DW12Sensor::WriteReg(uint8_t reg, uint8_t data)
+// {
+
+//   if (lis2dw12_write_reg(&reg_ctx, reg, &data, 1) != 0)
+//   {
+//     return LIS2DW12_STATUS_ERROR;
+//   }
+
+//   return LIS2DW12_STATUS_OK;
+// }
+
+
+// int32_t LIS2DW12_io_write(void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite)
+// {
+//   return ((LIS2DW12Sensor *)handle)->IO_Write(pBuffer, WriteAddr, nBytesToWrite);
+// }
+
+// int32_t LIS2DW12_io_read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead)
+// {
+//   return ((LIS2DW12Sensor *)handle)->IO_Read(pBuffer, ReadAddr, nBytesToRead);
+// }

--- a/blockware/lib/VirtualBlox/stubs/LIS2DW12Sensor.h
+++ b/blockware/lib/VirtualBlox/stubs/LIS2DW12Sensor.h
@@ -1,0 +1,262 @@
+/**
+ ******************************************************************************
+ * @file    LIS2DW12Sensor.h
+ * @author  CLab
+ * @version V1.0.0
+ * @date    15 November 2018
+ * @brief   Abstract Class of an LIS2DW12 Inertial Measurement Unit (IMU) 3 axes
+ *          sensor.
+ ******************************************************************************
+ * @attention
+ *
+ * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *   3. Neither the name of STMicroelectronics nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************
+ */
+
+
+/* Prevent recursive inclusion -----------------------------------------------*/
+
+#ifndef __LIS2DW12Sensor_H__
+#define __LIS2DW12Sensor_H__
+
+
+/* Includes ------------------------------------------------------------------*/
+
+#include "Wire.h"
+// #include "SPI.h"
+// #include "lis2dw12_reg.h"
+
+/* Defines -------------------------------------------------------------------*/
+
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_2G_LOPOW1_MODE   0.976f  /**< Sensitivity value for 2g full scale, Low-power1 mode [mg/LSB] */
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_2G_OTHER_MODES   0.244f  /**< Sensitivity value for 2g full scale, all other modes except Low-power1 [mg/LSB] */
+
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_4G_LOPOW1_MODE   1.952f  /**< Sensitivity value for 4g full scale, Low-power1 mode [mg/LSB] */
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_4G_OTHER_MODES   0.488f  /**< Sensitivity value for 4g full scale, all other modes except Low-power1 [mg/LSB] */
+
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_8G_LOPOW1_MODE   3.904f  /**< Sensitivity value for 8g full scale, Low-power1 mode [mg/LSB] */
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_8G_OTHER_MODES   0.976f  /**< Sensitivity value for 8g full scale, all other modes except Low-power1 [mg/LSB] */
+
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_16G_LOPOW1_MODE  7.808f  /**< Sensitivity value for 16g full scale, Low-power1 mode [mg/LSB] */
+#define LIS2DW12_ACC_SENSITIVITY_FOR_FS_16G_OTHER_MODES  1.952f  /**< Sensitivity value for 16g full scale, all other modes except Low-power1 [mg/LSB] */
+
+/* Typedefs ------------------------------------------------------------------*/
+typedef enum
+{
+  LIS2DW12_STATUS_OK = 0,
+  LIS2DW12_STATUS_ERROR
+} LIS2DW12StatusTypeDef;
+
+typedef struct
+{
+  unsigned int WakeUpStatus : 1;
+  unsigned int D6DOrientationStatus : 1;
+  unsigned int SleepStatus : 1;
+} LIS2DW12_Event_Status_t;
+
+typedef enum
+{
+  LIS2DW12_HIGH_PERFORMANCE_MODE,
+  LIS2DW12_LOW_POWER_MODE4,
+  LIS2DW12_LOW_POWER_MODE3,
+  LIS2DW12_LOW_POWER_MODE2,
+  LIS2DW12_LOW_POWER_MODE1
+} LIS2DW12_Operating_Mode_t;
+
+typedef enum
+{
+  LIS2DW12_LOW_NOISE_DISABLE,
+  LIS2DW12_LOW_NOISE_ENABLE
+} LIS2DW12_Low_Noise_t;
+
+/* Class Declaration ---------------------------------------------------------*/
+   
+/**
+ * Abstract class of an LIS2DW12 Inertial Measurement Unit (IMU) 3 axes
+ * sensor.
+ */
+class LIS2DW12Sensor
+{
+  public:
+    LIS2DW12Sensor(TwoWire *i2c, uint8_t address=0);
+    // LIS2DW12Sensor(SPIClass *spi, int cs_pin, uint32_t spi_speed=2000000);
+    LIS2DW12StatusTypeDef begin();
+    // LIS2DW12StatusTypeDef end();
+    LIS2DW12StatusTypeDef Enable_X(void);
+    // LIS2DW12StatusTypeDef Disable_X(void);
+    // LIS2DW12StatusTypeDef ReadID(uint8_t *id);
+    // LIS2DW12StatusTypeDef Get_X_Axes(int32_t *acceleration);
+    // LIS2DW12StatusTypeDef Get_X_Sensitivity(float *sensitivity);
+    LIS2DW12StatusTypeDef Get_X_AxesRaw(int16_t *value);
+    // LIS2DW12StatusTypeDef Get_X_ODR(float *odr);
+    // LIS2DW12StatusTypeDef Set_X_ODR(float odr);
+    // LIS2DW12StatusTypeDef Set_X_ODR_With_Mode(float odr, LIS2DW12_Operating_Mode_t mode=LIS2DW12_HIGH_PERFORMANCE_MODE, LIS2DW12_Low_Noise_t noise=LIS2DW12_LOW_NOISE_DISABLE);
+    // LIS2DW12StatusTypeDef Get_X_FS(float *full_scale);
+    // LIS2DW12StatusTypeDef Set_X_FS(float full_scale);
+    // LIS2DW12StatusTypeDef Enable_Wake_Up_Detection(void);
+    // LIS2DW12StatusTypeDef Disable_Wake_Up_Detection(void);
+    // LIS2DW12StatusTypeDef Set_Wake_Up_Threshold(uint8_t thr);
+    // LIS2DW12StatusTypeDef Set_Wake_Up_Duration(uint8_t dur);
+    // LIS2DW12StatusTypeDef Enable_Inactivity_Detection(void);
+    // LIS2DW12StatusTypeDef Disable_Inactivity_Detection(void);
+    // LIS2DW12StatusTypeDef Set_Sleep_Duration(uint8_t dur);
+    // LIS2DW12StatusTypeDef Enable_6D_Orientation(void);
+    // LIS2DW12StatusTypeDef Disable_6D_Orientation(void);
+    // LIS2DW12StatusTypeDef Set_6D_Orientation_Threshold(uint8_t thr);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_XL(uint8_t *xl);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_XH(uint8_t *xh);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_YL(uint8_t *yl);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_YH(uint8_t *yh);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_ZL(uint8_t *zl);
+    // LIS2DW12StatusTypeDef Get_6D_Orientation_ZH(uint8_t *zh);
+    // LIS2DW12StatusTypeDef Get_Event_Status(LIS2DW12_Event_Status_t *status);
+    // LIS2DW12StatusTypeDef Get_FIFO_Num_Samples(uint16_t *num_samples);
+    // LIS2DW12StatusTypeDef Set_FIFO_Mode(uint8_t mode);
+    // LIS2DW12StatusTypeDef ReadReg(uint8_t reg, uint8_t *data);
+    // LIS2DW12StatusTypeDef WriteReg(uint8_t reg, uint8_t data);
+    
+    // /**
+    //  * @brief Utility function to read data.
+    //  * @param  pBuffer: pointer to data to be read.
+    //  * @param  RegisterAddr: specifies internal address register to be read.
+    //  * @param  NumByteToRead: number of bytes to be read.
+    //  * @retval 0 if ok, an error code otherwise.
+    //  */
+    // uint8_t IO_Read(uint8_t* pBuffer, uint8_t RegisterAddr, uint16_t NumByteToRead)
+    // {        
+    //   if (dev_spi) {
+    //     dev_spi->beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
+
+    //     digitalWrite(cs_pin, LOW);
+
+    //     /* Write Reg Address */
+    //     dev_spi->transfer(RegisterAddr | 0x80);
+    //     /* Read the data */
+    //     for (uint16_t i=0; i<NumByteToRead; i++) {
+    //       *(pBuffer+i) = dev_spi->transfer(0x00);
+    //     }
+         
+    //     digitalWrite(cs_pin, HIGH);
+
+    //     dev_spi->endTransaction();
+
+    //     return 0;
+    //   }
+		
+    //   if (dev_i2c) {
+    //     dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
+    //     dev_i2c->write(RegisterAddr);
+    //     dev_i2c->endTransmission(false);
+
+    //     dev_i2c->requestFrom(((uint8_t)(((address) >> 1) & 0x7F)), (uint8_t) NumByteToRead);
+
+    //     int i=0;
+    //     while (dev_i2c->available()) {
+    //       pBuffer[i] = dev_i2c->read();
+    //       i++;
+    //     }
+
+    //     return 0;
+    //   }
+
+    //   return 1;
+    // }
+    
+    // /**
+    //  * @brief Utility function to write data.
+    //  * @param  pBuffer: pointer to data to be written.
+    //  * @param  RegisterAddr: specifies internal address register to be written.
+    //  * @param  NumByteToWrite: number of bytes to write.
+    //  * @retval 0 if ok, an error code otherwise.
+    //  */
+    // uint8_t IO_Write(uint8_t* pBuffer, uint8_t RegisterAddr, uint16_t NumByteToWrite)
+    // {  
+    //   if (dev_spi) {
+    //     dev_spi->beginTransaction(SPISettings(spi_speed, MSBFIRST, SPI_MODE3));
+
+    //     digitalWrite(cs_pin, LOW);
+
+    //     /* Write Reg Address */
+    //     dev_spi->transfer(RegisterAddr);
+    //     /* Write the data */
+    //     for (uint16_t i=0; i<NumByteToWrite; i++) {
+    //       dev_spi->transfer(pBuffer[i]);
+    //     }
+
+    //     digitalWrite(cs_pin, HIGH);
+
+    //     dev_spi->endTransaction();
+
+    //     return 0;                    
+    //   }
+  
+    //   if (dev_i2c) {
+    //     dev_i2c->beginTransmission(((uint8_t)(((address) >> 1) & 0x7F)));
+
+    //     dev_i2c->write(RegisterAddr);
+    //     for (uint16_t i = 0 ; i < NumByteToWrite ; i++) {
+    //       dev_i2c->write(pBuffer[i]);
+    //     }
+
+    //     dev_i2c->endTransmission(true);
+
+    //     return 0;
+    //   }
+
+    //   return 1;
+    // }
+
+  private:
+    LIS2DW12StatusTypeDef Set_X_ODR_When_Enabled(float odr, LIS2DW12_Operating_Mode_t mode, LIS2DW12_Low_Noise_t noise);
+    LIS2DW12StatusTypeDef Set_X_ODR_When_Disabled(float odr, LIS2DW12_Operating_Mode_t mode, LIS2DW12_Low_Noise_t noise);
+
+    /* Helper classes. */
+    TwoWire *dev_i2c;
+    // SPIClass *dev_spi;
+    
+    /* Configuration */
+    uint8_t address;
+    int cs_pin;
+    uint32_t spi_speed;
+    
+    uint8_t X_isEnabled;
+    float X_Last_ODR;
+    LIS2DW12_Operating_Mode_t X_Last_Operating_Mode;
+    LIS2DW12_Low_Noise_t X_Last_Noise;
+
+    // lis2dw12_ctx_t reg_ctx;
+};
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+int32_t LIS2DW12_io_write( void *handle, uint8_t WriteAddr, uint8_t *pBuffer, uint16_t nBytesToWrite );
+int32_t LIS2DW12_io_read( void *handle, uint8_t ReadAddr, uint8_t *pBuffer, uint16_t nBytesToRead );
+#ifdef __cplusplus
+  }
+#endif
+
+#endif

--- a/blockware/lib/VirtualBlox/stubs/Print.h
+++ b/blockware/lib/VirtualBlox/stubs/Print.h
@@ -15,7 +15,7 @@ using std::string;
 class Print {
 public:
     virtual size_t write(uint8_t) = 0;
-    virtual void print(char* str) {
+    virtual void print(const char* str) {
         for (int i = 0; i < strlen(str); i++)
         {
             write(str[i]);

--- a/blockware/lib/VirtualBlox/stubs/Wire.cpp
+++ b/blockware/lib/VirtualBlox/stubs/Wire.cpp
@@ -1,0 +1,331 @@
+/*
+    TwoWire.cpp - TWI/I2C library for Arduino & Wiring
+    Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+    Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
+    Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
+    Modified January 2017 by Bjorn Hammarberg (bjoham@esp8266.com) - i2c slave support
+*/
+
+extern "C" {
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+}
+
+#include "Wire.h"
+
+
+// //Some boards don't have these pins available, and hence don't support Wire.
+// //Check here for compile-time error.
+// #if !defined(PIN_WIRE_SDA) || !defined(PIN_WIRE_SCL)
+// #error Wire library is not supported on this board
+// #endif
+
+// // Initialize Class Variables //////////////////////////////////////////////////
+
+// uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
+// uint8_t TwoWire::rxBufferIndex = 0;
+// uint8_t TwoWire::rxBufferLength = 0;
+
+// uint8_t TwoWire::txAddress = 0;
+// uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
+// uint8_t TwoWire::txBufferIndex = 0;
+// uint8_t TwoWire::txBufferLength = 0;
+
+// uint8_t TwoWire::transmitting = 0;
+// void (*TwoWire::user_onRequest)(void);
+// void (*TwoWire::user_onReceive)(size_t);
+
+// static int default_sda_pin = SDA;
+// static int default_scl_pin = SCL;
+
+// // Constructors ////////////////////////////////////////////////////////////////
+
+// TwoWire::TwoWire() {}
+
+// // Public Methods //////////////////////////////////////////////////////////////
+
+// void TwoWire::begin(int sda, int scl)
+// {
+//     default_sda_pin = sda;
+//     default_scl_pin = scl;
+//     twi_init(sda, scl);
+//     flush();
+// }
+
+// void TwoWire::begin(int sda, int scl, uint8_t address)
+// {
+//     default_sda_pin = sda;
+//     default_scl_pin = scl;
+//     twi_setAddress(address);
+//     twi_init(sda, scl);
+//     twi_attachSlaveTxEvent(onRequestService);
+//     twi_attachSlaveRxEvent(onReceiveService);
+//     flush();
+// }
+
+// void TwoWire::pins(int sda, int scl)
+// {
+//     default_sda_pin = sda;
+//     default_scl_pin = scl;
+// }
+
+void TwoWire::begin(void)
+{
+}
+
+// void TwoWire::begin(uint8_t address)
+// {
+//     twi_setAddress(address);
+//     twi_attachSlaveTxEvent(onRequestService);
+//     twi_attachSlaveRxEvent(onReceiveService);
+//     begin();
+// }
+
+// uint8_t TwoWire::status()
+// {
+//     return twi_status();
+// }
+
+// void TwoWire::begin(int address)
+// {
+//     begin((uint8_t)address);
+// }
+
+void TwoWire::setClock(uint32_t frequency)
+{
+}
+
+// void TwoWire::setClockStretchLimit(uint32_t limit)
+// {
+//     twi_setClockStretchLimit(limit);
+// }
+
+// size_t TwoWire::requestFrom(uint8_t address, size_t size, bool sendStop)
+// {
+//     if (size > BUFFER_LENGTH)
+//     {
+//         size = BUFFER_LENGTH;
+//     }
+//     size_t read = (twi_readFrom(address, rxBuffer, size, sendStop) == 0) ? size : 0;
+//     rxBufferIndex = 0;
+//     rxBufferLength = read;
+//     return read;
+// }
+
+// uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
+// {
+//     return requestFrom(address, static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+// }
+
+// uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
+// {
+//     return requestFrom(address, static_cast<size_t>(quantity), true);
+// }
+
+// uint8_t TwoWire::requestFrom(int address, int quantity)
+// {
+//     return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), true);
+// }
+
+// uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
+// {
+//     return requestFrom(static_cast<uint8_t>(address), static_cast<size_t>(quantity), static_cast<bool>(sendStop));
+// }
+
+// void TwoWire::beginTransmission(uint8_t address)
+// {
+//     transmitting = 1;
+//     txAddress = address;
+//     txBufferIndex = 0;
+//     txBufferLength = 0;
+// }
+
+// void TwoWire::beginTransmission(int address)
+// {
+//     beginTransmission((uint8_t)address);
+// }
+
+// uint8_t TwoWire::endTransmission(uint8_t sendStop)
+// {
+//     int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, sendStop);
+//     txBufferIndex = 0;
+//     txBufferLength = 0;
+//     transmitting = 0;
+//     return ret;
+// }
+
+// uint8_t TwoWire::endTransmission(void)
+// {
+//     return endTransmission(true);
+// }
+
+// size_t TwoWire::write(uint8_t data)
+// {
+//     if (transmitting)
+//     {
+//         if (txBufferLength >= BUFFER_LENGTH)
+//         {
+//             setWriteError();
+//             return 0;
+//         }
+//         txBuffer[txBufferIndex] = data;
+//         ++txBufferIndex;
+//         txBufferLength = txBufferIndex;
+//     }
+//     else
+//     {
+//         twi_transmit(&data, 1);
+//     }
+//     return 1;
+// }
+
+// size_t TwoWire::write(const uint8_t *data, size_t quantity)
+// {
+//     if (transmitting)
+//     {
+//         for (size_t i = 0; i < quantity; ++i)
+//         {
+//             if (!write(data[i]))
+//             {
+//                 return i;
+//             }
+//         }
+//     }
+//     else
+//     {
+//         twi_transmit(data, quantity);
+//     }
+//     return quantity;
+// }
+
+// int TwoWire::available(void)
+// {
+//     int result = rxBufferLength - rxBufferIndex;
+
+//     if (!result)
+//     {
+//         // yielding here will not make more data "available",
+//         // but it will prevent the system from going into WDT reset
+//         optimistic_yield(1000);
+//     }
+
+//     return result;
+// }
+
+// int TwoWire::read(void)
+// {
+//     int value = -1;
+//     if (rxBufferIndex < rxBufferLength)
+//     {
+//         value = rxBuffer[rxBufferIndex];
+//         ++rxBufferIndex;
+//     }
+//     return value;
+// }
+
+// int TwoWire::peek(void)
+// {
+//     int value = -1;
+//     if (rxBufferIndex < rxBufferLength)
+//     {
+//         value = rxBuffer[rxBufferIndex];
+//     }
+//     return value;
+// }
+
+// void TwoWire::flush(void)
+// {
+//     rxBufferIndex = 0;
+//     rxBufferLength = 0;
+//     txBufferIndex = 0;
+//     txBufferLength = 0;
+// }
+
+// void TwoWire::onReceiveService(uint8_t* inBytes, size_t numBytes)
+// {
+//     // don't bother if user hasn't registered a callback
+//     if (!user_onReceive)
+//     {
+//         return;
+//     }
+//     // // don't bother if rx buffer is in use by a master requestFrom() op
+//     // // i know this drops data, but it allows for slight stupidity
+//     // // meaning, they may not have read all the master requestFrom() data yet
+//     // if(rxBufferIndex < rxBufferLength){
+//     //   return;
+//     // }
+
+//     // copy twi rx buffer into local read buffer
+//     // this enables new reads to happen in parallel
+//     for (uint8_t i = 0; i < numBytes; ++i)
+//     {
+//         rxBuffer[i] = inBytes[i];
+//     }
+
+//     // set rx iterator vars
+//     rxBufferIndex = 0;
+//     rxBufferLength = numBytes;
+
+//     // alert user program
+//     user_onReceive(numBytes);
+// }
+
+// void TwoWire::onRequestService(void)
+// {
+//     // don't bother if user hasn't registered a callback
+//     if (!user_onRequest)
+//     {
+//         return;
+//     }
+
+//     // reset tx buffer iterator vars
+//     // !!! this will kill any pending pre-master sendTo() activity
+//     txBufferIndex = 0;
+//     txBufferLength = 0;
+
+//     // alert user program
+//     user_onRequest();
+// }
+
+// void TwoWire::onReceive(void (*function)(int))
+// {
+//     // arduino api compatibility fixer:
+//     // really hope size parameter will not exceed 2^31 :)
+//     static_assert(sizeof(int) == sizeof(size_t), "something is wrong in Arduino kingdom");
+//     user_onReceive = reinterpret_cast<void(*)(size_t)>(function);
+// }
+
+// void TwoWire::onReceive(void (*function)(size_t))
+// {
+//     user_onReceive = function;
+//     twi_enableSlaveMode();
+// }
+
+// void TwoWire::onRequest(void (*function)(void))
+// {
+//     user_onRequest = function;
+//     twi_enableSlaveMode();
+// }
+
+// // Preinstantiate Objects //////////////////////////////////////////////////////
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
+TwoWire Wire;
+#endif

--- a/blockware/lib/VirtualBlox/stubs/Wire.h
+++ b/blockware/lib/VirtualBlox/stubs/Wire.h
@@ -1,0 +1,91 @@
+/*
+    TwoWire.h - TWI/I2C library for Arduino & Wiring
+    Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+    Modified December 2014 by Ivan Grokhotkov (ivan@esp8266.com) - esp8266 support
+    Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
+*/
+
+#ifndef TwoWire_h
+#define TwoWire_h
+
+#include <inttypes.h>
+// #include "Stream.h"
+#include <stddef.h>
+
+
+#define BUFFER_LENGTH 128
+
+class TwoWire
+{
+private:
+    static uint8_t rxBuffer[];
+    static uint8_t rxBufferIndex;
+    static uint8_t rxBufferLength;
+
+    static uint8_t txAddress;
+    static uint8_t txBuffer[];
+    static uint8_t txBufferIndex;
+    static uint8_t txBufferLength;
+
+    static uint8_t transmitting;
+    static void (*user_onRequest)(void);
+    static void (*user_onReceive)(size_t);
+    static void onRequestService(void);
+    static void onReceiveService(uint8_t*, size_t);
+public:
+    // TwoWire();
+    // void begin(int sda, int scl);
+    // void begin(int sda, int scl, uint8_t address);
+    // void pins(int sda, int scl) __attribute__((deprecated)); // use begin(sda, scl) in new code
+    void begin();
+    // void begin(uint8_t);
+    // void begin(int);
+    void setClock(uint32_t);
+    // void setClockStretchLimit(uint32_t);
+    // void beginTransmission(uint8_t);
+    // void beginTransmission(int);
+    // uint8_t endTransmission(void);
+    // uint8_t endTransmission(uint8_t);
+    // size_t requestFrom(uint8_t address, size_t size, bool sendStop);
+    // uint8_t status();
+
+    // uint8_t requestFrom(uint8_t, uint8_t);
+    // uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+    // uint8_t requestFrom(int, int);
+    // uint8_t requestFrom(int, int, int);
+
+    // virtual size_t write(uint8_t);
+    // virtual size_t write(const uint8_t *, size_t);
+    // virtual int available(void);
+    // virtual int read(void);
+    // virtual int peek(void);
+    // virtual void flush(void);
+    // void onReceive(void (*)(int));      // arduino api
+    // void onReceive(void (*)(size_t));   // legacy esp8266 backward compatibility
+    // void onRequest(void (*)(void));
+
+    // using Print::write;
+};
+
+#if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
+extern TwoWire Wire;
+#endif
+
+#endif
+

--- a/blockware/lib/VirtualBlox/wasm.cpp
+++ b/blockware/lib/VirtualBlox/wasm.cpp
@@ -1,3 +1,4 @@
+#if defined(EMSCRIPTEN)
 #include "Adafruit_SSD1351.h"
 #include <SDL2/SDL.h>
 #include <emscripten.h>
@@ -68,3 +69,4 @@ int main(int argc, char *argv[]) {
 
   return 0;
 }
+#endif


### PR DESCRIPTION
Adds VirtualBlox support for the fireworks example. I couldn't quite get `pixel-dust` to work because I couldn't convince platformIO to use the Adafruit pixel dust library with the native platform. Need more investigation there.